### PR TITLE
fix(oidc_core): batch-5 advisories (single-location client auth, sub-mismatch test)

### DIFF
--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -1802,6 +1802,11 @@ abstract class OidcUserManagerBase {
         headers: {...?settings.extraTokenHeaders, ...?headers},
         client: httpClient,
         options: settings.options,
+        // clientSecret is intentionally NOT passed here: `credentials`
+        // above is the single source of client authentication (RFC 6749
+        // §2.3). Also setting it on the request would duplicate it into
+        // the body even when `credentials` already authenticates via the
+        // Basic header (see OidcEndpoints.token).
         request: OidcTokenRequest.tokenExchange(
           subjectToken: actualSubjectToken,
           subjectTokenType: subjectTokenType,
@@ -1812,7 +1817,6 @@ abstract class OidcUserManagerBase {
           resource: resource ?? settings.resource,
           scope: scope,
           clientId: clientCredentials.clientId,
-          clientSecret: clientCredentials.clientSecret,
           extra: extra,
         ),
       ),
@@ -1855,11 +1859,15 @@ abstract class OidcUserManagerBase {
       credentials: clientCredentials,
       client: httpClient,
       headers: {...?settings.extraTokenHeaders, ...?headers},
+      // clientSecret is intentionally NOT passed here: `credentials`
+      // above is the single source of client authentication (RFC 6749
+      // §2.3). Also setting it on the request would duplicate it into
+      // the body even when `credentials` already authenticates via the
+      // Basic header (see OidcEndpoints.token).
       request: OidcIntrospectionRequest(
         token: actualToken,
         tokenTypeHint: tokenTypeHint,
         clientId: clientCredentials.clientId,
-        clientSecret: clientCredentials.clientSecret,
         extra: extra,
       ),
     );

--- a/packages/oidc_core/test/dual_client_auth_refresh_test.dart
+++ b/packages/oidc_core/test/dual_client_auth_refresh_test.dart
@@ -23,6 +23,10 @@ class _TestManager extends OidcUserManagerBase {
   /// Test hook to drive the protected auto-refresh-on-expiry path.
   Future<void> expire(OidcToken token) => handleTokenExpiring(token);
 
+  /// Test hook to drive the protected RFC 8693 token exchange path.
+  Future<OidcTokenResponse> exchange({String? subjectToken}) =>
+      exchangeToken(subjectToken: subjectToken);
+
   @override
   bool get isWeb => false;
   @override
@@ -91,6 +95,7 @@ OidcProviderMetadata _metadata() => OidcProviderMetadata.fromJson({
   'issuer': 'https://op.example.com',
   'authorization_endpoint': 'https://op.example.com/authorize',
   'token_endpoint': 'https://op.example.com/token',
+  'introspection_endpoint': 'https://op.example.com/introspect',
 });
 
 Future<_TestManager> _build(http.Client client) async {
@@ -192,6 +197,83 @@ void main() {
           final req = tokenCalls.first;
           expect(req.headers['Authorization'], startsWith('Basic '));
           expect(_qp(req).containsKey('client_secret'), isFalse);
+        },
+      );
+
+      test(
+        'exchangeToken(): Basic header present, no client_secret in body',
+        () async {
+          final tokenCalls = <http.Request>[];
+          final client = MockClient((req) async {
+            if (req.url.path.endsWith('/token')) {
+              tokenCalls.add(req);
+              return http.Response(
+                '{"access_token":"exchanged-access","token_type":"Bearer",'
+                '"expires_in":3600}',
+                200,
+                headers: const {'content-type': 'application/json'},
+              );
+            }
+            return http.Response('{}', 404);
+          });
+          final manager = await _build(client);
+
+          final result = await manager.exchange(
+            subjectToken: 'access-token-1',
+          );
+
+          expect(tokenCalls, isNotEmpty);
+          final req = tokenCalls.first;
+          expect(
+            req.headers['Authorization'],
+            startsWith('Basic '),
+            reason: 'client_secret_basic must authenticate via the header',
+          );
+          expect(
+            _qp(req).containsKey('client_secret'),
+            isFalse,
+            reason:
+                'the secret must not ALSO be duplicated into the request '
+                'body when a Basic header is already present',
+          );
+          expect(result.accessToken, 'exchanged-access');
+        },
+      );
+
+      test(
+        'introspectToken(): Basic header present, no client_secret in body',
+        () async {
+          final introspectCalls = <http.Request>[];
+          final client = MockClient((req) async {
+            if (req.url.path.endsWith('/introspect')) {
+              introspectCalls.add(req);
+              return http.Response(
+                '{"active":true}',
+                200,
+                headers: const {'content-type': 'application/json'},
+              );
+            }
+            return http.Response('{}', 404);
+          });
+          final manager = await _build(client);
+
+          final result = await manager.introspectToken();
+
+          expect(introspectCalls, isNotEmpty);
+          final req = introspectCalls.first;
+          expect(
+            req.headers['Authorization'],
+            startsWith('Basic '),
+            reason: 'client_secret_basic must authenticate via the header',
+          );
+          expect(
+            _qp(req).containsKey('client_secret'),
+            isFalse,
+            reason:
+                'the secret must not ALSO be duplicated into the request '
+                'body when a Basic header is already present',
+          );
+          expect(result.active, isTrue);
         },
       );
     },

--- a/packages/oidc_core/test/rfc9207_iss_test.dart
+++ b/packages/oidc_core/test/rfc9207_iss_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 Uri _cb(Map<String, String> params) =>
     Uri.parse('https://app.example.com/cb').replace(queryParameters: params);
 
-final _issuer = Uri.parse('https://op.example.com');
+final Uri _issuer = Uri.parse('https://op.example.com');
 
 /// Minimal concrete manager for driving [OidcUserManagerBase.tryGetAuthResponse]
 /// (via [OidcUserManagerBase.loginAuthorizationCodeFlow]) in a VM test.

--- a/packages/oidc_core/test/userinfo_missing_sub_test.dart
+++ b/packages/oidc_core/test/userinfo_missing_sub_test.dart
@@ -159,6 +159,47 @@ void main() {
       },
     );
 
