### PR TITLE
fix: logout without postLogoutRedirectUri throws assert exception

### DIFF
--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -433,7 +433,8 @@ abstract class OidcUserManagerBase {
           clientId: clientCredentials.clientId,
           postLogoutRedirectUri: postLogoutRedirectUri,
           uiLocales: uiLocalesOverride ?? settings.uiLocales,
-          idTokenHint: currentUser.idToken,
+          idTokenHint:
+              postLogoutRedirectUri == null ? null : currentUser.idToken,
           extra: extraParameters,
           logoutHint: logoutHint,
           state: stateData?.id,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Calling _logout()_ of OidcUserManager without _postLogoutRedirectUri_ throws assert exception in flutter_appauth lib:

`assert((idTokenHint == null && postLogoutRedirectUrl == null) ||
            (idTokenHint != null && postLogoutRedirectUrl != null)) `

[flutter_appauth end_session_request.dart](https://github.com/MaikuB/flutter_appauth/blob/51f0b22740510e0cdd54aa31a36dffe91c1a50bb/flutter_appauth_platform_interface/lib/src/end_session_request.dart#L16)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
