### PR TITLE
chore(deps): bump rxdart from 0.27.7 to ">=0.27.7 <2.0.0" in /packages/oidc & /packages/oidc_web_core

### DIFF
--- a/packages/oidc/pubspec.yaml
+++ b/packages/oidc/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   http: ^1.1.0
   jose_plus: ^0.4.4
   retry: ^3.1.2
-  rxdart: ^0.27.7
+  rxdart: ">=0.27.7 <2.0.0"
   logging: ^1.2.0
   json_annotation: ^4.8.1
   nonce: ^1.2.0

--- a/packages/oidc_web_core/pubspec.yaml
+++ b/packages/oidc_web_core/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   collection: ^1.18.0
   logging: ^1.2.0
   oidc_core: ^0.9.1
-  rxdart: ^0.27.7
+  rxdart: ">=0.27.7 <2.0.0"
   web: ">=0.5.1 <2.0.0"
 
 dev_dependencies:


### PR DESCRIPTION
## Description

Allows usage with packages that depend on `rxdart` higher
than `0.27.0` and keeps the backward compatibility.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
