### PR TITLE
chore: ignore .omc/ (oh-my-claudecode local session state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ build/
 .classpath
 .settings
 pubspec_overrides.yaml
+
+# oh-my-claudecode local session/state, plans, research & logs (not source)
+.omc/


### PR DESCRIPTION
Adds `.omc/` (oh-my-claudecode local session/state, plans, research, logs — not source) to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude an additional local development directory from version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bdaya-Dev/oidc/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->