### PR TITLE
fix: handle refresh responses without id_token

### DIFF
--- a/packages/oidc/test/oidc_test.dart
+++ b/packages/oidc/test/oidc_test.dart
@@ -177,6 +177,231 @@ void main() {
             );
           });
           test(
+            'With expired token and refresh response without id_token should keep cached expired id_token',
+            () async {
+              client = createMockOidcClient(
+                beforeDefault: (request) async {
+                  final pathSegments = request.url.pathSegments;
+                  if (pathSegments.length == 2 &&
+                      pathSegments[0] == '.well-known' &&
+                      pathSegments[1] == 'openid-configuration') {
+                    return Response(jsonEncode(mockProviderMetadata), 200);
+                  }
+                  if (pathSegments.isNotEmpty &&
+                      pathSegments.first == 'token') {
+                    final tokenResponse = createMockTokenResponse(
+                      claimsJson: defaultIdTokenClaimsJson(),
+                    )..remove('id_token');
+                    return Response(jsonEncode(tokenResponse), 200);
+                  }
+                  throw UnimplementedError(
+                    "Don't know how to handle the request ${request.url}",
+                  );
+                },
+              );
+              manager = OidcUserManager(
+                id: managerId,
+                discoveryDocument: doc,
+                clientCredentials: clientCredentials,
+                store: store,
+                settings: settings,
+                httpClient: client,
+              );
+
+              final nowMock = tokenCreatedAt.add(const Duration(hours: 2));
+              nowClock = Clock.fixed(nowMock);
+
+              await withClock(nowClock, () async {
+                await manager.init();
+              });
+
+              expect(manager.didInit, isTrue);
+              expect(manager.currentUser, isNotNull);
+
+              final newToken = manager.currentUser!.token;
+              expect(newToken.creationTime, nowMock);
+              expect(newToken.idToken, cachedTokenJson['id_token']);
+              expect(newToken.allowExpiredIdToken, isTrue);
+              expect(newToken.accessToken, isNot(equals('SlAV32hkKG')));
+
+              final storedToken = await store.get(
+                OidcStoreNamespace.secureTokens,
+                key: OidcConstants_Store.currentToken,
+                managerId: managerId,
+              );
+              expect(storedToken, isNotNull);
+
+              final decodedStoredToken =
+                  jsonDecode(storedToken!) as Map<String, dynamic>;
+              expect(
+                decodedStoredToken[OidcConstants_AuthParameters.idToken],
+                cachedTokenJson['id_token'],
+              );
+              expect(
+                decodedStoredToken[OidcConstants_Store.allowExpiredIdToken],
+                isTrue,
+              );
+            },
+          );
+          test(
+            'Should reload a refreshed token without re-rejecting the reused expired id_token',
+            () async {
+              client = createMockOidcClient(
+                beforeDefault: (request) async {
+                  final pathSegments = request.url.pathSegments;
+                  if (pathSegments.length == 2 &&
+                      pathSegments[0] == '.well-known' &&
+                      pathSegments[1] == 'openid-configuration') {
+                    return Response(jsonEncode(mockProviderMetadata), 200);
+                  }
+                  if (pathSegments.isNotEmpty &&
+                      pathSegments.first == 'token') {
+                    final tokenResponse = createMockTokenResponse(
+                      claimsJson: defaultIdTokenClaimsJson(),
+                    )..remove('id_token');
+                    return Response(jsonEncode(tokenResponse), 200);
+                  }
+                  throw UnimplementedError(
+                    "Don't know how to handle the request ${request.url}",
+                  );
+                },
+              );
+              manager = OidcUserManager(
+                id: managerId,
+                discoveryDocument: doc,
+                clientCredentials: clientCredentials,
+                store: store,
+                settings: settings,
+                httpClient: client,
+              );
+
+              final refreshedAt = tokenCreatedAt.add(const Duration(hours: 2));
+              await withClock(Clock.fixed(refreshedAt), () async {
+                await manager.init();
+              });
+              expect(manager.currentUser, isNotNull);
+
+              client = createMockOidcClient(
+                beforeDefault: (request) async {
+                  throw StateError(
+                      'Unexpected network request: ${request.url}');
+                },
+              );
+              manager = OidcUserManager(
+                id: managerId,
+                discoveryDocument: doc,
+                clientCredentials: clientCredentials,
+                store: store,
+                settings: settings,
+                httpClient: client,
+              );
+
+              final reloadAt = refreshedAt.add(const Duration(minutes: 30));
+              await withClock(Clock.fixed(reloadAt), () async {
+                await manager.init();
+              });
+
+              final reloadedToken = manager.currentUser?.token;
+              expect(reloadedToken, isNotNull);
+              expect(reloadedToken!.allowExpiredIdToken, isTrue);
+              expect(reloadedToken.idToken, cachedTokenJson['id_token']);
+              expect(reloadedToken.creationTime, refreshedAt);
+            },
+          );
+          test(
+            'Should not emit token expired when refresh succeeds without id_token',
+            () async {
+              final createdAt = DateTime.now().toUtc();
+              cachedTokenJson = {
+                "scope": OidcInternalUtilities.joinSpaceDelimitedList([
+                  OidcConstants_Scopes.openid,
+                  OidcConstants_Scopes.profile,
+                  OidcConstants_Scopes.email,
+                  "offline_access"
+                ]),
+                "access_token": "short-lived-token",
+                "token_type": "Bearer",
+                "refresh_token": "8xLOxBtZp8",
+                "expires_in": const Duration(seconds: 1).inSeconds,
+                "id_token": createIdToken(
+                  claimsJson: defaultIdTokenClaimsJson(
+                    iat: createdAt,
+                    exp: createdAt.add(const Duration(hours: 1)),
+                  ),
+                ),
+                "expiresInReferenceDate": createdAt.toIso8601String(),
+                "session_state":
+                    "YaSjXERcv7iG5F9euVQ_F4smjyt0jD3sYxARlJdBMVE.9A5536CDE44A8BE6D4F2A9E2ABD73ECF"
+              };
+              await store.set(
+                OidcStoreNamespace.secureTokens,
+                key: OidcConstants_Store.currentToken,
+                value: jsonEncode(cachedTokenJson),
+                managerId: managerId,
+              );
+
+              var refreshRequestCount = 0;
+              client = createMockOidcClient(
+                beforeDefault: (request) async {
+                  final pathSegments = request.url.pathSegments;
+                  if (pathSegments.length == 2 &&
+                      pathSegments[0] == '.well-known' &&
+                      pathSegments[1] == 'openid-configuration') {
+                    return Response(jsonEncode(mockProviderMetadata), 200);
+                  }
+                  if (pathSegments.isNotEmpty &&
+                      pathSegments.first == 'token') {
+                    refreshRequestCount++;
+                    final tokenResponse = createMockTokenResponse(
+                      claimsJson: defaultIdTokenClaimsJson(),
+                    )..remove('id_token');
+                    return Response(jsonEncode(tokenResponse), 200);
+                  }
+                  throw UnimplementedError(
+                    "Don't know how to handle the request ${request.url}",
+                  );
+                },
+              );
+
+              final eventSettings = OidcUserManagerSettings(
+                redirectUri: settings.redirectUri,
+                refreshBefore: (_) => const Duration(milliseconds: 700),
+              );
+              manager = OidcUserManager(
+                id: managerId,
+                discoveryDocument: doc,
+                clientCredentials: clientCredentials,
+                store: store,
+                settings: eventSettings,
+                httpClient: client,
+              );
+
+              await manager.init();
+              expect(manager.currentUser, isNotNull);
+
+              final events = <OidcEvent>[];
+              final sub = manager.events().listen(events.add);
+
+              await Future<void>.delayed(const Duration(milliseconds: 450));
+
+              expect(refreshRequestCount, equals(1));
+              expect(
+                events.whereType<OidcTokenExpiringEvent>(),
+                hasLength(1),
+              );
+              expect(events.whereType<OidcTokenExpiredEvent>(), isEmpty);
+              expect(manager.currentUser, isNotNull);
+              expect(manager.currentUser!.token.allowExpiredIdToken, isTrue);
+
+              await Future<void>.delayed(const Duration(milliseconds: 750));
+
+              expect(events.whereType<OidcTokenExpiredEvent>(), isEmpty);
+
+              await sub.cancel();
+              await manager.dispose();
+            },
+          );
+          test(
               'With expired token and no refresh token available, should remove the token',
               () async {
             cachedTokenJson.remove('refresh_token');

--- a/packages/oidc_core/lib/src/constants.dart
+++ b/packages/oidc_core/lib/src/constants.dart
@@ -717,6 +717,7 @@ class OidcConstants_AuthorizeRequest_CodeChallengeMethod {
 class OidcConstants_Store {
   static const expiresAt = 'expiresAt';
   static const expiresInReferenceDate = 'expiresInReferenceDate';
+  static const allowExpiredIdToken = 'allowExpiredIdToken';
   static const currentUserAttributes = 'userAttributes';
   static const currentUserInfo = 'userInfo';
   static const originalUri = 'original_uri';

--- a/packages/oidc_core/lib/src/endpoints/token/token.dart
+++ b/packages/oidc_core/lib/src/endpoints/token/token.dart
@@ -76,6 +76,9 @@ class OidcToken {
 
   bool get isOidc => idToken?.isNotEmpty ?? false;
 
+  bool get allowExpiredIdToken =>
+      extra?[OidcConstants_Store.allowExpiredIdToken] == true;
+
   /// RECOMMENDED.
   ///
   /// The lifetime in seconds of the access token.

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -1558,7 +1558,7 @@ abstract class OidcUserManagerBase {
   }
 
   bool _isJwtExpiredError(Exception error) =>
-      error is JoseException && error.message.startsWith('JWT expired.');
+      error is JoseException && error.message.startsWith('JWT expired');
 
   /// This function validates that a user claims
   @protected

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -1022,9 +1022,10 @@ abstract class OidcUserManagerBase {
     required Map<String, dynamic>? attributes,
     required Map<String, dynamic>? userInfo,
     required OidcProviderMetadata metadata,
+    OidcUser? currentUserOverride,
     bool validateAndSave = true,
   }) async {
-    final currentUser = this.currentUser;
+    final currentUser = currentUserOverride ?? this.currentUser;
     OidcUser? newUser;
     final idTokenOverride = await settings.getIdToken?.call(token);
     if (currentUser == null) {
@@ -1039,11 +1040,14 @@ abstract class OidcUserManagerBase {
         cacheStore: store,
       );
     } else {
+      final reusesExistingIdToken =
+          idTokenOverride == null && token.idToken == null;
       newUser = await currentUser.replaceToken(
         token,
         idTokenOverride: idTokenOverride,
         strictVerification: settings.strictJwtVerification,
         cacheStore: store,
+        allowExpiredIdToken: reusesExistingIdToken,
       );
       if (attributes != null) {
         newUser = newUser.setAttributes(attributes);
@@ -1220,10 +1224,24 @@ abstract class OidcUserManagerBase {
     String? overrideRefreshToken,
     OidcProviderMetadata? discoveryDocumentOverride,
     Map<String, dynamic>? extraBodyFields,
+  }) {
+    return _refreshToken(
+      overrideRefreshToken: overrideRefreshToken,
+      discoveryDocumentOverride: discoveryDocumentOverride,
+      extraBodyFields: extraBodyFields,
+    );
+  }
+
+  Future<OidcUser?> _refreshToken({
+    String? overrideRefreshToken,
+    OidcProviderMetadata? discoveryDocumentOverride,
+    Map<String, dynamic>? extraBodyFields,
+    OidcUser? currentUserOverride,
   }) async {
     ensureInit();
     final discoveryDocument =
         discoveryDocumentOverride ?? this.discoveryDocument;
+    final existingUser = currentUserOverride ?? currentUser;
     if (!discoveryDocument.grantTypesSupportedOrDefault.contains(
       OidcConstants_GrantType.refreshToken,
     )) {
@@ -1232,7 +1250,7 @@ abstract class OidcUserManagerBase {
     }
 
     final refreshToken =
-        overrideRefreshToken ?? currentUser?.token.refreshToken;
+        overrideRefreshToken ?? existingUser?.token.refreshToken;
     if (refreshToken == null) {
       // Can't refresh the access token anyway.
       return null;
@@ -1268,7 +1286,7 @@ abstract class OidcUserManagerBase {
       final token = OidcToken.fromResponse(
         tokenResponse,
         overrideExpiresIn: settings.getExpiresIn?.call(tokenResponse),
-        sessionState: currentUser?.token.sessionState,
+        sessionState: existingUser?.token.sessionState,
       );
 
       // Successful refresh - update last server contact and exit offline mode
@@ -1279,18 +1297,19 @@ abstract class OidcUserManagerBase {
         userInfo: null,
         attributes: null,
         metadata: discoveryDocument,
+        currentUserOverride: existingUser,
       );
     } on Object catch (e) {
       // Handle errors based on offline auth settings
       final handledOffline = handleOfflineEligibleFailure(
         error: e,
-        fallbackToken: currentUser?.token,
+        fallbackToken: existingUser?.token,
         emitRepeatFailureWarning: true,
       );
 
       if (handledOffline) {
         // Return the same user - callers will continue with cached state
-        return currentUser;
+        return existingUser;
       }
 
       // Non-network error or offline auth not supported - rethrow
@@ -1521,6 +1540,9 @@ abstract class OidcUserManagerBase {
         expiryTolerance: settings.expiryTolerance,
       ),
     ];
+    if (user.token.allowExpiredIdToken) {
+      errors.removeWhere(_isJwtExpiredError);
+    }
     if (user.parsedIdToken.claims.subject == null) {
       errors.add(
         JoseException('id token is missing a `sub` claim.'),
@@ -1534,6 +1556,9 @@ abstract class OidcUserManagerBase {
 
     return errors;
   }
+
+  bool _isJwtExpiredError(Exception error) =>
+      error is JoseException && error.message.startsWith('JWT expired.');
 
   /// This function validates that a user claims
   @protected
@@ -1609,17 +1634,12 @@ abstract class OidcUserManagerBase {
     }
 
     // Check if we're using expired tokens in offline mode
-    final hasExpiredTokenError = errors.any(
-      (e) => e is JoseException && e.message.startsWith('JWT expired.'),
-    );
+    final hasExpiredTokenError = errors.any(_isJwtExpiredError);
 
     if (errors.isEmpty ||
         //keep going if the only error is that the token expired,
         //and it's allowed in settings.
-        (settings.supportOfflineAuth &&
-            errors.every(
-              (e) => e is JoseException && e.message.startsWith('JWT expired.'),
-            ))) {
+        (settings.supportOfflineAuth && errors.every(_isJwtExpiredError))) {
       // Check if offline duration is excessive
       if (settings.supportOfflineAuth && isOfflineDurationExcessive()) {
         emitOfflineAuthWarning(
@@ -1834,8 +1854,9 @@ abstract class OidcUserManagerBase {
         if (token.refreshToken != null &&
             (idTokenNeedsRefresh || token.isAccessTokenExpired())) {
           try {
-            final refreshedUser = await refreshToken(
+            final refreshedUser = await _refreshToken(
               overrideRefreshToken: token.refreshToken,
+              currentUserOverride: loadedUser,
             );
             if (refreshedUser != null) {
               loadedUser = refreshedUser;

--- a/packages/oidc_core/lib/src/models/user.dart
+++ b/packages/oidc_core/lib/src/models/user.dart
@@ -156,6 +156,7 @@ class OidcUser {
     String? idTokenOverride,
     bool strictVerification = false,
     OidcStore? cacheStore,
+    bool allowExpiredIdToken = false,
   }) async {
     final idToken = idTokenOverride ?? newToken.idToken ?? this.idToken;
 
@@ -172,14 +173,21 @@ class OidcUser {
       webToken = parsedIdToken;
     }
 
+    final mergedTokenJson = {
+      // keep old data and override the new data.
+      ...token.toJson(),
+      ...newToken.toJson(),
+    };
+    if (allowExpiredIdToken) {
+      mergedTokenJson[OidcConstants_Store.allowExpiredIdToken] = true;
+    } else {
+      mergedTokenJson.remove(OidcConstants_Store.allowExpiredIdToken);
+    }
+
     return OidcUser._(
       idToken: idToken,
       parsedIdToken: webToken,
-      token: OidcToken.fromJson({
-        // keep old data and override the new data.
-        ...token.toJson(),
-        ...newToken.toJson(),
-      }),
+      token: OidcToken.fromJson(mergedTokenJson),
       attributes: attributes,
       allowedAlgorithms: allowedAlgorithms,
       keystore: keystore,

--- a/packages/oidc_core/test/model_test.dart
+++ b/packages/oidc_core/test/model_test.dart
@@ -124,6 +124,20 @@ void main() {
               isExpired,
             );
           });
+          test('preserves allowExpiredIdToken when stored', () {
+            final src = {
+              OidcConstants_AuthParameters.accessToken: 'TlBN45jURg',
+              OidcConstants_AuthParameters.tokenType: 'Bearer',
+              OidcConstants_AuthParameters.refreshToken: '9yNOxJtZa5',
+              OidcConstants_AuthParameters.expiresIn: expiresIn.inSeconds,
+              OidcConstants_Store.expiresInReferenceDate: createdAt
+                  .toIso8601String(),
+              OidcConstants_Store.allowExpiredIdToken: true,
+            };
+            final obj = OidcToken.fromJson(src);
+            expect(obj.allowExpiredIdToken, isTrue);
+            expect(obj.toJson(), src);
+          });
         });
       }
     });


### PR DESCRIPTION
Fixes #306 

## Description
This change fixes the case where a successful refresh token response does not include id_token.

Previously, the library could still reject the session later if it had to keep using the previous id_token and that token was already expired. There was also no regression coverage around token event behavior for this refresh path.

## What changed

- Reuse the previously loaded user during cached-token startup refresh so refresh responses without id_token can still preserve the existing id_token.
- Persist a narrow internal marker on refreshed tokens when the manager had to reuse the previous id_token because the token response omitted one.
- During validation, ignore only the JWT expired error for that specific reused-id-token case.
- Keep all other id_token validation checks intact, including issuer, audience, sub, and iat validation.
- Add regression tests for: cached-token refresh without id_token, reload after a refresh without id_token,  no token expired event after a successful refresh without id_token

## Why
Some providers do not return id_token on refresh. In that case, a successful refresh should not cause the session to be rejected solely because the manager had to keep using the prior id_token.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OIDC handling improved to preserve and reuse a cached ID token when refresh responses omit an ID token, with a flag to allow treating an expired ID token as valid during refreshes.

* **Tests**
  * Added tests covering refresh flows without ID tokens: token state preservation, persisted store contents, event emission behavior, and re-initialization without extra network calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->