### PR TITLE
style(oidc_web_core): fix dart format to green main

### DIFF
--- a/packages/oidc_web_core/lib/src/oidc_web_core.dart
+++ b/packages/oidc_web_core/lib/src/oidc_web_core.dart
@@ -117,30 +117,29 @@ class OidcWebCore {
             );
           }
           preparedWindow.location.replace(uri.toString());
-          preparedWindowClosedTimer = Timer.periodic(
-            _windowCloseCheckInterval,
-            (_) {
-              if (c.isCompleted) {
-                return;
-              }
-              if (!preparedWindow.closed) {
-                canDetectPreparedWindowClosure = true;
-                return;
-              }
-              if (!canDetectPreparedWindowClosure) {
-                // COOP can sever the WindowProxy and report `closed == true`
-                // even while the auth window is still open.
-                preparedWindowClosedTimer?.cancel();
-                return;
-              }
-              c.completeError(
-                const OidcException(
-                  'The authentication window was closed before the flow completed.',
-                  extra: {'reason': 'window_closed'},
-                ),
-              );
-            },
-          );
+          preparedWindowClosedTimer = Timer.periodic(_windowCloseCheckInterval, (
+            _,
+          ) {
+            if (c.isCompleted) {
+              return;
+            }
+            if (!preparedWindow.closed) {
+              canDetectPreparedWindowClosure = true;
+              return;
+            }
+            if (!canDetectPreparedWindowClosure) {
+              // COOP can sever the WindowProxy and report `closed == true`
+              // even while the auth window is still open.
+              preparedWindowClosedTimer?.cancel();
+              return;
+            }
+            c.completeError(
+              const OidcException(
+                'The authentication window was closed before the flow completed.',
+                extra: {'reason': 'window_closed'},
+              ),
+            );
+          });
           //listen to response uri.
           final res = await c.future;
           preparedWindowClosedTimer.cancel();


### PR DESCRIPTION
oidc_web_core.dart (from #305) was not Dart-3.12 tall-style formatted, failing the `melos run format` check on main. This applies `dart format`. No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code restructuring to improve code organization and maintainability. No changes to functionality or user-facing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bdaya-Dev/oidc/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->