+    test(
+      'a UserInfo response with a PRESENT but DIFFERENT sub fails '
+      'validation and the refresh is rejected',
+      () async {
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            return _tokenResponse();
+          }
+          if (req.url.path.endsWith('/userinfo')) {
+            return http.Response(
+              '{"sub":"someone-else","email":"user@example.com"}',
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        });
+        final manager = await _build(client);
+        final originalUser = manager.currentUser;
+        expect(originalUser, isNotNull);
+
+        final result = await manager.refreshToken();
+
+        expect(
+          result,
+          isNull,
+          reason:
+              'a UserInfo `sub` that does not match the authenticated '
+              'subject (OIDC Core §5.3.2 comparison) must be rejected, not '
+              'silently accepted',
+        );
+        expect(
+          manager.currentUser?.token.accessToken,
+          originalUser!.token.accessToken,
+          reason:
+              'a failed validation must not apply the new (unverified) '
+              'token/identity to the current user',
+        );
+      },
+    );
+
     test('a UserInfo response WITH a matching sub is accepted', () async {
       final client = MockClient((req) async {
         if (req.url.path.endsWith('/token')) {


### PR DESCRIPTION
## Description

Implements the batch-4 reviewer's advisory follow-ups from #324 in `packages/oidc_core`.

1. **Dual client auth on `exchangeToken` (RFC 8693) and `introspectToken` (RFC 7662)**: both call sites passed `clientSecret` into the request body AND into the `credentials` object used to build the Basic auth header, so `OidcEndpoints.token`/`OidcEndpoints.introspect` (which unconditionally spread `request.toMap()` into the body) sent the secret twice for `client_secret_basic` clients. This is the same class of bug batch-4 fixed on the two refresh paths (f6bf79a); `credentials` is now the single source of client authentication (RFC 6749 §2.3) for these two call sites too. `dual_client_auth_refresh_test.dart` is extended to cover both.
2. **Explicit present-but-mismatched `sub` regression test**: batch-4's `userinfo_missing_sub_test.dart` covered a UserInfo response omitting `sub`; adds the complementary case where `sub` is PRESENT but does not match the authenticated subject (OIDC Core §5.3.2 comparison path).
3. **Lint**: fixes a trivial `dart analyze` info-lint on `rfc9207_iss_test.dart:11` (`specify_nonobvious_property_types`), folded into commit 2.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Build configuration change (test-only additions)

## Test plan

- [x] `dart analyze packages/oidc_core` — 0 errors, 16 pre-existing info-level issues (no new issues; net -1 vs. baseline from the lint fix)
- [x] `dart test` from `packages/oidc_core` — 378 passed, 0 failed (baseline 375 + 3 new tests)

**Do not merge before independent review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoZeDcHumT38zpaTic62Rb