### PR TITLE
fix(oidc_web_core): detect closed auth window during web redirect flow

### DIFF
--- a/packages/oidc_web_core/lib/src/oidc_web_core.dart
+++ b/packages/oidc_web_core/lib/src/oidc_web_core.dart
@@ -15,6 +15,8 @@ class OidcWebCore {
   /// {@macro oidc_web_core}
   const OidcWebCore();
 
+  static const _windowCloseCheckInterval = Duration(milliseconds: 250);
+
   String _calculatePopupOptions(OidcPlatformSpecificOptions_Web options) {
     final h = options.popupHeight;
     final w = options.popupWidth;
@@ -62,8 +64,12 @@ class OidcWebCore {
   }) async {
     final channel = BroadcastChannel(options.broadcastChannel);
     final c = Completer<Uri>();
+    Timer? preparedWindowClosedTimer;
 
     void eventFunction(MessageEvent event) {
+      if (c.isCompleted) {
+        return;
+      }
       final data = event.data;
       if (!data.isA<JSString>()) {
         return;
@@ -110,8 +116,22 @@ class OidcWebCore {
             );
           }
           preparedWindow.location.replace(uri.toString());
+          preparedWindowClosedTimer = Timer.periodic(
+            _windowCloseCheckInterval,
+            (_) {
+              if (c.isCompleted || !preparedWindow.closed) {
+                return;
+              }
+              c.completeError(
+                const OidcException(
+                  'The authentication window was closed before the flow completed.',
+                ),
+              );
+            },
+          );
           //listen to response uri.
           final res = await c.future;
+          preparedWindowClosedTimer.cancel();
           if (!preparedWindow.closed) {
             preparedWindow.close();
           }
@@ -133,6 +153,7 @@ class OidcWebCore {
           return res;
       }
     } finally {
+      preparedWindowClosedTimer?.cancel();
       channel.close();
     }
   }

--- a/packages/oidc_web_core/lib/src/oidc_web_core.dart
+++ b/packages/oidc_web_core/lib/src/oidc_web_core.dart
@@ -65,6 +65,7 @@ class OidcWebCore {
     final channel = BroadcastChannel(options.broadcastChannel);
     final c = Completer<Uri>();
     Timer? preparedWindowClosedTimer;
+    var canDetectPreparedWindowClosure = false;
 
     void eventFunction(MessageEvent event) {
       if (c.isCompleted) {
@@ -119,7 +120,17 @@ class OidcWebCore {
           preparedWindowClosedTimer = Timer.periodic(
             _windowCloseCheckInterval,
             (_) {
-              if (c.isCompleted || !preparedWindow.closed) {
+              if (c.isCompleted) {
+                return;
+              }
+              if (!preparedWindow.closed) {
+                canDetectPreparedWindowClosure = true;
+                return;
+              }
+              if (!canDetectPreparedWindowClosure) {
+                // COOP can sever the WindowProxy and report `closed == true`
+                // even while the auth window is still open.
+                preparedWindowClosedTimer?.cancel();
                 return;
               }
               c.completeError(

--- a/packages/oidc_web_core/lib/src/oidc_web_core.dart
+++ b/packages/oidc_web_core/lib/src/oidc_web_core.dart
@@ -125,6 +125,7 @@ class OidcWebCore {
               c.completeError(
                 const OidcException(
                   'The authentication window was closed before the flow completed.',
+                  extra: {'reason': 'window_closed'},
                 ),
               );
             },


### PR DESCRIPTION
## Description

Fixes #303.

When `popup` or `newPage` navigation is used on web, closing the authentication window before the redirect page posts a response through the `BroadcastChannel` leaves `_getResponseUri()` waiting indefinitely.

Because `loginAuthorizationCodeFlow()` depends on that future, callers can remain stuck waiting for an interactive sign-in, re-authentication, or MFA step that was already cancelled by the user.

This change starts a short polling timer right after the prepared auth window is navigated. If the window is closed before any redirect response is received, the flow now completes with an `OidcException` instead of hanging forever.

The timer is cancelled as soon as a response arrives and again during cleanup, so successful flows keep the existing behavior and no extra timer is left running.

Verified with `fvm dart analyze packages/oidc_web_core` and with a manual Flutter web reproduction where the auth popup is closed before completing the login flow.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of closed authentication windows in popup and new-page modes.
  * Prevented duplicate completion of authentication flows when multiple signals arrive.
  * Ensured periodic background checks are stopped and cleaned up, avoiding lingering timers after flow completion or error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->