### PR TITLE
chore: Upgrade web dependency to >=0.5.1 <2.0.0

### DIFF
--- a/packages/oidc_web_core/pubspec.yaml
+++ b/packages/oidc_web_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: oidc_web_core
 description: dart web package for oidc protocol
 version: 0.1.0
 repository: https://github.com/Bdaya-Dev/oidc/tree/main/packages/oidc_web_core
-topics: ['oidc', 'openidconnect', 'oauth', 'authentication']
+topics: ["oidc", "openidconnect", "oauth", "authentication"]
 homepage: https://bdaya-dev.github.io/oidc/
 
 environment:
@@ -13,8 +13,7 @@ dependencies:
   logging: ^1.2.0
   oidc_core: ^0.7.0
   rxdart: ^0.27.7
-  web: ^0.5.1
-
+  web: ">=0.5.1 <2.0.0"
 
 dev_dependencies:
   mocktail: ^1.0.3


### PR DESCRIPTION
## Description
This PR addresses an issue with the oidc_web_core package, which still relies on an older version of the web package (^0.5.1). With the recent major update of the web package to version 1.0.0, we needed to ensure compatibility with newer versions without breaking existing functionality.

fixes #119

## Requirements
Update the web package dependency to: >=0.5.1 <2.0.0

## Testing:
All tests should pass with the updated dependency range.

## Changes
The web dependency in pubspec.yaml has been updated to allow versions from 0.5.1 to any version below 2.0.0. This ensures compatibility with both the current 0.5.1 version and the major 1.0.0 release, while still preventing potential breaking changes in the 2.x.x versions.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
