### PR TITLE
fix: optional scopes in refresh token

### DIFF
--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -760,7 +760,7 @@ abstract class OidcUserManagerBase {
         clientId: clientCredentials.clientId,
         clientSecret: clientCredentials.clientSecret,
         extra: settings.extraTokenParameters,
-        scope: settings.scope,
+        scope: settings.includeScopesOnRefresh ? settings.scope : [],
       ),
     );
     return createUserFromToken(

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -821,7 +821,7 @@ abstract class OidcUserManagerBase {
           clientId: clientCredentials.clientId,
           clientSecret: clientCredentials.clientSecret,
           extra: settings.extraTokenParameters,
-          scope: settings.scope,
+          scope: settings.includeScopesOnRefresh ? settings.scope : [],
         ),
       );
       newUser = await createUserFromToken(

--- a/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
+++ b/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
@@ -35,6 +35,7 @@ class OidcUserManagerSettings {
     this.sessionManagementSettings = const OidcSessionManagementSettings(),
     this.getIdToken,
     this.supportOfflineAuth = false,
+    this.includeScopesOnRefresh = true,
   });
 
   /// The default scopes
@@ -127,6 +128,9 @@ class OidcUserManagerSettings {
 
   /// platform-specific options.
   final OidcPlatformSpecificOptions? options;
+
+  /// Specify whether or not to include scopes when refresh token
+  final bool includeScopesOnRefresh;
 }
 
 ///


### PR DESCRIPTION
## Description

This fix proposes the introduction of a new attribute of the UserManagerSettings class that would be used during the flow of refresh token to decide whether or not to include the scopes as param in the body of the request.
This fix is needed, as I pointed out in #167, because Salesforce doesn't support scope parameter in the body request when refreshing token.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
