### PR TITLE
feat: Added `OidcTokenExpiredEvent` and `OidcTokenExpiringEvent`

### DIFF
--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -794,7 +794,9 @@ abstract class OidcUserManagerBase {
 
   @protected
   Future<void> handleTokenExpiring(OidcToken event) async {
-    settings.onTokenExpiring?.call(event);
+    eventsController.add(
+      OidcTokenExpiringEvent.now(currentToken: event),
+    );
 
     final refreshToken = event.refreshToken;
     if (refreshToken == null) {
@@ -836,7 +838,9 @@ abstract class OidcUserManagerBase {
 
   @protected
   void handleTokenExpired(OidcToken event) {
-    settings.onTokenExpired?.call(event);
+    eventsController.add(
+      OidcTokenExpiredEvent.now(currentToken: event),
+    );
 
     if (!settings.supportOfflineAuth) {
       forgetUser();

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -784,15 +784,6 @@ abstract class OidcUserManagerBase {
     if (user == null) {
       tokenEventsManager.unload();
     } else {
-      if (!discoveryDocument.grantTypesSupportedOrDefault
-          .contains(OidcConstants_GrantType.refreshToken)) {
-        //Server doesn't support refresh_token grant.
-        return;
-      }
-      if (user.token.refreshToken == null) {
-        // Can't refresh the access token anyway.
-        return;
-      }
       if (user.token.expiresIn == null) {
         // Can't know how much time is left.
         return;
@@ -803,6 +794,8 @@ abstract class OidcUserManagerBase {
 
   @protected
   Future<void> handleTokenExpiring(OidcToken event) async {
+    settings.onTokenExpiring?.call(event);
+
     final refreshToken = event.refreshToken;
     if (refreshToken == null) {
       return;
@@ -843,6 +836,8 @@ abstract class OidcUserManagerBase {
 
   @protected
   void handleTokenExpired(OidcToken event) {
+    settings.onTokenExpired?.call(event);
+
     if (!settings.supportOfflineAuth) {
       forgetUser();
     }

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -138,8 +138,7 @@ abstract class OidcUserManagerBase {
   /// Listens to incoming front channel logout requests.
   /// returns an empty stream on non-supported platforms.
   @protected
-  Stream<OidcFrontChannelLogoutIncomingRequest>
-      listenToFrontChannelLogoutRequests(
+  Stream<OidcFrontChannelLogoutIncomingRequest> listenToFrontChannelLogoutRequests(
     Uri listenOn,
     OidcFrontChannelRequestListeningOptions options,
   );
@@ -155,9 +154,7 @@ abstract class OidcUserManagerBase {
   OidcPlatformSpecificOptions getPlatformOptions([
     OidcPlatformSpecificOptions? optionsOverride,
   ]) {
-    return optionsOverride ??
-        settings.options ??
-        const OidcPlatformSpecificOptions();
+    return optionsOverride ?? settings.options ?? const OidcPlatformSpecificOptions();
   }
 
   /// Attempts to login the user via the AuthorizationCodeFlow.
@@ -184,8 +181,7 @@ abstract class OidcUserManagerBase {
     OidcPlatformSpecificOptions? options,
   }) async {
     ensureInit();
-    final discoveryDocument =
-        discoveryDocumentOverride ?? this.discoveryDocument;
+    final discoveryDocument = discoveryDocumentOverride ?? this.discoveryDocument;
     options = getPlatformOptions(options);
     final prep = prepareForRedirectFlow(options);
     final simpleReq = OidcSimpleAuthorizationCodeFlowRequest(
@@ -198,8 +194,8 @@ abstract class OidcUserManagerBase {
       extraStateData: extraStateData,
       uiLocales: uiLocalesOverride ?? settings.uiLocales,
       acrValues: acrValuesOverride ?? settings.acrValues,
-      idTokenHint: idTokenHintOverride ??
-          (includeIdTokenHintFromCurrentUser ? currentUser?.idToken : null),
+      idTokenHint:
+          idTokenHintOverride ?? (includeIdTokenHintFromCurrentUser ? currentUser?.idToken : null),
       loginHint: loginHint,
       extraTokenHeaders: {
         ...?settings.extraTokenHeaders,
@@ -219,8 +215,7 @@ abstract class OidcUserManagerBase {
     // this function adds state, state data, nonce to the store
     // the state/state data is only until we get a response (success or fail).
     // the nonce is until the user logs out.
-    final requestContainer =
-        await OidcEndpoints.prepareAuthorizationCodeFlowRequest(
+    final requestContainer = await OidcEndpoints.prepareAuthorizationCodeFlowRequest(
       input: simpleReq,
       metadata: discoveryDocument,
       store: store,
@@ -241,8 +236,7 @@ abstract class OidcUserManagerBase {
     List<String>? scopeOverride,
     OidcProviderMetadata? discoveryDocumentOverride,
   }) async {
-    final discoveryDocument =
-        discoveryDocumentOverride ?? this.discoveryDocument;
+    final discoveryDocument = discoveryDocumentOverride ?? this.discoveryDocument;
     final tokenResp = await OidcEndpoints.token(
       tokenEndpoint: discoveryDocument.tokenEndpoint!,
       request: OidcTokenRequest.password(
@@ -279,8 +273,7 @@ abstract class OidcUserManagerBase {
     required Map<String, dynamic> prep,
   }) async {
     try {
-      final response =
-          await getAuthorizationResponse(metadata, request, options, prep);
+      final response = await getAuthorizationResponse(metadata, request, options, prep);
       if (response == null) {
         return null;
       }
@@ -346,8 +339,8 @@ abstract class OidcUserManagerBase {
       extraStateData: extraStateData,
       uiLocales: uiLocalesOverride ?? settings.uiLocales,
       acrValues: acrValuesOverride ?? settings.acrValues,
-      idTokenHint: idTokenHintOverride ??
-          (includeIdTokenHintFromCurrentUser ? currentUser?.idToken : null),
+      idTokenHint:
+          idTokenHintOverride ?? (includeIdTokenHintFromCurrentUser ? currentUser?.idToken : null),
       loginHint: loginHint,
       extraParameters: {
         ...?settings.extraAuthenticationParameters,
@@ -402,16 +395,14 @@ abstract class OidcUserManagerBase {
     OidcProviderMetadata? discoveryDocumentOverride,
   }) async {
     ensureInit();
-    final discoveryDocument =
-        discoveryDocumentOverride ?? this.discoveryDocument;
+    final discoveryDocument = discoveryDocumentOverride ?? this.discoveryDocument;
     options = getPlatformOptions(options);
     final prep = prepareForRedirectFlow(options);
     final currentUser = this.currentUser;
     if (currentUser == null) {
       return;
     }
-    final postLogoutRedirectUri =
-        postLogoutRedirectUriOverride ?? settings.postLogoutRedirectUri;
+    final postLogoutRedirectUri = postLogoutRedirectUriOverride ?? settings.postLogoutRedirectUri;
 
     final stateData = postLogoutRedirectUri == null
         ? null
@@ -449,8 +440,7 @@ abstract class OidcUserManagerBase {
     final result = await resultFuture;
     if (result == null) {
       if (isWeb &&
-          options.web.navigationMode ==
-              OidcPlatformSpecificOptions_Web_NavigationMode.samePage) {
+          options.web.navigationMode == OidcPlatformSpecificOptions_Web_NavigationMode.samePage) {
         //wait for a result after redirect.
         return;
       }
@@ -525,12 +515,10 @@ abstract class OidcUserManagerBase {
       if (grantType == OidcConstants_GrantType.implicit) {
         //implicit grant gets the token directly from the response.
         final implicitTokenResponse = OidcTokenResponse.fromJson(response.src);
-        if (implicitTokenResponse.accessToken != null ||
-            implicitTokenResponse.idToken != null) {
+        if (implicitTokenResponse.accessToken != null || implicitTokenResponse.idToken != null) {
           final token = OidcToken.fromResponse(
             implicitTokenResponse,
-            overrideExpiresIn:
-                settings.getExpiresIn?.call(implicitTokenResponse),
+            overrideExpiresIn: settings.getExpiresIn?.call(implicitTokenResponse),
             sessionState: response.sessionState,
           );
           return await createUserFromToken(
@@ -640,8 +628,8 @@ abstract class OidcUserManagerBase {
       }
     }
 
-    final idTokenNonce = newUser
-        .parsedIdToken.claims[OidcConstants_AuthParameters.nonce] as String?;
+    final idTokenNonce =
+        newUser.parsedIdToken.claims[OidcConstants_AuthParameters.nonce] as String?;
     if (nonce != null && idTokenNonce != nonce) {
       logAndThrow(
         'Server returned a wrong id_token nonce, might be a replay attack.',
@@ -735,16 +723,14 @@ abstract class OidcUserManagerBase {
     OidcProviderMetadata? discoveryDocumentOverride,
   }) async {
     ensureInit();
-    final discoveryDocument =
-        discoveryDocumentOverride ?? this.discoveryDocument;
+    final discoveryDocument = discoveryDocumentOverride ?? this.discoveryDocument;
     if (!discoveryDocument.grantTypesSupportedOrDefault
         .contains(OidcConstants_GrantType.refreshToken)) {
       //Server doesn't support refresh_token grant.
       return null;
     }
 
-    final refreshToken =
-        overrideRefreshToken ?? currentUser?.token.refreshToken;
+    final refreshToken = overrideRefreshToken ?? currentUser?.token.refreshToken;
     if (refreshToken == null) {
       // Can't refresh the access token anyway.
       return null;
@@ -797,6 +783,12 @@ abstract class OidcUserManagerBase {
     eventsController.add(
       OidcTokenExpiringEvent.now(currentToken: event),
     );
+
+    if (!discoveryDocument.grantTypesSupportedOrDefault
+        .contains(OidcConstants_GrantType.refreshToken)) {
+      //Server doesn't support refresh_token grant.
+      return;
+    }
 
     final refreshToken = event.refreshToken;
     if (refreshToken == null) {
@@ -895,16 +887,14 @@ abstract class OidcUserManagerBase {
             tokenLocation: settings.userInfoSettings.accessTokenLocation,
             client: httpClient,
             allowedAlgorithms: metadata.userinfoSigningAlgValuesSupported,
-            followDistributedClaims:
-                settings.userInfoSettings.followDistributedClaims,
+            followDistributedClaims: settings.userInfoSettings.followDistributedClaims,
             getAccessTokenForDistributedSource:
                 settings.userInfoSettings.getAccessTokenForDistributedSource,
             keyStore: keyStore,
           );
 
           logger.info('UserInfo response: ${userInfoResp.src}');
-          if (userInfoResp.sub != null &&
-              userInfoResp.sub != actualUser.claims.subject) {
+          if (userInfoResp.sub != null && userInfoResp.sub != actualUser.claims.subject) {
             errors.add(
               const OidcException("UserInfo didn't return the same subject."),
             );
@@ -919,8 +909,7 @@ abstract class OidcUserManagerBase {
         //keep going if the only error is that the token expired,
         //and it's allowed in settings.
         (settings.supportOfflineAuth &&
-            errors.every((e) =>
-                e is JoseException && e.message.startsWith('JWT expired.')))) {
+            errors.every((e) => e is JoseException && e.message.startsWith('JWT expired.')))) {
       // apply userinfo if present
       if (userInfoResp != null) {
         actualUser = actualUser.withUserInfo(userInfoResp.src);
@@ -1068,12 +1057,10 @@ abstract class OidcUserManagerBase {
     }
 
     try {
-      final decodedAttributes = rawAttributes == null
-          ? null
-          : jsonDecode(rawAttributes) as Map<String, dynamic>;
-      final decodedUserInfo = rawUserInfo == null
-          ? null
-          : jsonDecode(rawUserInfo) as Map<String, dynamic>;
+      final decodedAttributes =
+          rawAttributes == null ? null : jsonDecode(rawAttributes) as Map<String, dynamic>;
+      final decodedUserInfo =
+          rawUserInfo == null ? null : jsonDecode(rawUserInfo) as Map<String, dynamic>;
       final decodedToken = jsonDecode(rawToken) as Map<String, dynamic>;
       final token = OidcToken.fromJson(decodedToken);
       final metadata = discoveryDocument;
@@ -1095,11 +1082,9 @@ abstract class OidcUserManagerBase {
             .whereType<JoseException>()
             .any((element) => element.message.startsWith('JWT expired'));
 
-        if (token.refreshToken != null &&
-            (idTokenNeedsRefresh || token.isAccessTokenExpired())) {
+        if (token.refreshToken != null && (idTokenNeedsRefresh || token.isAccessTokenExpired())) {
           try {
-            loadedUser =
-                await refreshToken(overrideRefreshToken: token.refreshToken);
+            loadedUser = await refreshToken(overrideRefreshToken: token.refreshToken);
           } catch (e) {
             // An app might go offline during token refresh, so we consult the
             // supportOfflineAuth setting to check whether this is an issue or
@@ -1145,8 +1130,7 @@ abstract class OidcUserManagerBase {
     }
 
     for (final entry in statesWithResponses.entries) {
-      final (stateData: stateDataRaw, stateResponse: stateResponseRaw) =
-          entry.value;
+      final (stateData: stateDataRaw, stateResponse: stateResponseRaw) = entry.value;
 
       final stateResponseUrl = Uri.tryParse(stateResponseRaw);
       if (stateResponseUrl == null) {
@@ -1169,8 +1153,7 @@ abstract class OidcUserManagerBase {
           );
           return true;
         case OidcEndSessionState():
-          final resp =
-              OidcEndSessionResponse.fromJson(stateResponseUrl.queryParameters);
+          final resp = OidcEndSessionResponse.fromJson(stateResponseUrl.queryParameters);
           await handleEndSessionResponse(result: resp);
           return true;
         default:
@@ -1191,8 +1174,7 @@ abstract class OidcUserManagerBase {
     if (requestUri == null) {
       return false;
     }
-    final requestType =
-        requestUri.queryParameters[OidcConstants_Store.requestType];
+    final requestType = requestUri.queryParameters[OidcConstants_Store.requestType];
     if (requestType != OidcConstants_Store.frontChannelLogout) {
       return false;
     }
@@ -1311,8 +1293,7 @@ abstract class OidcUserManagerBase {
         promptOverride: ['none'],
         options: const OidcPlatformSpecificOptions(
           web: OidcPlatformSpecificOptions_Web(
-            navigationMode:
-                OidcPlatformSpecificOptions_Web_NavigationMode.hiddenIFrame,
+            navigationMode: OidcPlatformSpecificOptions_Web_NavigationMode.hiddenIFrame,
           ),
         ),
       );

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -138,7 +138,8 @@ abstract class OidcUserManagerBase {
   /// Listens to incoming front channel logout requests.
   /// returns an empty stream on non-supported platforms.
   @protected
-  Stream<OidcFrontChannelLogoutIncomingRequest> listenToFrontChannelLogoutRequests(
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+      listenToFrontChannelLogoutRequests(
     Uri listenOn,
     OidcFrontChannelRequestListeningOptions options,
   );
@@ -154,7 +155,9 @@ abstract class OidcUserManagerBase {
   OidcPlatformSpecificOptions getPlatformOptions([
     OidcPlatformSpecificOptions? optionsOverride,
   ]) {
-    return optionsOverride ?? settings.options ?? const OidcPlatformSpecificOptions();
+    return optionsOverride ??
+        settings.options ??
+        const OidcPlatformSpecificOptions();
   }
 
   /// Attempts to login the user via the AuthorizationCodeFlow.
@@ -181,7 +184,8 @@ abstract class OidcUserManagerBase {
     OidcPlatformSpecificOptions? options,
   }) async {
     ensureInit();
-    final discoveryDocument = discoveryDocumentOverride ?? this.discoveryDocument;
+    final discoveryDocument =
+        discoveryDocumentOverride ?? this.discoveryDocument;
     options = getPlatformOptions(options);
     final prep = prepareForRedirectFlow(options);
     final simpleReq = OidcSimpleAuthorizationCodeFlowRequest(
@@ -194,8 +198,8 @@ abstract class OidcUserManagerBase {
       extraStateData: extraStateData,
       uiLocales: uiLocalesOverride ?? settings.uiLocales,
       acrValues: acrValuesOverride ?? settings.acrValues,
-      idTokenHint:
-          idTokenHintOverride ?? (includeIdTokenHintFromCurrentUser ? currentUser?.idToken : null),
+      idTokenHint: idTokenHintOverride ??
+          (includeIdTokenHintFromCurrentUser ? currentUser?.idToken : null),
       loginHint: loginHint,
       extraTokenHeaders: {
         ...?settings.extraTokenHeaders,
@@ -215,7 +219,8 @@ abstract class OidcUserManagerBase {
     // this function adds state, state data, nonce to the store
     // the state/state data is only until we get a response (success or fail).
     // the nonce is until the user logs out.
-    final requestContainer = await OidcEndpoints.prepareAuthorizationCodeFlowRequest(
+    final requestContainer =
+        await OidcEndpoints.prepareAuthorizationCodeFlowRequest(
       input: simpleReq,
       metadata: discoveryDocument,
       store: store,
@@ -236,7 +241,8 @@ abstract class OidcUserManagerBase {
     List<String>? scopeOverride,
     OidcProviderMetadata? discoveryDocumentOverride,
   }) async {
-    final discoveryDocument = discoveryDocumentOverride ?? this.discoveryDocument;
+    final discoveryDocument =
+        discoveryDocumentOverride ?? this.discoveryDocument;
     final tokenResp = await OidcEndpoints.token(
       tokenEndpoint: discoveryDocument.tokenEndpoint!,
       request: OidcTokenRequest.password(
@@ -273,7 +279,8 @@ abstract class OidcUserManagerBase {
     required Map<String, dynamic> prep,
   }) async {
     try {
-      final response = await getAuthorizationResponse(metadata, request, options, prep);
+      final response =
+          await getAuthorizationResponse(metadata, request, options, prep);
       if (response == null) {
         return null;
       }
@@ -339,8 +346,8 @@ abstract class OidcUserManagerBase {
       extraStateData: extraStateData,
       uiLocales: uiLocalesOverride ?? settings.uiLocales,
       acrValues: acrValuesOverride ?? settings.acrValues,
-      idTokenHint:
-          idTokenHintOverride ?? (includeIdTokenHintFromCurrentUser ? currentUser?.idToken : null),
+      idTokenHint: idTokenHintOverride ??
+          (includeIdTokenHintFromCurrentUser ? currentUser?.idToken : null),
       loginHint: loginHint,
       extraParameters: {
         ...?settings.extraAuthenticationParameters,
@@ -395,14 +402,16 @@ abstract class OidcUserManagerBase {
     OidcProviderMetadata? discoveryDocumentOverride,
   }) async {
     ensureInit();
-    final discoveryDocument = discoveryDocumentOverride ?? this.discoveryDocument;
+    final discoveryDocument =
+        discoveryDocumentOverride ?? this.discoveryDocument;
     options = getPlatformOptions(options);
     final prep = prepareForRedirectFlow(options);
     final currentUser = this.currentUser;
     if (currentUser == null) {
       return;
     }
-    final postLogoutRedirectUri = postLogoutRedirectUriOverride ?? settings.postLogoutRedirectUri;
+    final postLogoutRedirectUri =
+        postLogoutRedirectUriOverride ?? settings.postLogoutRedirectUri;
 
     final stateData = postLogoutRedirectUri == null
         ? null
@@ -440,7 +449,8 @@ abstract class OidcUserManagerBase {
     final result = await resultFuture;
     if (result == null) {
       if (isWeb &&
-          options.web.navigationMode == OidcPlatformSpecificOptions_Web_NavigationMode.samePage) {
+          options.web.navigationMode ==
+              OidcPlatformSpecificOptions_Web_NavigationMode.samePage) {
         //wait for a result after redirect.
         return;
       }
@@ -515,10 +525,12 @@ abstract class OidcUserManagerBase {
       if (grantType == OidcConstants_GrantType.implicit) {
         //implicit grant gets the token directly from the response.
         final implicitTokenResponse = OidcTokenResponse.fromJson(response.src);
-        if (implicitTokenResponse.accessToken != null || implicitTokenResponse.idToken != null) {
+        if (implicitTokenResponse.accessToken != null ||
+            implicitTokenResponse.idToken != null) {
           final token = OidcToken.fromResponse(
             implicitTokenResponse,
-            overrideExpiresIn: settings.getExpiresIn?.call(implicitTokenResponse),
+            overrideExpiresIn:
+                settings.getExpiresIn?.call(implicitTokenResponse),
             sessionState: response.sessionState,
           );
           return await createUserFromToken(
@@ -628,8 +640,8 @@ abstract class OidcUserManagerBase {
       }
     }
 
-    final idTokenNonce =
-        newUser.parsedIdToken.claims[OidcConstants_AuthParameters.nonce] as String?;
+    final idTokenNonce = newUser
+        .parsedIdToken.claims[OidcConstants_AuthParameters.nonce] as String?;
     if (nonce != null && idTokenNonce != nonce) {
       logAndThrow(
         'Server returned a wrong id_token nonce, might be a replay attack.',
@@ -723,14 +735,16 @@ abstract class OidcUserManagerBase {
     OidcProviderMetadata? discoveryDocumentOverride,
   }) async {
     ensureInit();
-    final discoveryDocument = discoveryDocumentOverride ?? this.discoveryDocument;
+    final discoveryDocument =
+        discoveryDocumentOverride ?? this.discoveryDocument;
     if (!discoveryDocument.grantTypesSupportedOrDefault
         .contains(OidcConstants_GrantType.refreshToken)) {
       //Server doesn't support refresh_token grant.
       return null;
     }
 
-    final refreshToken = overrideRefreshToken ?? currentUser?.token.refreshToken;
+    final refreshToken =
+        overrideRefreshToken ?? currentUser?.token.refreshToken;
     if (refreshToken == null) {
       // Can't refresh the access token anyway.
       return null;
@@ -887,14 +901,16 @@ abstract class OidcUserManagerBase {
             tokenLocation: settings.userInfoSettings.accessTokenLocation,
             client: httpClient,
             allowedAlgorithms: metadata.userinfoSigningAlgValuesSupported,
-            followDistributedClaims: settings.userInfoSettings.followDistributedClaims,
+            followDistributedClaims:
+                settings.userInfoSettings.followDistributedClaims,
             getAccessTokenForDistributedSource:
                 settings.userInfoSettings.getAccessTokenForDistributedSource,
             keyStore: keyStore,
           );
 
           logger.info('UserInfo response: ${userInfoResp.src}');
-          if (userInfoResp.sub != null && userInfoResp.sub != actualUser.claims.subject) {
+          if (userInfoResp.sub != null &&
+              userInfoResp.sub != actualUser.claims.subject) {
             errors.add(
               const OidcException("UserInfo didn't return the same subject."),
             );
@@ -909,7 +925,8 @@ abstract class OidcUserManagerBase {
         //keep going if the only error is that the token expired,
         //and it's allowed in settings.
         (settings.supportOfflineAuth &&
-            errors.every((e) => e is JoseException && e.message.startsWith('JWT expired.')))) {
+            errors.every((e) =>
+                e is JoseException && e.message.startsWith('JWT expired.')))) {
       // apply userinfo if present
       if (userInfoResp != null) {
         actualUser = actualUser.withUserInfo(userInfoResp.src);
@@ -1057,10 +1074,12 @@ abstract class OidcUserManagerBase {
     }
 
     try {
-      final decodedAttributes =
-          rawAttributes == null ? null : jsonDecode(rawAttributes) as Map<String, dynamic>;
-      final decodedUserInfo =
-          rawUserInfo == null ? null : jsonDecode(rawUserInfo) as Map<String, dynamic>;
+      final decodedAttributes = rawAttributes == null
+          ? null
+          : jsonDecode(rawAttributes) as Map<String, dynamic>;
+      final decodedUserInfo = rawUserInfo == null
+          ? null
+          : jsonDecode(rawUserInfo) as Map<String, dynamic>;
       final decodedToken = jsonDecode(rawToken) as Map<String, dynamic>;
       final token = OidcToken.fromJson(decodedToken);
       final metadata = discoveryDocument;
@@ -1082,9 +1101,11 @@ abstract class OidcUserManagerBase {
             .whereType<JoseException>()
             .any((element) => element.message.startsWith('JWT expired'));
 
-        if (token.refreshToken != null && (idTokenNeedsRefresh || token.isAccessTokenExpired())) {
+        if (token.refreshToken != null &&
+            (idTokenNeedsRefresh || token.isAccessTokenExpired())) {
           try {
-            loadedUser = await refreshToken(overrideRefreshToken: token.refreshToken);
+            loadedUser =
+                await refreshToken(overrideRefreshToken: token.refreshToken);
           } catch (e) {
             // An app might go offline during token refresh, so we consult the
             // supportOfflineAuth setting to check whether this is an issue or
@@ -1130,7 +1151,8 @@ abstract class OidcUserManagerBase {
     }
 
     for (final entry in statesWithResponses.entries) {
-      final (stateData: stateDataRaw, stateResponse: stateResponseRaw) = entry.value;
+      final (stateData: stateDataRaw, stateResponse: stateResponseRaw) =
+          entry.value;
 
       final stateResponseUrl = Uri.tryParse(stateResponseRaw);
       if (stateResponseUrl == null) {
@@ -1153,7 +1175,8 @@ abstract class OidcUserManagerBase {
           );
           return true;
         case OidcEndSessionState():
-          final resp = OidcEndSessionResponse.fromJson(stateResponseUrl.queryParameters);
+          final resp =
+              OidcEndSessionResponse.fromJson(stateResponseUrl.queryParameters);
           await handleEndSessionResponse(result: resp);
           return true;
         default:
@@ -1174,7 +1197,8 @@ abstract class OidcUserManagerBase {
     if (requestUri == null) {
       return false;
     }
-    final requestType = requestUri.queryParameters[OidcConstants_Store.requestType];
+    final requestType =
+        requestUri.queryParameters[OidcConstants_Store.requestType];
     if (requestType != OidcConstants_Store.frontChannelLogout) {
       return false;
     }
@@ -1293,7 +1317,8 @@ abstract class OidcUserManagerBase {
         promptOverride: ['none'],
         options: const OidcPlatformSpecificOptions(
           web: OidcPlatformSpecificOptions_Web(
-            navigationMode: OidcPlatformSpecificOptions_Web_NavigationMode.hiddenIFrame,
+            navigationMode:
+                OidcPlatformSpecificOptions_Web_NavigationMode.hiddenIFrame,
           ),
         ),
       );

--- a/packages/oidc_core/lib/src/models/events/_exports.dart
+++ b/packages/oidc_core/lib/src/models/events/_exports.dart
@@ -1,2 +1,4 @@
 export 'event.dart';
 export 'pre_logout_event.dart';
+export 'token_expired_event.dart';
+export 'token_expiring_event.dart';

--- a/packages/oidc_core/lib/src/models/events/token_expired_event.dart
+++ b/packages/oidc_core/lib/src/models/events/token_expired_event.dart
@@ -1,0 +1,18 @@
+import 'package:oidc_core/oidc_core.dart';
+
+/// An event that gets raised after a token expired.
+class OidcTokenExpiredEvent extends OidcEvent {
+  ///
+  const OidcTokenExpiredEvent({
+    required this.currentToken,
+    required super.at,
+  });
+
+  ///
+  OidcTokenExpiredEvent.now({
+    required this.currentToken,
+  }) : super.now();
+
+  /// The current token that is expired.
+  final OidcToken currentToken;
+}

--- a/packages/oidc_core/lib/src/models/events/token_expiring_event.dart
+++ b/packages/oidc_core/lib/src/models/events/token_expiring_event.dart
@@ -1,0 +1,18 @@
+import 'package:oidc_core/oidc_core.dart';
+
+/// An event that gets raised before a token expires.
+class OidcTokenExpiringEvent extends OidcEvent {
+  ///
+  const OidcTokenExpiringEvent({
+    required this.currentToken,
+    required super.at,
+  });
+
+  ///
+  OidcTokenExpiringEvent.now({
+    required this.currentToken,
+  }) : super.now();
+
+  /// The current token that is expiring.
+  final OidcToken currentToken;
+}

--- a/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
+++ b/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
@@ -3,8 +3,6 @@ import 'package:oidc_core/oidc_core.dart';
 /// The callback used to determine the `expiring` duration.
 typedef OidcRefreshBeforeCallback = Duration? Function(OidcToken token);
 
-typedef OidcTokenCallback = void Function(OidcToken token);
-
 /// The default refreshBefore function, which refreshes 1 minute before the token expires.
 Duration? defaultRefreshBefore(OidcToken token) {
   return const Duration(minutes: 1);
@@ -37,8 +35,6 @@ class OidcUserManagerSettings {
     this.sessionManagementSettings = const OidcSessionManagementSettings(),
     this.getIdToken,
     this.supportOfflineAuth = false,
-    this.onTokenExpiring,
-    this.onTokenExpired,
   });
 
   /// The default scopes
@@ -131,12 +127,6 @@ class OidcUserManagerSettings {
 
   /// platform-specific options.
   final OidcPlatformSpecificOptions? options;
-
-  /// Callback that is called before the token expires.
-  final OidcTokenCallback? onTokenExpiring;
-
-  /// Callback that is called after the token expired.
-  final OidcTokenCallback? onTokenExpired;
 }
 
 ///

--- a/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
+++ b/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
@@ -3,6 +3,8 @@ import 'package:oidc_core/oidc_core.dart';
 /// The callback used to determine the `expiring` duration.
 typedef OidcRefreshBeforeCallback = Duration? Function(OidcToken token);
 
+typedef OidcTokenCallback = void Function(OidcToken token);
+
 /// The default refreshBefore function, which refreshes 1 minute before the token expires.
 Duration? defaultRefreshBefore(OidcToken token) {
   return const Duration(minutes: 1);
@@ -35,6 +37,8 @@ class OidcUserManagerSettings {
     this.sessionManagementSettings = const OidcSessionManagementSettings(),
     this.getIdToken,
     this.supportOfflineAuth = false,
+    this.onTokenExpiring,
+    this.onTokenExpired,
   });
 
   /// The default scopes
@@ -127,6 +131,12 @@ class OidcUserManagerSettings {
 
   /// platform-specific options.
   final OidcPlatformSpecificOptions? options;
+
+  /// Callback that is called before the token expires.
+  final OidcTokenCallback? onTokenExpiring;
+
+  /// Callback that is called after the token expired.
+  final OidcTokenCallback? onTokenExpired;
 }
 
 ///


### PR DESCRIPTION
Background: I use auth flow [jwt-bearer](https://datatracker.ietf.org/doc/html/rfc7523) where there is no refresh token. Still I want to auto-refresh before the token expires. The new callback `onTokenExpiring` can be used to achieve this.