### PR TITLE
fix(oidc_core): batch-4 P1 spec-compliance hardening (#324)

### DIFF
--- a/packages/oidc_core/lib/src/constants.dart
+++ b/packages/oidc_core/lib/src/constants.dart
@@ -608,6 +608,10 @@ class OidcConstants_ProviderMetadata {
   ///Boolean value specifying whether the OP supports HTTP-based logout, with true indicating support
   static const frontchannelLogoutSupported = 'frontchannel_logout_supported';
 
+  ///Boolean value specifying whether the OP can pass a sid (session ID) Claim in the Logout Token to identify the RP session with the OP, when front-channel logout is supported
+  static const frontchannelLogoutSessionSupported =
+      'frontchannel_logout_session_supported';
+
   ///Boolean value specifying whether the OP supports back-channel logout, with true indicating support
   static const backchannelLogoutSupported = 'backchannel_logout_supported';
 

--- a/packages/oidc_core/lib/src/endpoints/discovery/resp.dart
+++ b/packages/oidc_core/lib/src/endpoints/discovery/resp.dart
@@ -55,6 +55,10 @@ class OidcProviderMetadata extends JsonBasedResponse {
     this.opTosUri,
     this.checkSessionIframe,
     this.endSessionEndpoint,
+    this.frontchannelLogoutSupported,
+    this.frontchannelLogoutSessionSupported,
+    this.backchannelLogoutSupported,
+    this.backchannelLogoutSessionSupported,
     this.revocationEndpoint,
     this.revocationEndpointAuthMethodsSupported,
     this.revocationEndpointAuthSigningAlgValuesSupported,
@@ -353,6 +357,40 @@ class OidcProviderMetadata extends JsonBasedResponse {
     fromJson: OidcInternalUtilities.tryParseUri,
   )
   final Uri? endSessionEndpoint;
+
+  /// `true` when the OP supports HTTP-based (front-channel) logout, as
+  /// specified by OpenID Connect Front-Channel Logout 1.0. Absent ⇒ `false`.
+  @JsonKey(name: OidcConstants_ProviderMetadata.frontchannelLogoutSupported)
+  final bool? frontchannelLogoutSupported;
+  bool get frontchannelLogoutSupportedOrDefault =>
+      frontchannelLogoutSupported ?? false;
+
+  /// `true` when the OP can pass a `sid` (session ID) query parameter to
+  /// identify the RP session at the OP when front-channel logout is
+  /// supported. Absent ⇒ `false`.
+  @JsonKey(
+    name: OidcConstants_ProviderMetadata.frontchannelLogoutSessionSupported,
+  )
+  final bool? frontchannelLogoutSessionSupported;
+  bool get frontchannelLogoutSessionSupportedOrDefault =>
+      frontchannelLogoutSessionSupported ?? false;
+
+  /// `true` when the OP supports back-channel logout, as specified by
+  /// OpenID Connect Back-Channel Logout 1.0. Absent ⇒ `false`.
+  @JsonKey(name: OidcConstants_ProviderMetadata.backchannelLogoutSupported)
+  final bool? backchannelLogoutSupported;
+  bool get backchannelLogoutSupportedOrDefault =>
+      backchannelLogoutSupported ?? false;
+
+  /// `true` when the OP can pass a `sid` (session ID) Claim in the Logout
+  /// Token to identify the RP session at the OP when back-channel logout is
+  /// supported. Absent ⇒ `false`.
+  @JsonKey(
+    name: OidcConstants_ProviderMetadata.backchannelLogoutSessionSupported,
+  )
+  final bool? backchannelLogoutSessionSupported;
+  bool get backchannelLogoutSessionSupportedOrDefault =>
+      backchannelLogoutSessionSupported ?? false;
 
   /// URL of the authorization server's OAuth 2.0 revocation endpoint.
   @JsonKey(

--- a/packages/oidc_core/lib/src/endpoints/discovery/resp.g.dart
+++ b/packages/oidc_core/lib/src/endpoints/discovery/resp.g.dart
@@ -117,6 +117,22 @@ abstract class _$OidcProviderMetadataCWProxy {
 
   OidcProviderMetadata endSessionEndpoint(Uri? endSessionEndpoint);
 
+  OidcProviderMetadata frontchannelLogoutSupported(
+    bool? frontchannelLogoutSupported,
+  );
+
+  OidcProviderMetadata frontchannelLogoutSessionSupported(
+    bool? frontchannelLogoutSessionSupported,
+  );
+
+  OidcProviderMetadata backchannelLogoutSupported(
+    bool? backchannelLogoutSupported,
+  );
+
+  OidcProviderMetadata backchannelLogoutSessionSupported(
+    bool? backchannelLogoutSessionSupported,
+  );
+
   OidcProviderMetadata revocationEndpoint(Uri? revocationEndpoint);
 
   OidcProviderMetadata revocationEndpointAuthMethodsSupported(
@@ -202,6 +218,10 @@ abstract class _$OidcProviderMetadataCWProxy {
     Uri? opTosUri,
     Uri? checkSessionIframe,
     Uri? endSessionEndpoint,
+    bool? frontchannelLogoutSupported,
+    bool? frontchannelLogoutSessionSupported,
+    bool? backchannelLogoutSupported,
+    bool? backchannelLogoutSessionSupported,
     Uri? revocationEndpoint,
     List<String>? revocationEndpointAuthMethodsSupported,
     List<String>? revocationEndpointAuthSigningAlgValuesSupported,
@@ -411,6 +431,30 @@ class _$OidcProviderMetadataCWProxyImpl
       call(endSessionEndpoint: endSessionEndpoint);
 
   @override
+  OidcProviderMetadata frontchannelLogoutSupported(
+    bool? frontchannelLogoutSupported,
+  ) => call(frontchannelLogoutSupported: frontchannelLogoutSupported);
+
+  @override
+  OidcProviderMetadata frontchannelLogoutSessionSupported(
+    bool? frontchannelLogoutSessionSupported,
+  ) => call(
+    frontchannelLogoutSessionSupported: frontchannelLogoutSessionSupported,
+  );
+
+  @override
+  OidcProviderMetadata backchannelLogoutSupported(
+    bool? backchannelLogoutSupported,
+  ) => call(backchannelLogoutSupported: backchannelLogoutSupported);
+
+  @override
+  OidcProviderMetadata backchannelLogoutSessionSupported(
+    bool? backchannelLogoutSessionSupported,
+  ) => call(
+    backchannelLogoutSessionSupported: backchannelLogoutSessionSupported,
+  );
+
+  @override
   OidcProviderMetadata revocationEndpoint(Uri? revocationEndpoint) =>
       call(revocationEndpoint: revocationEndpoint);
 
@@ -534,6 +578,10 @@ class _$OidcProviderMetadataCWProxyImpl
     Object? opTosUri = const $CopyWithPlaceholder(),
     Object? checkSessionIframe = const $CopyWithPlaceholder(),
     Object? endSessionEndpoint = const $CopyWithPlaceholder(),
+    Object? frontchannelLogoutSupported = const $CopyWithPlaceholder(),
+    Object? frontchannelLogoutSessionSupported = const $CopyWithPlaceholder(),
+    Object? backchannelLogoutSupported = const $CopyWithPlaceholder(),
+    Object? backchannelLogoutSessionSupported = const $CopyWithPlaceholder(),
     Object? revocationEndpoint = const $CopyWithPlaceholder(),
     Object? revocationEndpointAuthMethodsSupported =
         const $CopyWithPlaceholder(),
@@ -723,6 +771,26 @@ class _$OidcProviderMetadataCWProxyImpl
           ? _value.endSessionEndpoint
           // ignore: cast_nullable_to_non_nullable
           : endSessionEndpoint as Uri?,
+      frontchannelLogoutSupported:
+          frontchannelLogoutSupported == const $CopyWithPlaceholder()
+          ? _value.frontchannelLogoutSupported
+          // ignore: cast_nullable_to_non_nullable
+          : frontchannelLogoutSupported as bool?,
+      frontchannelLogoutSessionSupported:
+          frontchannelLogoutSessionSupported == const $CopyWithPlaceholder()
+          ? _value.frontchannelLogoutSessionSupported
+          // ignore: cast_nullable_to_non_nullable
+          : frontchannelLogoutSessionSupported as bool?,
+      backchannelLogoutSupported:
+          backchannelLogoutSupported == const $CopyWithPlaceholder()
+          ? _value.backchannelLogoutSupported
+          // ignore: cast_nullable_to_non_nullable
+          : backchannelLogoutSupported as bool?,
+      backchannelLogoutSessionSupported:
+          backchannelLogoutSessionSupported == const $CopyWithPlaceholder()
+          ? _value.backchannelLogoutSessionSupported
+          // ignore: cast_nullable_to_non_nullable
+          : backchannelLogoutSessionSupported as bool?,
       revocationEndpoint: revocationEndpoint == const $CopyWithPlaceholder()
           ? _value.revocationEndpoint
           // ignore: cast_nullable_to_non_nullable
@@ -902,6 +970,12 @@ OidcProviderMetadata _$OidcProviderMetadataFromJson(
   endSessionEndpoint: OidcInternalUtilities.tryParseUri(
     json['end_session_endpoint'],
   ),
+  frontchannelLogoutSupported: json['frontchannel_logout_supported'] as bool?,
+  frontchannelLogoutSessionSupported:
+      json['frontchannel_logout_session_supported'] as bool?,
+  backchannelLogoutSupported: json['backchannel_logout_supported'] as bool?,
+  backchannelLogoutSessionSupported:
+      json['backchannel_logout_session_supported'] as bool?,
   revocationEndpoint: OidcInternalUtilities.tryParseUri(
     json['revocation_endpoint'],
   ),

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -1452,10 +1452,14 @@ abstract class OidcUserManagerBase {
         request: OidcTokenHookRequest(
           metadata: discoveryDocument,
           tokenEndpoint: discoveryDocument.tokenEndpoint!,
+          // clientSecret is intentionally NOT passed here: `credentials`
+          // below is the single source of client authentication (RFC 6749
+          // §2.3). Also setting it on the request would duplicate it into
+          // the body even when `credentials` already authenticates via the
+          // Basic header (see OidcEndpoints.token).
           request: OidcTokenRequest.refreshToken(
             refreshToken: refreshToken,
             clientId: clientCredentials.clientId,
-            clientSecret: clientCredentials.clientSecret,
             extra: {...?settings.extraTokenParameters, ...?extraBodyFields},
             scope: settings.scope,
             resource: settings.resource,
@@ -1552,10 +1556,14 @@ abstract class OidcUserManagerBase {
           credentials: clientCredentials,
           client: httpClient,
           headers: settings.extraTokenHeaders,
+          // clientSecret is intentionally NOT passed here: `credentials`
+          // above is the single source of client authentication (RFC 6749
+          // §2.3). Also setting it on the request would duplicate it into
+          // the body even when `credentials` already authenticates via the
+          // Basic header (see OidcEndpoints.token).
           request: OidcTokenRequest.refreshToken(
             refreshToken: refreshToken,
             clientId: clientCredentials.clientId,
-            clientSecret: clientCredentials.clientSecret,
             extra: settings.extraTokenParameters,
             scope: settings.scope,
             resource: settings.resource,

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -550,6 +550,35 @@ abstract class OidcUserManagerBase {
       if (state != null) {
         await store.setStateResponseData(state: state, stateData: null);
       }
+      // RFC 9207 mix-up attack defense, mirroring handleSuccessfulAuthResponse:
+      // an authorization ERROR response is just as capable of originating
+      // from the wrong AS as a successful one, so it gets the same `iss`
+      // check before the original server-error is allowed to propagate.
+      final responseIss = response.iss;
+      final expectedIssuer = metadata.issuer;
+      // §2.4: a client MUST reject a response that omits `iss` when the AS
+      // advertises support via `authorization_response_iss_parameter_supported`.
+      if (metadata.authorizationResponseIssParameterSupportedOrDefault &&
+          responseIss == null) {
+        logAndThrow(
+          'The authorization server advertises '
+          '`authorization_response_iss_parameter_supported` but the '
+          'authorization error response is missing the `iss` parameter '
+          '(RFC 9207 §2.4); refusing as a possible mix-up attack.',
+        );
+      }
+      // When `iss` is present it MUST match the provider issuer (string compare,
+      // not Uri normalization — RFC 9207 §2.4). A no-op for OPs that omit it and
+      // do not advertise support.
+      if (responseIss != null &&
+          expectedIssuer != null &&
+          responseIss.toString() != expectedIssuer.toString()) {
+        logAndThrow(
+          'Authorization error response `iss` ($responseIss) does not '
+          'match the provider issuer ($expectedIssuer); possible mix-up '
+          'attack (RFC 9207).',
+        );
+      }
       rethrow;
     }
   }

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -916,7 +916,10 @@ abstract class OidcUserManagerBase {
         clientId: clientCredentials.clientId,
         postLogoutRedirectUri: postLogoutRedirectUri,
         uiLocales: uiLocalesOverride ?? settings.uiLocales,
-        idTokenHint: postLogoutRedirectUri == null ? null : currentUser.idToken,
+        // Always send id_token_hint: it's the RP-initiated-logout mechanism
+        // OPs use to identify/authenticate the logout request, independent
+        // of whether a post_logout_redirect_uri was also requested.
+        idTokenHint: currentUser.idToken,
         extra: extraParameters,
         logoutHint: logoutHint,
         state: stateData?.id,

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -2124,8 +2124,9 @@ abstract class OidcUserManagerBase {
           );
 
           logger.info('UserInfo response: ${userInfoResp.src}');
-          if (userInfoResp.sub != null &&
-              userInfoResp.sub != actualUser.claims.subject) {
+          // OIDC Core §5.3.2: `sub` is REQUIRED in the UserInfo response; a
+          // response omitting it MUST be rejected, not silently accepted.
+          if (userInfoResp.sub != actualUser.claims.subject) {
             errors.add(
               const OidcException("UserInfo didn't return the same subject."),
             );

--- a/packages/oidc_core/lib/src/models/client_auth.dart
+++ b/packages/oidc_core/lib/src/models/client_auth.dart
@@ -125,10 +125,16 @@ class OidcClientAuthentication {
         OidcConstants_ClientAuthenticationMethods.clientSecretBasic) {
       return null;
     }
-    if (clientSecret == null) {
+    final secret = clientSecret;
+    if (secret == null) {
       return null;
     }
-    final concat = '$clientId:$clientSecret';
+    // RFC 6749 §2.3.1: the client_id and client_secret are each individually
+    // encoded with the "application/x-www-form-urlencoded" encoding algorithm
+    // (per Appendix B) BEFORE being concatenated with a colon and base64'd.
+    final concat =
+        '${Uri.encodeQueryComponent(clientId)}:'
+        '${Uri.encodeQueryComponent(secret)}';
     return 'Basic ${_utf8ThenBase64.encode(concat)}';
   }
 

--- a/packages/oidc_core/test/client_secret_basic_encoding_test.dart
+++ b/packages/oidc_core/test/client_secret_basic_encoding_test.dart
@@ -1,0 +1,57 @@
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('client_secret_basic percent-encoding (RFC 6749 §2.3.1)', () {
+    test(
+      'a secret with reserved/special characters is form-urlencoded before '
+      'the colon-join + base64',
+      () {
+        const clientId = 'client:1';
+        const clientSecret = 's3cr%t &+special';
+        const auth = OidcClientAuthentication.clientSecretBasic(
+          clientId: clientId,
+          clientSecret: clientSecret,
+        );
+
+        final header = auth.getAuthorizationHeader();
+        expect(header, isNotNull);
+        expect(header, startsWith('Basic '));
+
+        final decoded = utf8.decode(
+          base64.decode(header!.substring('Basic '.length)),
+        );
+        final expected =
+            '${Uri.encodeQueryComponent(clientId)}:'
+            '${Uri.encodeQueryComponent(clientSecret)}';
+        expect(decoded, expected);
+        // Sanity: the raw, un-encoded concatenation must NOT be what's sent.
+        expect(decoded, isNot('$clientId:$clientSecret'));
+      },
+    );
+
+    test(
+      'a plain alphanumeric secret produces an unchanged header '
+      '(backward compat)',
+      () {
+        const clientId = 'client1';
+        const clientSecret = 'secret123';
+        const auth = OidcClientAuthentication.clientSecretBasic(
+          clientId: clientId,
+          clientSecret: clientSecret,
+        );
+
+        final header = auth.getAuthorizationHeader();
+        final expectedRaw = base64.encode(
+          utf8.encode('$clientId:$clientSecret'),
+        );
+        expect(header, 'Basic $expectedRaw');
+      },
+    );
+  });
+}

--- a/packages/oidc_core/test/dual_client_auth_refresh_test.dart
+++ b/packages/oidc_core/test/dual_client_auth_refresh_test.dart
@@ -1,0 +1,199 @@
+@TestOn('vm')
+library;
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+/// Minimal concrete manager for driving non-platform flows in a VM test.
+class _TestManager extends OidcUserManagerBase {
+  _TestManager({
+    required super.discoveryDocument,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    super.httpClient,
+  });
+
+  void seed(OidcUser user) => userSubject.add(user);
+
+  /// Test hook to drive the protected auto-refresh-on-expiry path.
+  Future<void> expire(OidcToken token) => handleTokenExpiring(token);
+
+  @override
+  bool get isWeb => false;
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+String _signIdToken() {
+  final key = JsonWebKey.generate('RS256');
+  return (JsonWebSignatureBuilder()
+        ..jsonContent = {
+          'iss': 'https://op.example.com',
+          'sub': 'user-1',
+          'aud': 'client-1',
+          'exp':
+              clock
+                  .now()
+                  .add(const Duration(hours: 1))
+                  .millisecondsSinceEpoch ~/
+              1000,
+          'iat': clock.now().millisecondsSinceEpoch ~/ 1000,
+        }
+        ..addRecipient(key, algorithm: 'RS256'))
+      .build()
+      .toCompactSerialization();
+}
+
+Future<OidcUser> _user() => OidcUser.fromIdToken(
+  token: OidcToken(
+    creationTime: clock.now(),
+    idToken: _signIdToken(),
+    accessToken: 'access-token-1',
+    refreshToken: 'refresh-token-1',
+    tokenType: 'Bearer',
+  ),
+  strictVerification: false,
+);
+
+OidcProviderMetadata _metadata() => OidcProviderMetadata.fromJson({
+  'issuer': 'https://op.example.com',
+  'authorization_endpoint': 'https://op.example.com/authorize',
+  'token_endpoint': 'https://op.example.com/token',
+});
+
+Future<_TestManager> _build(http.Client client) async {
+  final manager = _TestManager(
+    discoveryDocument: _metadata(),
+    // client_secret_basic: the secret is authenticated via the Authorization
+    // header, so it must never ALSO appear in the token request body.
+    clientCredentials: const OidcClientAuthentication.clientSecretBasic(
+      clientId: 'client-1',
+      clientSecret: 'super-secret',
+    ),
+    store: OidcMemoryStore(),
+    httpClient: client,
+    settings: OidcUserManagerSettings(
+      redirectUri: Uri.parse('com.example.app://cb'),
+      strictJwtVerification: false,
+    ),
+  );
+  await manager.init();
+  manager.seed(await _user());
+  return manager;
+}
+
+Map<String, String> _qp(http.Request r) => Uri.splitQueryString(r.body);
+
+void main() {
+  group(
+    'client auth is sent in exactly one location on refresh (RFC 6749 §2.3)',
+    () {
+      test(
+        'manual refreshToken(): Basic header present, no client_secret in body',
+        () async {
+          final tokenCalls = <http.Request>[];
+          final client = MockClient((req) async {
+            if (req.url.path.endsWith('/token')) {
+              tokenCalls.add(req);
+              return http.Response(
+                '{"access_token":"new-access","token_type":"Bearer",'
+                '"expires_in":3600,"refresh_token":"refresh-token-2",'
+                '"id_token":"${_signIdToken()}"}',
+                200,
+                headers: const {'content-type': 'application/json'},
+              );
+            }
+            return http.Response('{}', 404);
+          });
+          final manager = await _build(client);
+
+          final result = await manager.refreshToken();
+
+          expect(tokenCalls, isNotEmpty);
+          final req = tokenCalls.first;
+          expect(
+            req.headers['Authorization'],
+            startsWith('Basic '),
+            reason: 'client_secret_basic must authenticate via the header',
+          );
+          expect(
+            _qp(req).containsKey('client_secret'),
+            isFalse,
+            reason:
+                'the secret must not ALSO be duplicated into the request '
+                'body when a Basic header is already present',
+          );
+          expect(result, isNotNull);
+        },
+      );
+
+      test(
+        'AUTO refresh-on-expiry: Basic header present, no client_secret in body',
+        () async {
+          final tokenCalls = <http.Request>[];
+          final client = MockClient((req) async {
+            if (req.url.path.endsWith('/token')) {
+              tokenCalls.add(req);
+              return http.Response(
+                '{"access_token":"new-access","token_type":"Bearer",'
+                '"expires_in":3600,"refresh_token":"refresh-token-2",'
+                '"id_token":"${_signIdToken()}"}',
+                200,
+                headers: const {'content-type': 'application/json'},
+              );
+            }
+            return http.Response('{}', 404);
+          });
+          final manager = await _build(client);
+
+          await manager.expire(
+            OidcToken(
+              creationTime: clock.now(),
+              idToken: _signIdToken(),
+              accessToken: 'access-token-1',
+              refreshToken: 'refresh-token-1',
+              tokenType: 'Bearer',
+            ),
+          );
+
+          expect(tokenCalls, isNotEmpty);
+          final req = tokenCalls.first;
+          expect(req.headers['Authorization'], startsWith('Basic '));
+          expect(_qp(req).containsKey('client_secret'), isFalse);
+        },
+      );
+    },
+  );
+}

--- a/packages/oidc_core/test/endpoints/provider_metadata_test.dart
+++ b/packages/oidc_core/test/endpoints/provider_metadata_test.dart
@@ -216,6 +216,79 @@ void main() {
           expect(parsed.src['registration_endpoint'], malformed);
         });
       });
+
+      group('typed logout capability flags', () {
+        Map<String, dynamic> validDiscovery([
+          Map<String, dynamic>? overrides,
+        ]) => {
+          'issuer': 'https://op.example.com',
+          'authorization_endpoint': 'https://op.example.com/authorize',
+          'token_endpoint': 'https://op.example.com/token',
+          'jwks_uri': 'https://op.example.com/jwks',
+          ...?overrides,
+        };
+
+        test('a JSON round-trip exposes all four flags when true', () {
+          final parsed = OidcProviderMetadata.fromJson(
+            validDiscovery({
+              'frontchannel_logout_supported': true,
+              'frontchannel_logout_session_supported': true,
+              'backchannel_logout_supported': true,
+              'backchannel_logout_session_supported': true,
+            }),
+          );
+
+          expect(parsed.frontchannelLogoutSupported, isTrue);
+          expect(parsed.frontchannelLogoutSessionSupported, isTrue);
+          expect(parsed.backchannelLogoutSupported, isTrue);
+          expect(parsed.backchannelLogoutSessionSupported, isTrue);
+
+          expect(parsed.frontchannelLogoutSupportedOrDefault, isTrue);
+          expect(parsed.frontchannelLogoutSessionSupportedOrDefault, isTrue);
+          expect(parsed.backchannelLogoutSupportedOrDefault, isTrue);
+          expect(parsed.backchannelLogoutSessionSupportedOrDefault, isTrue);
+        });
+
+        test('a JSON round-trip exposes all four flags when false', () {
+          final parsed = OidcProviderMetadata.fromJson(
+            validDiscovery({
+              'frontchannel_logout_supported': false,
+              'frontchannel_logout_session_supported': false,
+              'backchannel_logout_supported': false,
+              'backchannel_logout_session_supported': false,
+            }),
+          );
+
+          expect(parsed.frontchannelLogoutSupported, isFalse);
+          expect(parsed.frontchannelLogoutSessionSupported, isFalse);
+          expect(parsed.backchannelLogoutSupported, isFalse);
+          expect(parsed.backchannelLogoutSessionSupported, isFalse);
+        });
+
+        test(
+          'absent flags are null, and the ...OrDefault getters fall back to '
+          'the spec default of false',
+          () {
+            final parsed = OidcProviderMetadata.fromJson(validDiscovery());
+
+            expect(parsed.frontchannelLogoutSupported, isNull);
+            expect(parsed.frontchannelLogoutSessionSupported, isNull);
+            expect(parsed.backchannelLogoutSupported, isNull);
+            expect(parsed.backchannelLogoutSessionSupported, isNull);
+
+            expect(parsed.frontchannelLogoutSupportedOrDefault, isFalse);
+            expect(
+              parsed.frontchannelLogoutSessionSupportedOrDefault,
+              isFalse,
+            );
+            expect(parsed.backchannelLogoutSupportedOrDefault, isFalse);
+            expect(
+              parsed.backchannelLogoutSessionSupportedOrDefault,
+              isFalse,
+            );
+          },
+        );
+      });
     });
   });
 }

--- a/packages/oidc_core/test/logout_id_token_hint_test.dart
+++ b/packages/oidc_core/test/logout_id_token_hint_test.dart
@@ -1,0 +1,161 @@
+@TestOn('vm')
+library;
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+/// Minimal concrete manager that captures the [OidcEndSessionRequest] built
+/// by [OidcUserManagerBase.logout] instead of actually driving a platform
+/// end-session flow.
+class _TestManager extends OidcUserManagerBase {
+  _TestManager({
+    required super.discoveryDocument,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    super.httpClient,
+  });
+
+  void seed(OidcUser user) => userSubject.add(user);
+
+  OidcEndSessionRequest? capturedRequest;
+
+  @override
+  bool get isWeb => false;
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async {
+    capturedRequest = request;
+    return null;
+  }
+
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+String _signIdToken() {
+  final key = JsonWebKey.generate('RS256');
+  return (JsonWebSignatureBuilder()
+        ..jsonContent = {
+          'iss': 'https://op.example.com',
+          'sub': 'user-1',
+          'aud': 'client-1',
+          'exp':
+              clock
+                  .now()
+                  .add(const Duration(hours: 1))
+                  .millisecondsSinceEpoch ~/
+              1000,
+          'iat': clock.now().millisecondsSinceEpoch ~/ 1000,
+        }
+        ..addRecipient(key, algorithm: 'RS256'))
+      .build()
+      .toCompactSerialization();
+}
+
+Future<OidcUser> _user() => OidcUser.fromIdToken(
+  token: OidcToken(
+    creationTime: clock.now(),
+    idToken: _signIdToken(),
+    accessToken: 'access-token-1',
+    refreshToken: 'refresh-token-1',
+    tokenType: 'Bearer',
+  ),
+  strictVerification: false,
+);
+
+OidcProviderMetadata _metadata() => OidcProviderMetadata.fromJson({
+  'issuer': 'https://op.example.com',
+  'authorization_endpoint': 'https://op.example.com/authorize',
+  'token_endpoint': 'https://op.example.com/token',
+  'end_session_endpoint': 'https://op.example.com/end-session',
+});
+
+Future<_TestManager> _build({Uri? postLogoutRedirectUri}) async {
+  final client = MockClient((req) async => http.Response('{}', 404));
+  final manager = _TestManager(
+    discoveryDocument: _metadata(),
+    clientCredentials: const OidcClientAuthentication.none(
+      clientId: 'client-1',
+    ),
+    store: OidcMemoryStore(),
+    httpClient: client,
+    settings: OidcUserManagerSettings(
+      redirectUri: Uri.parse('com.example.app://cb'),
+      postLogoutRedirectUri: postLogoutRedirectUri,
+      strictJwtVerification: false,
+    ),
+  );
+  await manager.init();
+  manager.seed(await _user());
+  return manager;
+}
+
+void main() {
+  group('RP-initiated logout always sends id_token_hint', () {
+    test(
+      'id_token_hint is present even when there is NO '
+      'post_logout_redirect_uri',
+      () async {
+        final manager = await _build();
+        final idToken = manager.currentUser!.idToken;
+
+        await manager.logout();
+
+        expect(manager.capturedRequest, isNotNull);
+        expect(manager.capturedRequest!.postLogoutRedirectUri, isNull);
+        expect(
+          manager.capturedRequest!.idTokenHint,
+          idToken,
+          reason:
+              'id_token_hint must not be withheld just because no '
+              'post_logout_redirect_uri was requested',
+        );
+      },
+    );
+
+    test(
+      'id_token_hint is present when a post_logout_redirect_uri IS set',
+      () async {
+        final manager = await _build(
+          postLogoutRedirectUri: Uri.parse('com.example.app://logged-out'),
+        );
+        final idToken = manager.currentUser!.idToken;
+
+        await manager.logout();
+
+        expect(manager.capturedRequest, isNotNull);
+        expect(manager.capturedRequest!.postLogoutRedirectUri, isNotNull);
+        expect(manager.capturedRequest!.idTokenHint, idToken);
+      },
+    );
+  });
+}

--- a/packages/oidc_core/test/rfc9207_iss_test.dart
+++ b/packages/oidc_core/test/rfc9207_iss_test.dart
@@ -1,6 +1,7 @@
 @TestOn('vm')
 library;
 
+import 'package:http/testing.dart';
 import 'package:oidc_core/oidc_core.dart';
 import 'package:test/test.dart';
 
@@ -8,6 +9,95 @@ Uri _cb(Map<String, String> params) =>
     Uri.parse('https://app.example.com/cb').replace(queryParameters: params);
 
 final _issuer = Uri.parse('https://op.example.com');
+
+/// Minimal concrete manager for driving [OidcUserManagerBase.tryGetAuthResponse]
+/// (via [OidcUserManagerBase.loginAuthorizationCodeFlow]) in a VM test.
+///
+/// [getAuthorizationResponse] simulates a platform channel that returns an
+/// authorization ERROR response without doing any `iss` validation of its
+/// own — exactly like a native platform's raw callback parsing — so the test
+/// exercises the manager-level RFC 9207 defense in `tryGetAuthResponse`'s
+/// catch block, independent of [OidcEndpoints.parseAuthorizeResponse].
+class _TestManager extends OidcUserManagerBase {
+  _TestManager({
+    required super.discoveryDocument,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    required this.buildErrorResponse,
+    super.httpClient,
+  });
+
+  final OidcErrorResponse Function(String? state) buildErrorResponse;
+
+  @override
+  bool get isWeb => false;
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async {
+    throw OidcException.serverError(
+      errorResponse: buildErrorResponse(request.state),
+    );
+  }
+
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+OidcProviderMetadata _metadata({required bool issSupported}) =>
+    OidcProviderMetadata.fromJson({
+      'issuer': _issuer.toString(),
+      'authorization_endpoint': 'https://op.example.com/authorize',
+      'token_endpoint': 'https://op.example.com/token',
+      if (issSupported) 'authorization_response_iss_parameter_supported': true,
+    });
+
+Future<_TestManager> _buildManager({
+  required bool issSupported,
+  required OidcErrorResponse Function(String? state) buildErrorResponse,
+}) async {
+  final manager = _TestManager(
+    discoveryDocument: _metadata(issSupported: issSupported),
+    clientCredentials: const OidcClientAuthentication.none(
+      clientId: 'client-1',
+    ),
+    store: OidcMemoryStore(),
+    httpClient: MockClient(
+      (_) async => throw UnimplementedError('no HTTP calls expected'),
+    ),
+    settings: OidcUserManagerSettings(
+      redirectUri: Uri.parse('com.example.app://cb'),
+      strictJwtVerification: false,
+    ),
+    buildErrorResponse: buildErrorResponse,
+  );
+  await manager.init();
+  return manager;
+}
 
 void main() {
   group('RFC 9207 authorization-response iss validation', () {
@@ -98,4 +188,110 @@ void main() {
       },
     );
   });
+
+  group(
+    'manager-level: iss is validated on the authorization ERROR path '
+    '(tryGetAuthResponse catch block, independent of parseAuthorizeResponse)',
+    () {
+      test(
+        'require-when-advertised: an error response missing iss is rejected '
+        'as a mix-up, not surfaced as the original server error',
+        () async {
+          final manager = await _buildManager(
+            issSupported: true,
+            buildErrorResponse: (state) => OidcErrorResponse.fromJson({
+              'error': 'access_denied',
+              'state': ?state,
+            }),
+          );
+
+          await expectLater(
+            manager.loginAuthorizationCodeFlow(),
+            throwsA(
+              predicate(
+                (e) => e is OidcException && e.toString().contains('mix-up'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'present-but-mismatched iss on an error response is rejected as a '
+        'mix-up',
+        () async {
+          final manager = await _buildManager(
+            issSupported: true,
+            buildErrorResponse: (state) => OidcErrorResponse.fromJson({
+              'error': 'access_denied',
+              'iss': 'https://attacker.example',
+              'state': ?state,
+            }),
+          );
+
+          await expectLater(
+            manager.loginAuthorizationCodeFlow(),
+            throwsA(
+              predicate(
+                (e) => e is OidcException && e.toString().contains('mix-up'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'matching iss on an error response lets the original server error '
+        'through unchanged',
+        () async {
+          final manager = await _buildManager(
+            issSupported: true,
+            buildErrorResponse: (state) => OidcErrorResponse.fromJson({
+              'error': 'access_denied',
+              'iss': _issuer.toString(),
+              'state': ?state,
+            }),
+          );
+
+          await expectLater(
+            manager.loginAuthorizationCodeFlow(),
+            throwsA(
+              predicate(
+                (e) =>
+                    e is OidcException &&
+                    !e.toString().contains('mix-up') &&
+                    e.errorResponse?.error == 'access_denied',
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'lenient: when the AS does not advertise iss support, a missing iss '
+        'on an error response is not treated as a mix-up',
+        () async {
+          final manager = await _buildManager(
+            issSupported: false,
+            buildErrorResponse: (state) => OidcErrorResponse.fromJson({
+              'error': 'access_denied',
+              'state': ?state,
+            }),
+          );
+
+          await expectLater(
+            manager.loginAuthorizationCodeFlow(),
+            throwsA(
+              predicate(
+                (e) =>
+                    e is OidcException &&
+                    !e.toString().contains('mix-up') &&
+                    e.errorResponse?.error == 'access_denied',
+              ),
+            ),
+          );
+        },
+      );
+    },
+  );
 }

--- a/packages/oidc_core/test/userinfo_missing_sub_test.dart
+++ b/packages/oidc_core/test/userinfo_missing_sub_test.dart
@@ -1,0 +1,184 @@
+@TestOn('vm')
+library;
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+/// Minimal concrete manager for driving non-platform flows in a VM test.
+class _TestManager extends OidcUserManagerBase {
+  _TestManager({
+    required super.discoveryDocument,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    super.httpClient,
+  });
+
+  void seed(OidcUser user) => userSubject.add(user);
+
+  @override
+  bool get isWeb => false;
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+String _signIdToken() {
+  final key = JsonWebKey.generate('RS256');
+  return (JsonWebSignatureBuilder()
+        ..jsonContent = {
+          'iss': 'https://op.example.com',
+          'sub': 'user-1',
+          'aud': 'client-1',
+          'exp':
+              clock
+                  .now()
+                  .add(const Duration(hours: 1))
+                  .millisecondsSinceEpoch ~/
+              1000,
+          'iat': clock.now().millisecondsSinceEpoch ~/ 1000,
+        }
+        ..addRecipient(key, algorithm: 'RS256'))
+      .build()
+      .toCompactSerialization();
+}
+
+Future<OidcUser> _user() => OidcUser.fromIdToken(
+  token: OidcToken(
+    creationTime: clock.now(),
+    idToken: _signIdToken(),
+    accessToken: 'access-token-1',
+    refreshToken: 'refresh-token-1',
+    tokenType: 'Bearer',
+  ),
+  strictVerification: false,
+);
+
+OidcProviderMetadata _metadata() => OidcProviderMetadata.fromJson({
+  'issuer': 'https://op.example.com',
+  'authorization_endpoint': 'https://op.example.com/authorize',
+  'token_endpoint': 'https://op.example.com/token',
+  'userinfo_endpoint': 'https://op.example.com/userinfo',
+});
+
+Future<_TestManager> _build(http.Client client) async {
+  final manager = _TestManager(
+    discoveryDocument: _metadata(),
+    clientCredentials: const OidcClientAuthentication.none(
+      clientId: 'client-1',
+    ),
+    store: OidcMemoryStore(),
+    httpClient: client,
+    settings: OidcUserManagerSettings(
+      redirectUri: Uri.parse('com.example.app://cb'),
+      strictJwtVerification: false,
+    ),
+  );
+  await manager.init();
+  manager.seed(await _user());
+  return manager;
+}
+
+http.Response _tokenResponse() => http.Response(
+  '{"access_token":"new-access","token_type":"Bearer",'
+  '"expires_in":3600,"refresh_token":"refresh-token-2",'
+  '"id_token":"${_signIdToken()}"}',
+  200,
+  headers: const {'content-type': 'application/json'},
+);
+
+void main() {
+  group('UserInfo missing sub is rejected (OIDC Core §5.3.2)', () {
+    test(
+      'a UserInfo response without `sub` fails validation and the refresh '
+      'is rejected',
+      () async {
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            return _tokenResponse();
+          }
+          if (req.url.path.endsWith('/userinfo')) {
+            return http.Response(
+              '{"email":"user@example.com"}',
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        });
+        final manager = await _build(client);
+        final originalUser = manager.currentUser;
+        expect(originalUser, isNotNull);
+
+        final result = await manager.refreshToken();
+
+        expect(
+          result,
+          isNull,
+          reason:
+              '`sub` is REQUIRED in the UserInfo response (OIDC Core '
+              '§5.3.2); a response omitting it must be rejected',
+        );
+        expect(
+          manager.currentUser?.token.accessToken,
+          originalUser!.token.accessToken,
+          reason:
+              'a failed validation must not apply the new (unverified) '
+              'token/identity to the current user',
+        );
+      },
+    );
+
+    test('a UserInfo response WITH a matching sub is accepted', () async {
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/token')) {
+          return _tokenResponse();
+        }
+        if (req.url.path.endsWith('/userinfo')) {
+          return http.Response(
+            '{"sub":"user-1","email":"user@example.com"}',
+            200,
+            headers: const {'content-type': 'application/json'},
+          );
+        }
+        return http.Response('{}', 404);
+      });
+      final manager = await _build(client);
+
+      final result = await manager.refreshToken();
+
+      expect(result, isNotNull);
+      expect(manager.currentUser, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
Batch-4 of the audit tracked in #324 — six P1 items, one commit per fix, each with regression tests (+15 tests; oidc_core suite 375/375 green locally post-rebase).

| # | Fix | Spec |
|---|---|---|
| 10 | Percent-encode `client_secret_basic` credentials before base64 | RFC 6749 §2.3.1 |
| 11 | Client auth sent in exactly one location on refresh (was header **and** body) | RFC 6749 §2.3 |
| 12 | Reject UserInfo responses missing `sub` (was silently accepted) | OIDC Core §5.3.2 |
| 13 | Always send `id_token_hint` on RP-initiated logout (was gated on `post_logout_redirect_uri`) | OIDC RP-Initiated Logout |
| 14 | Typed logout capability flags on provider metadata (incl. missing `frontchannel_logout_session_supported` constant) | OIDC Front/Back-Channel Logout |
| 19 | Validate RFC 9207 `iss` on authorization **error** responses (native/platform-channel path) | RFC 9207 |

Remaining open P1s from #324 after this: #9 (strict-verification opt-out removal — breaking-change decision), #15 (web token encryption at rest — design work), #20–#24 (feature-scale: EdDSA, mTLS, dpop_jkt, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoZeDcHumT38zpaTic62Rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional logout capability fields in provider discovery responses.
  * Logout requests now always include the current ID token hint.

* **Bug Fixes**
  * Improved protection against issuer mix-up issues on authorization error responses.
  * Fixed UserInfo validation so missing or mismatched subject claims are rejected.
  * Updated client authentication encoding for special characters in basic auth credentials.
  * Refined token refresh requests to use header-based client authentication consistently.

* **Tests**
  * Added coverage for logout metadata, logout behavior, issuer validation, refresh authentication, and UserInfo subject handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->