### PR TITLE
fix: Allow refreshing of the token when we don't have a user

### DIFF
--- a/packages/oidc/lib/src/managers/user_manager.dart
+++ b/packages/oidc/lib/src/managers/user_manager.dart
@@ -615,7 +615,7 @@ class OidcUserManager {
       return null;
     }
     
-    final refreshToken = currentUser?.token.refreshToken ?? overrideRefreshToken;
+    final refreshToken = overrideRefreshToken ?? currentUser?.token.refreshToken;
     if (refreshToken == null) {
       // Can't refresh the access token anyway.
       return null;

--- a/packages/oidc/lib/src/managers/user_manager.dart
+++ b/packages/oidc/lib/src/managers/user_manager.dart
@@ -606,16 +606,16 @@ class OidcUserManager {
   ///
   /// An [OidcException] will be thrown if the server returns an error.
   Future<OidcUser?> refreshToken({String? overrideRefreshToken}) async {
+
+    _ensureInit();
+    
     if (!discoveryDocument.grantTypesSupportedOrDefault
         .contains(OidcConstants_GrantType.refreshToken)) {
       //Server doesn't support refresh_token grant.
       return null;
     }
-    final user = currentUser;
-    if (user == null) {
-      return null;
-    }
-    final refreshToken = overrideRefreshToken ?? user.token.refreshToken;
+    
+    final refreshToken = currentUser?.token.refreshToken ?? overrideRefreshToken;
     if (refreshToken == null) {
       // Can't refresh the access token anyway.
       return null;
@@ -638,7 +638,7 @@ class OidcUserManager {
       token: OidcToken.fromResponse(
         tokenResponse,
         overrideExpiresIn: settings.getExpiresIn?.call(tokenResponse),
-        sessionState: user.token.sessionState,
+        sessionState: currentUser?.token.sessionState,
       ),
       nonce: null,
       attributes: null,

--- a/packages/oidc/lib/src/managers/user_manager.dart
+++ b/packages/oidc/lib/src/managers/user_manager.dart
@@ -606,16 +606,16 @@ class OidcUserManager {
   ///
   /// An [OidcException] will be thrown if the server returns an error.
   Future<OidcUser?> refreshToken({String? overrideRefreshToken}) async {
-
     _ensureInit();
-    
+
     if (!discoveryDocument.grantTypesSupportedOrDefault
         .contains(OidcConstants_GrantType.refreshToken)) {
       //Server doesn't support refresh_token grant.
       return null;
     }
-    
-    final refreshToken = overrideRefreshToken ?? currentUser?.token.refreshToken;
+
+    final refreshToken =
+        overrideRefreshToken ?? currentUser?.token.refreshToken;
     if (refreshToken == null) {
       // Can't refresh the access token anyway.
       return null;


### PR DESCRIPTION
## Description

This doesn't fix the user being logged out (https://github.com/Bdaya-Dev/oidc/issues/47) but does allow updating of a refresh token without already having a user logged in.

This allows my work around to work without having to have a custom version of this library.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
