### PR TITLE
Feat.: Token Management for Multi-Resource Access in Azure 

### DIFF
--- a/packages/oidc_core/lib/src/endpoints/authorize/req.dart
+++ b/packages/oidc_core/lib/src/endpoints/authorize/req.dart
@@ -21,6 +21,7 @@ class OidcAuthorizeRequest extends JsonBasedRequest {
     required this.clientId,
     required this.redirectUri,
     required this.scope,
+    this.extraScopeToConsent,
     this.codeChallenge,
     this.codeChallengeMethod,
     super.extra,
@@ -55,6 +56,11 @@ class OidcAuthorizeRequest extends JsonBasedRequest {
     toJson: OidcInternalUtilities.joinSpaceDelimitedList,
   )
   List<String> scope;
+
+  /// OPTIONAL.
+  ///
+  /// Will be requested to be consented by the user. Included in initial AuthorizationCodeFlowRequest but not in the Token request.
+  List<String>? extraScopeToConsent;
 
   /// REQUIRED.
   ///

--- a/packages/oidc_core/lib/src/endpoints/authorize/simple_code_flow_request.dart
+++ b/packages/oidc_core/lib/src/endpoints/authorize/simple_code_flow_request.dart
@@ -11,6 +11,7 @@ class OidcSimpleAuthorizationCodeFlowRequest {
     required this.scope,
     required this.clientId,
     required this.redirectUri,
+    this.extraScopeToConsent,
     this.originalUri,
     this.display,
     this.prompt,
@@ -50,6 +51,9 @@ class OidcSimpleAuthorizationCodeFlowRequest {
 
   /// see [OidcAuthorizeRequest.scope].
   final List<String> scope;
+
+  /// see [OidcAuthorizeRequest.extraScopeToConsent].
+  final List<String>? extraScopeToConsent;
 
   /// see [OidcAuthorizeRequest.clientId].
   final String clientId;

--- a/packages/oidc_core/lib/src/endpoints/facade.dart
+++ b/packages/oidc_core/lib/src/endpoints/facade.dart
@@ -162,6 +162,7 @@ class OidcEndpoints {
               if (supportsOpenIdScope) OidcConstants_Scopes.openid,
               ...input.scope,
             ],
+      extraScopeToConsent: input.extraScopeToConsent,
       acrValues: input.acrValues,
       codeChallenge: codeChallenge,
       codeChallengeMethod: codeChallengeMethod,

--- a/packages/oidc_core/lib/src/endpoints/token/req.dart
+++ b/packages/oidc_core/lib/src/endpoints/token/req.dart
@@ -34,6 +34,7 @@ class OidcTokenRequest extends JsonBasedRequest {
 
   OidcTokenRequest.authorizationCode({
     required String this.code,
+    required this.scope,
     this.redirectUri,
     this.clientId,
     this.clientSecret,
@@ -49,8 +50,7 @@ class OidcTokenRequest extends JsonBasedRequest {
         subjectToken = null,
         actorTokenType = null,
         actorToken = null,
-        refreshToken = null,
-        scope = null;
+        refreshToken = null;
 
   OidcTokenRequest.refreshToken({
     required String this.refreshToken,

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -1092,7 +1092,7 @@ abstract class OidcUserManagerBase {
 
   /// Loads and verifies the tokens.
   @protected
-  Future<void> loadCachedTokens() async {
+  Future<void> loadCachedTokens({bool skipSupportedCheck = false}) async {
     final usedKeys = <String>{
       OidcConstants_Store.currentToken,
       OidcConstants_Store.currentUserAttributes,
@@ -1141,8 +1141,9 @@ abstract class OidcUserManagerBase {
         if (token.refreshToken != null &&
             (idTokenNeedsRefresh || token.isAccessTokenExpired())) {
           try {
-            loadedUser =
-                await refreshToken(overrideRefreshToken: token.refreshToken);
+            loadedUser = await refreshToken(
+                overrideRefreshToken: token.refreshToken,
+                skipSupportedCheck: skipSupportedCheck);
           } catch (e) {
             // An app might go offline during token refresh, so we consult the
             // supportOfflineAuth setting to check whether this is an issue or
@@ -1266,7 +1267,7 @@ abstract class OidcUserManagerBase {
 
   /// Initializes the user manager, this also gets the [discoveryDocument] if it
   /// wasn't provided.
-  Future<void> init() async {
+  Future<void> init({bool skipSupportedCheck = false}) async {
     if (hasInit) {
       return;
     }
@@ -1283,7 +1284,7 @@ abstract class OidcUserManagerBase {
         //no logout requests.
         if (!await loadStateResult()) {
           //no state results.
-          await loadCachedTokens();
+          await loadCachedTokens(skipSupportedCheck: skipSupportedCheck);
         }
       }
       final frontChannelLogoutUri = settings.frontChannelLogoutUri;


### PR DESCRIPTION
## Description

**Problem Statement:**  
In Azure, it is not possible to use the same access token for different resources. For example, if your application needs access to both your app's API and Azure Blob Storage, you must obtain **two separate access tokens**. This can lead to challenges in managing user experience, as users may encounter multiple pop-ups or login dialogs when consenting to different resources.

**Proposed Solution:**  
To streamline the user experience, you can leverage **refresh tokens** to obtain new access tokens for different resources without requiring additional user interaction. However, this approach requires that the user has already consented to the resource during the initial authorization process.

To achieve this:
- **Include additional scopes for consent** in the initial authorization code request. This ensures that the user consents to all required resources upfront.
- **Do not include these extra scopes in the token request.** The token request must only specify scopes for a single resource, as per Azure's OAuth 2.0 implementation.

[The Microsoft documentation explains this behavior](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow):  
> A space-separated list of [scopes](https://learn.microsoft.com/en-us/entra/identity-platform/permissions-consent-overview) that you want the user to consent to. For the /authorize leg of the request, this parameter can cover multiple resources. This value allows your app to get consent for multiple web APIs you want to call.

> A space-separated list of scopes. The scopes must all be from a single resource, along with OIDC scopes (profile, openid, email). For more information, see [Permissions and consent in the Microsoft identity platform](https://learn.microsoft.com/en-us/entra/identity-platform/permissions-consent-overview). This parameter is a Microsoft extension to the authorization code flow, intended to allow apps to declare the resource they want the token for during token redemption.

**Note:** Passing `null` for scopes in the token request leads to an error if access tokens for multiple resources are listed in the initial request.

As a result, the `loginAuthorizationCodeFlow()` function could accept an optional `extraScopeToConsent` parameter, and a few additional minor modifications are needed.

---

### Additional Considerations:
- **Handling Multiple Access Tokens:**  
  When refreshing a second token, it should not replace the "main" token. To address this, I added a `bool replaceUserToken = true` parameter as an optional named parameter to the `refreshToken(..)` function.
  
- **Discovery Document Limitation:**  
  Azure does not list `refresh_token` in the supported grant types in their discovery document. However, it works. To handle this, I added a named `skipSupportedCheck = false` parameter to the `refreshToken(..)` function. This also applies to the init() function.

---

### Open Issues:
- When loading a state result, it is not known which scopes should be requested. For now I added all scopes from the response. This needs further discussion or clarification.
- Documentation

---

**I know this PR might not be ready to merge, but I'd be happy to hear your feedback.**

---

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)  
            (hopefully not :worried: )
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore