### PR TITLE
feat(oidc_core)!: always-strict ID-token verification (JWKS rotation-safe) (#324 item 9)

### DIFF
--- a/docs/oidc-usage.md
+++ b/docs/oidc-usage.md
@@ -118,7 +118,24 @@ settings to control the behavior of the instance.
     !!! Tip
         For detailed information about offline authentication, including security best practices, error handling, and implementation examples, see the [Offline Authentication Guide](oidc-offline-auth.md).
 
-- `bool strictJwtVerification = false`: whether JWTs are strictly verified.
+- ID-token (and signed UserInfo / signed discovery `signed_metadata`) signature
+  verification is **always strict** (fail-closed): a token/response whose
+  signature cannot be verified is rejected. There is no opt-out setting.
+
+    !!! Info "Key rotation"
+        A `kid` that isn't in the currently-cached JWKS (e.g. right after the
+        OP rotates its signing keys) triggers one rate-limited, cache-busting
+        JWKS refetch before failing, so a routine key rotation does not cause
+        spurious login failures.
+
+    !!! Warning "HS256 id_tokens (e.g. Auth0's default client signing algorithm)"
+        Some OPs (Auth0 in particular, for confidential clients by default)
+        sign id_tokens with `HS256`, a symmetric algorithm keyed by your
+        `client_secret` rather than a JWKS-published public key. Verifying
+        these requires passing `clientSecret` on your
+        `OidcClientAuthentication` — the manager registers it as the HS256
+        verification key during `init()`. Without a `clientSecret`, an
+        HS256-signed id_token cannot be verified and login will fail-closed.
 - `Uri redirectUri`: the redirect uri that was configured with the provider.
 - `Uri? postLogoutRedirectUri`: the post logout redirect uri that was configured with the provider.
 - `Uri? frontChannelLogoutUri`: the uri of the front channel logout flow. this Uri MUST be registered with the OP first. the OP will call this Uri when it wants to logout the user.

--- a/docs/oidc_core.md
+++ b/docs/oidc_core.md
@@ -111,15 +111,21 @@ A wrapper around `OidcToken` that requires the existence of `id_token` to unders
 to create a user, you should call `fromIdToken` which takes the following parameters:
 
 - `OidcToken token`: the source token, this MUST contain `idToken`.
-- `strictVerification`: if true, will throw an error if we fail to verify the signature of the JWT id token.
-!!! Warning
-    The current jose package we use is unmaintained, and has multiple problems, so setting `strictVerification: true` might throw random errors.
+- `keystore`: the store that contains information about the public json web keys. When provided, signature
+  verification is **always strict** (fail-closed) — an id_token whose signature cannot be verified throws;
+  there is no opt-out. When omitted, the id_token is parsed but left unverified.
 
-    you MUST test if it works before using it in production.
+    !!! Info "Key rotation"
+        A `kid` absent from the currently-loaded JWKS triggers one rate-limited, cache-busting JWKS refetch
+        before failing (OpenID Connect Core 1.0 §10.1.1), so a routine signing-key rotation at the OP does not
+        cause a spurious verification failure.
 
-    see this issue for more information: [oidc#9](https://github.com/Bdaya-Dev/oidc/issues/9).
-
-- `keystore`: the store that contains information about the public json web keys.
+    !!! Warning "HS256 id_tokens"
+        Some OPs (e.g. Auth0, for confidential clients by default) sign id_tokens with the symmetric `HS256`
+        algorithm, keyed by the client secret rather than a JWKS-published key. Verifying these requires an
+        `oct` key derived from the client secret to be present in `keystore` — `OidcUserManagerBase.init()`
+        does this automatically when `clientCredentials` carries a `clientSecret`. Calling `fromIdToken`
+        directly (bypassing the manager) must add that key itself.
 - `attributes`: extra attributes to put with the user for customization.
 - `userInfo`: the response from the `/userinfo` endpoint.
 

--- a/packages/oidc/example/integration_test/conformance/manager.dart
+++ b/packages/oidc/example/integration_test/conformance/manager.dart
@@ -22,7 +22,6 @@ OidcUserManager conformanceManager(
     redirectUri: redirectUri,
     postLogoutRedirectUri: postLogoutRedirectUri,
     frontChannelLogoutUri: frontChannelLogoutUri,
-    strictJwtVerification: true,
     options: const OidcPlatformSpecificOptions(
       // On headless CI emulators/simulators the system auth browser opens but no
       // user can interact, so the redirect never arrives and

--- a/packages/oidc/example/integration_test/shared_offline.dart
+++ b/packages/oidc/example/integration_test/shared_offline.dart
@@ -226,9 +226,7 @@ OidcTokenResponse _buildTokenResponse(String label) {
   });
 }
 
-String _createSignedIdToken({
-  Duration validity = const Duration(minutes: 5),
-}) {
+String _createSignedIdToken({Duration validity = const Duration(minutes: 5)}) {
   final now = clock.now();
   final builder = JsonWebSignatureBuilder()
     ..jsonContent = {

--- a/packages/oidc/example/integration_test/shared_offline.dart
+++ b/packages/oidc/example/integration_test/shared_offline.dart
@@ -12,7 +12,6 @@
 // patrol_test/app_test.dart` only.
 
 import 'dart:collection';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:clock/clock.dart';
@@ -29,6 +28,13 @@ typedef PumpFrame = Future<void> Function();
 const _issuer = 'https://test.example.com';
 const _audience = 'test-client';
 const _testSubject = 'user-123';
+
+/// Signature verification is always-strict now; every id_token this file
+/// mints is signed by this key, registered directly on the test manager's
+/// keyStore (see [createManager]) so it verifies without needing a real
+/// (mocked) `jwks_uri` fetch — these tests exercise OFFLINE / refresh
+/// behaviour, not JWKS resolution.
+final _signingKey = JsonWebKey.generate('RS256');
 
 /// Asserts the manager enters offline mode after a refresh network failure and
 /// keeps serving the cached token.
@@ -153,7 +159,7 @@ OfflineTestUserManager createManager({
     'jwks_uri': '$_issuer/jwks',
     'response_types_supported': ['code'],
     'subject_types_supported': ['public'],
-    'id_token_signing_alg_values_supported': ['none'],
+    'id_token_signing_alg_values_supported': ['RS256'],
     'token_endpoint_auth_methods_supported': ['none'],
     'grant_types_supported': ['authorization_code', 'refresh_token'],
   });
@@ -161,13 +167,6 @@ OfflineTestUserManager createManager({
   final settings = OidcUserManagerSettings(
     redirectUri: Uri.parse('com.example.test:/callback'),
     scope: const ['openid', 'offline_access'],
-    // These tests seed UNSIGNED (alg:none) id_tokens via the fake OP
-    // (id_token_signing_alg_values_supported: ['none']) to exercise OFFLINE /
-    // refresh behaviour — not signature verification. Since the library now
-    // correctly rejects alg:none (and strictJwtVerification defaults to true),
-    // opt this behaviour-test manager out so the seeded token is accepted as
-    // unverified. Production code must NOT set this.
-    strictJwtVerification: false,
     supportOfflineAuth: true,
     offlineRepeatFailureWarningThreshold: warningThreshold,
     userInfoSettings: const OidcUserInfoSettings(sendUserInfoRequest: false),
@@ -207,6 +206,7 @@ OfflineTestUserManager createManager({
     clientCredentials: const OidcClientAuthentication.none(clientId: _audience),
     store: OidcMemoryStore(),
     settings: settings,
+    keyStore: JsonWebKeyStore()..addKey(_signingKey),
   );
 }
 
@@ -216,7 +216,7 @@ OidcToken _buildToken(String label) {
 }
 
 OidcTokenResponse _buildTokenResponse(String label) {
-  final idToken = _createUnsignedIdToken(validity: const Duration(minutes: 10));
+  final idToken = _createSignedIdToken(validity: const Duration(minutes: 10));
   return OidcTokenResponse.fromJson({
     'access_token': 'access-$label',
     'refresh_token': 'refresh-$label',
@@ -226,25 +226,20 @@ OidcTokenResponse _buildTokenResponse(String label) {
   });
 }
 
-String _createUnsignedIdToken({
+String _createSignedIdToken({
   Duration validity = const Duration(minutes: 5),
 }) {
-  final header = base64UrlEncode(
-    utf8.encode(jsonEncode({'alg': 'none', 'typ': 'JWT'})),
-  ).replaceAll('=', '');
   final now = clock.now();
-  final payload = base64UrlEncode(
-    utf8.encode(
-      jsonEncode({
-        'iss': _issuer,
-        'sub': _testSubject,
-        'aud': _audience,
-        'exp': (now.add(validity).millisecondsSinceEpoch ~/ 1000),
-        'iat': (now.millisecondsSinceEpoch ~/ 1000),
-      }),
-    ),
-  ).replaceAll('=', '');
-  return '$header.$payload.';
+  final builder = JsonWebSignatureBuilder()
+    ..jsonContent = {
+      'iss': _issuer,
+      'sub': _testSubject,
+      'aud': _audience,
+      'exp': (now.add(validity).millisecondsSinceEpoch ~/ 1000),
+      'iat': (now.millisecondsSinceEpoch ~/ 1000),
+    }
+    ..addRecipient(_signingKey, algorithm: 'RS256');
+  return builder.build().toCompactSerialization();
 }
 
 class OfflineTestUserManager extends OidcUserManager {

--- a/packages/oidc/example/lib/app_state.dart
+++ b/packages/oidc/example/lib/app_state.dart
@@ -164,7 +164,6 @@ final duendeManager = OidcUserManager.lazy(
     refreshBefore: (token) {
       return const Duration(seconds: 5);
     },
-    strictJwtVerification: true,
     // set to true to enable offline auth
     supportOfflineAuth: true,
     // Scopes supported by the provider and needed by the client.
@@ -237,7 +236,6 @@ final duendeManager = OidcUserManager.lazy(
 //   ),
 //   store: OidcDefaultStore(),
 //   settings: OidcUserManagerSettings(
-//     strictJwtVerification: true,
 //     scope: ['profile', 'email'],
 //     redirectUri: Uri.parse('http://localhost:22433/redirect.html'),
 //     frontChannelLogoutUri: Uri.parse(

--- a/packages/oidc/example/lib/pages/add_manager_dialog.dart
+++ b/packages/oidc/example/lib/pages/add_manager_dialog.dart
@@ -21,7 +21,6 @@ class _AddManagerDialogState extends State<AddManagerDialog> {
   final _scopeController = TextEditingController(text: 'openid profile email');
 
   OidcClientAuthenticationType _authType = OidcClientAuthenticationType.none;
-  bool _strictJwtVerification = true;
   bool _supportOfflineAuth = false;
 
   @override
@@ -190,16 +189,6 @@ class _AddManagerDialogState extends State<AddManagerDialog> {
                 ),
                 const SizedBox(height: 16),
                 SwitchListTile(
-                  title: const Text('Strict JWT Verification'),
-                  subtitle: const Text('Enable strict JWT token verification'),
-                  value: _strictJwtVerification,
-                  onChanged: (value) {
-                    setState(() {
-                      _strictJwtVerification = value;
-                    });
-                  },
-                ),
-                SwitchListTile(
                   title: const Text('Support Offline Auth'),
                   subtitle: const Text('Allow authentication when offline'),
                   value: _supportOfflineAuth,
@@ -263,7 +252,6 @@ class _AddManagerDialogState extends State<AddManagerDialog> {
         httpClient: app_state.client,
         settings: OidcUserManagerSettings(
           scope: scopes,
-          strictJwtVerification: _strictJwtVerification,
           supportOfflineAuth: _supportOfflineAuth,
           redirectUri: Uri.parse(_redirectUriController.text),
           postLogoutRedirectUri: _postLogoutRedirectUriController.text.isEmpty

--- a/packages/oidc/test/mock_client.dart
+++ b/packages/oidc/test/mock_client.dart
@@ -35,6 +35,7 @@ Map<String, dynamic> defaultIdTokenClaimsJson({
   "sub": "248289761001",
   "nonce": "n-0S6_WzA2Mj",
 };
+
 /// The (well-known, RFC 7515/7520 test-vector) HS256 key every mock id_token
 /// in this file is signed with. Signature verification is always-strict now,
 /// so tests that build an [OidcUserManager] must register this key on its

--- a/packages/oidc/test/mock_client.dart
+++ b/packages/oidc/test/mock_client.dart
@@ -35,19 +35,22 @@ Map<String, dynamic> defaultIdTokenClaimsJson({
   "sub": "248289761001",
   "nonce": "n-0S6_WzA2Mj",
 };
+/// The (well-known, RFC 7515/7520 test-vector) HS256 key every mock id_token
+/// in this file is signed with. Signature verification is always-strict now,
+/// so tests that build an [OidcUserManager] must register this key on its
+/// `keyStore` for the mock id_tokens to verify.
+final JsonWebKey mockSigningKey = JsonWebKey.fromJson({
+  "kty": "oct",
+  "k":
+      "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow",
+})!;
+
 String createIdToken({required Map<String, dynamic> claimsJson}) {
   final claims = JsonWebTokenClaims.fromJson(claimsJson);
 
   final builder = JsonWebSignatureBuilder()
     ..jsonContent = claims.toJson()
-    ..addRecipient(
-      JsonWebKey.fromJson({
-        "kty": "oct",
-        "k":
-            "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow",
-      }),
-      algorithm: "HS256",
-    );
+    ..addRecipient(mockSigningKey, algorithm: "HS256");
   final res = builder.build();
   return res.toCompactSerialization();
 }

--- a/packages/oidc/test/oidc_test.dart
+++ b/packages/oidc/test/oidc_test.dart
@@ -25,11 +25,11 @@ void main() {
   );
   final settings = OidcUserManagerSettings(
     redirectUri: Uri.parse('http://example.com/redirect.html'),
-    // The mock id_tokens are HS256-signed with a symmetric key not served by
-    // the (Google) jwks_uri, so they can't be signature-verified here. These
-    // tests exercise manager/caching/refresh logic, not signature validation.
-    strictJwtVerification: false,
   );
+  // Signature verification is always-strict now; every manager below is
+  // constructed with a keyStore holding the mock id_tokens' HS256 signing
+  // key (see mock_client.dart's `mockSigningKey`) so they verify.
+  final managerKeyStore = JsonWebKeyStore()..addKey(mockSigningKey);
 
   setUp(() {
     oidcPlatform = MockOidcPlatform();
@@ -60,6 +60,7 @@ void main() {
           store: store,
           settings: settings,
           httpClient: client,
+          keyStore: managerKeyStore,
           id: 'test-manager',
         );
         expect(manager.didInit, isFalse);
@@ -77,6 +78,7 @@ void main() {
           store: store,
           settings: settings,
           httpClient: client,
+          keyStore: managerKeyStore,
         );
         expect(manager.didInit, isFalse);
         await manager.init();
@@ -126,6 +128,7 @@ void main() {
               store: store,
               settings: settings,
               httpClient: client,
+              keyStore: managerKeyStore,
             );
           });
 
@@ -212,6 +215,7 @@ void main() {
                 store: store,
                 settings: settings,
                 httpClient: client,
+                keyStore: managerKeyStore,
               );
 
               final nowMock = tokenCreatedAt.add(const Duration(hours: 2));
@@ -279,6 +283,7 @@ void main() {
                 store: store,
                 settings: settings,
                 httpClient: client,
+                keyStore: managerKeyStore,
               );
 
               final refreshedAt = tokenCreatedAt.add(const Duration(hours: 2));
@@ -301,6 +306,7 @@ void main() {
                 store: store,
                 settings: settings,
                 httpClient: client,
+                keyStore: managerKeyStore,
               );
 
               final reloadAt = refreshedAt.add(const Duration(minutes: 30));
@@ -373,7 +379,6 @@ void main() {
               final eventSettings = OidcUserManagerSettings(
                 redirectUri: settings.redirectUri,
                 refreshBefore: (_) => const Duration(milliseconds: 700),
-                strictJwtVerification: false,
               );
               manager = OidcUserManager(
                 id: managerId,
@@ -382,6 +387,7 @@ void main() {
                 store: store,
                 settings: eventSettings,
                 httpClient: client,
+                keyStore: managerKeyStore,
               );
 
               await manager.init();

--- a/packages/oidc_core/lib/src/endpoints/facade.dart
+++ b/packages/oidc_core/lib/src/endpoints/facade.dart
@@ -896,7 +896,6 @@ class OidcEndpoints {
     bool validateSignedResponseClaims = true,
     bool requireSignedResponseIssAud = false,
     Duration claimsExpiryTolerance = const Duration(minutes: 1),
-    bool strictJwtVerification = true,
   }) async {
     if (tokenLocation == OidcUserInfoAccessTokenLocations.formParameter &&
         requestMethod != OidcConstants_RequestMethod.post) {
@@ -984,31 +983,26 @@ class OidcEndpoints {
       } else {
         // No keyStore => we cannot verify a signed UserInfo response.
         // OIDC Core 5.3.2: a signed UserInfo Response MUST have its signature
-        // validated. Refuse to silently trust it unless the caller has
-        // explicitly opted out (strictJwtVerification == false), mirroring
-        // id_token handling.
-        if (strictJwtVerification) {
-          throw const OidcException(
-            'UserInfo returned a signed (application/jwt) response but no '
-            'keyStore was provided to verify its signature; refusing to trust '
-            'an unverified UserInfo JWT (strictJwtVerification=true). Provide a '
-            'keyStore, or set strictJwtVerification=false to opt out (insecure).',
-          );
-        }
-        jwt = JsonWebToken.unverified(resp.body);
+        // validated. Always refuse to silently trust it — mirroring id_token
+        // handling, there is no unverified-fallback opt-out.
+        throw const OidcException(
+          'UserInfo returned a signed (application/jwt) response but no '
+          'keyStore was provided to verify its signature; refusing to trust '
+          'an unverified UserInfo JWT. Provide a keyStore.',
+        );
       }
       ret = OidcUserInfoResponse.fromJson(jwt.claims.toJson());
       // OIDC Core 5.3.2/5.3.4: when the UserInfo response is a signed JWT that
-      // we VERIFIED against the keyStore, validate its iss/aud/exp. Gated on
-      // `keyStore != null` so the unverified path above never gains false
-      // assurance, and only on the signed-JWT branch (plain JSON is exempt).
+      // we VERIFIED against the keyStore, validate its iss/aud/exp. Reaching
+      // here always means `keyStore != null` — the `else` branch above always
+      // throws, so the unverified path never gains false assurance.
       //
       // We deliberately do NOT call `jwt.claims.validate(...)`: that force-
       // unwraps `exp` (crashing when a UserInfo JWT omits it, which is common)
       // and treats an absent `iss` as a mismatch. UserInfo `iss`/`aud`/`exp`
       // are validate-when-present (SHOULD), so use custom logic on the parsed
       // model fields.
-      if (keyStore != null && validateSignedResponseClaims) {
+      if (validateSignedResponseClaims) {
         final iss = ret.iss;
         if (iss != null) {
           // Simple-string compare (consistent with the repo's RFC 9207 `iss`

--- a/packages/oidc_core/lib/src/managers/jwks_store_loader.dart
+++ b/packages/oidc_core/lib/src/managers/jwks_store_loader.dart
@@ -15,8 +15,7 @@ import 'package:oidc_core/oidc_core.dart';
 Uri cacheBustJwksUri(Uri uri) => uri.replace(
   queryParameters: {
     ...uri.queryParameters,
-    '_oidc_jwks_refresh': clock.now().toUtc().microsecondsSinceEpoch
-        .toString(),
+    '_oidc_jwks_refresh': clock.now().toUtc().microsecondsSinceEpoch.toString(),
   },
 );
 

--- a/packages/oidc_core/lib/src/managers/jwks_store_loader.dart
+++ b/packages/oidc_core/lib/src/managers/jwks_store_loader.dart
@@ -2,10 +2,29 @@ import 'package:clock/clock.dart';
 import 'package:jose_plus/jose.dart';
 import 'package:oidc_core/oidc_core.dart';
 
+/// Appends a unique query parameter to [uri] so a request through it defeats
+/// any HTTP/CDN-level response caching sitting in front of the JWKS
+/// endpoint.
+///
+/// Used when forcing a live JWKS refetch after an id_token signature
+/// verification failure whose `kid` could not be resolved against the
+/// just-loaded key set — a possible in-flight key rotation (OpenID Connect
+/// Core 1.0 §10.1.1 Rotation of Asymmetric Signing Keys). A plain repeated GET
+/// to the same URL could otherwise be served from an edge cache that hasn't
+/// picked up the rotated key yet.
+Uri cacheBustJwksUri(Uri uri) => uri.replace(
+  queryParameters: {
+    ...uri.queryParameters,
+    '_oidc_jwks_refresh': clock.now().toUtc().microsecondsSinceEpoch
+        .toString(),
+  },
+);
+
 class OidcJwksStoreLoader extends DefaultJsonWebKeySetLoader {
   OidcJwksStoreLoader({
     required this.store,
     this.staleCacheMaxAge = const Duration(days: 1),
+    this.forceFresh = false,
     super.cacheExpiry,
     super.httpClient,
   });
@@ -28,6 +47,16 @@ class OidcJwksStoreLoader extends DefaultJsonWebKeySetLoader {
   /// unbounded behavior.
   final Duration staleCacheMaxAge;
 
+  /// When `true`, the live fetch is issued against a [cacheBustJwksUri]
+  /// variant of the requested uri (bypassing any HTTP/CDN cache in front of
+  /// `jwks_uri`), while the persisted offline-fallback copy is still
+  /// read/written under the canonical (non-busted) uri key.
+  ///
+  /// Set this for the ONE retry attempt after a signature verification
+  /// failure whose id_token `kid` was absent from the just-loaded JWKS (see
+  /// `OidcUser.fromIdToken`) — never for routine reads.
+  final bool forceFresh;
+
   /// Sidecar key suffix that holds the epoch-millis fetched-at timestamp next
   /// to a persisted JWKS value. The suffix cannot collide with a real
   /// `jwks_uri` / discovery-URL key.
@@ -38,9 +67,13 @@ class OidcJwksStoreLoader extends DefaultJsonWebKeySetLoader {
     final key = uri.toString();
     final sidecarKey = '$key$_fetchedAtSuffix';
     try {
-      final result = await super.readAsString(uri);
+      final result = await super.readAsString(
+        forceFresh ? cacheBustJwksUri(uri) : uri,
+      );
       // Persist the JWKS alongside a fetched-at timestamp in one write so the
-      // value and its age are co-stored.
+      // value and its age are co-stored. Always keyed by the CANONICAL uri
+      // (not the cache-busted one), so a forced refetch refreshes the same
+      // offline-fallback entry a normal read would use.
       await store.setMany(
         OidcStoreNamespace.discoveryDocument,
         values: {

--- a/packages/oidc_core/lib/src/managers/jwks_store_loader.dart
+++ b/packages/oidc_core/lib/src/managers/jwks_store_loader.dart
@@ -116,3 +116,23 @@ class OidcJwksStoreLoader extends DefaultJsonWebKeySetLoader {
     }
   }
 }
+
+/// A one-shot [JsonWebKeySetLoader] used to force a live, cache-busted JWKS
+/// refetch when no [OidcStore] is available to persist an offline fallback
+/// copy — the `cacheStore`-less `OidcUser.fromIdToken` path.
+///
+/// A fresh instance's own (per-instance) HTTP response cache starts empty, so
+/// pairing it with [cacheBustJwksUri] guarantees the request bypasses BOTH
+/// this loader's cache and any HTTP/CDN cache in front of the `jwks_uri` —
+/// unlike the long-lived, process-wide default loader
+/// ([JsonWebKeySetLoader.current]'s fallback when no loader is zoned in),
+/// whose in-memory TTL cache (default 5 minutes, longer when the OP sends a
+/// generous `Cache-Control`/`Expires`) can otherwise mask a just-rotated
+/// signing key for its full cache lifetime.
+class OidcForceFreshJwksLoader extends DefaultJsonWebKeySetLoader {
+  OidcForceFreshJwksLoader({super.httpClient});
+
+  @override
+  Future<String> readAsString(Uri uri) =>
+      super.readAsString(cacheBustJwksUri(uri));
+}

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -1229,11 +1229,11 @@ abstract class OidcUserManagerBase {
         allowedAlgorithms: resolveAllowedIdTokenAlgorithms(metadata),
         keystore: keyStore,
         attributes: attributes,
-        strictVerification: settings.strictJwtVerification,
         userInfo: userInfo,
         idTokenOverride: idTokenOverride,
         cacheStore: store,
         jwksCacheMaxAge: settings.jwksCacheMaxAge,
+        httpClient: httpClient,
       );
     } else {
       final reusesExistingIdToken =
@@ -1241,10 +1241,10 @@ abstract class OidcUserManagerBase {
       newUser = await currentUser.replaceToken(
         token,
         idTokenOverride: idTokenOverride,
-        strictVerification: settings.strictJwtVerification,
         cacheStore: store,
         allowExpiredIdToken: reusesExistingIdToken,
         jwksCacheMaxAge: settings.jwksCacheMaxAge,
+        httpClient: httpClient,
       );
       // OpenID Connect Core §12.2: a freshly-issued id_token MUST keep the same
       // `sub` (and `iss`) as the prior one — refuse a possible account swap on
@@ -1896,9 +1896,9 @@ abstract class OidcUserManagerBase {
       // the sole protection — honour an explicit `allowedIdTokenAlgorithms` pin.
       allowedAlgorithms: resolveAllowedIdTokenAlgorithms(metadata),
       keystore: keyStore,
-      strictVerification: settings.strictJwtVerification,
       cacheStore: store,
       jwksCacheMaxAge: settings.jwksCacheMaxAge,
+      httpClient: httpClient,
     );
     final idTokenNonce =
         frontChannelUser.parsedIdToken.claims[OidcConstants_AuthParameters
@@ -2142,12 +2142,6 @@ abstract class OidcUserManagerBase {
             requireSignedResponseIssAud:
                 settings.userInfoSettings.requireSignedResponseIssAud,
             claimsExpiryTolerance: settings.expiryTolerance,
-            // A signed (application/jwt) UserInfo response that cannot be
-            // verified is rejected when strict. The managed flow always passes
-            // a non-null keyStore (see [keyStore]), so this path is unreachable
-            // here; threading keeps the contract explicit and consistent with
-            // id_token handling.
-            strictJwtVerification: settings.strictJwtVerification,
             // Present a DPoP-bound access token with the DPoP scheme + an
             // `ath`-bound proof (RFC 9449 §7.1).
             dpopManager: actualUser.token.tokenType?.toUpperCase() == 'DPOP'
@@ -2387,25 +2381,16 @@ abstract class OidcUserManagerBase {
               jwksCacheMaxAge: settings.jwksCacheMaxAge,
             );
       } on OidcException catch (e, st) {
-        // Mirror the _validateDiscoveryIssuer strict/warn idiom.
-        if (settings.strictJwtVerification) {
-          logAndThrow(
-            'Failed to verify the discovery `signed_metadata` JWT '
-            '(RFC 8414 §2.1); refusing to use the document '
-            '(strictJwtVerification=true).',
-            error: e,
-            stackTrace: st,
-            extra: {
-              OidcConstants_Exception.discoveryDocumentUri: uri,
-            },
-          );
-        }
-        logger.warning(
+        // Always fail-closed: refuse to use the document. There is no
+        // unverified-fallback opt-out (mirrors id_token handling).
+        logAndThrow(
           'Failed to verify the discovery `signed_metadata` JWT '
-          '(RFC 8414 §2.1); strictJwtVerification is disabled so the plain '
-          '(unmerged) document is being used anyway.',
-          e,
-          st,
+          '(RFC 8414 §2.1); refusing to use the document.',
+          error: e,
+          stackTrace: st,
+          extra: {
+            OidcConstants_Exception.discoveryDocumentUri: uri,
+          },
         );
       }
     }

--- a/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
+++ b/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
@@ -73,7 +73,6 @@ class OidcUserManagerSettings {
     this.frontChannelRequestListeningOptions =
         const OidcFrontChannelRequestListeningOptions(),
     this.refreshBefore = defaultRefreshBefore,
-    this.strictJwtVerification = true,
     this.allowedIdTokenAlgorithms,
     this.strictIssuerValidation = false,
     this.verifySignedMetadata = false,
@@ -102,22 +101,6 @@ class OidcUserManagerSettings {
 
   /// Settings to control using the user_info endpoint.
   final OidcUserInfoSettings userInfoSettings;
-
-  /// Whether id_token signatures are strictly verified (fail-closed).
-  ///
-  /// When `true` (the default), an id_token whose signature cannot be verified
-  /// against the OP's JWKS is **rejected** (an exception is thrown). When
-  /// `false`, a verification failure is logged and the token is accepted
-  /// *unverified* — which means a forged or tampered id_token would be trusted.
-  ///
-  /// This ALSO governs signed UserInfo responses: when `true`, an
-  /// `application/jwt` UserInfo response that cannot be verified (no keyStore /
-  /// no usable keys) is **rejected**; when `false` it is parsed *unverified*.
-  ///
-  /// Defaults to `true` per OpenID Connect Core §3.1.3.7 / §5.3.2 and the
-  /// OAuth 2.0 Security BCP (RFC 9700). Only set this to `false` if you fully
-  /// understand the risk (e.g. a controlled test environment).
-  final bool strictJwtVerification;
 
   /// Optional explicit allowlist of JWS signing algorithms (canonical JWA
   /// names, e.g. `['RS256','ES256']`) that an id_token's `alg` header is
@@ -171,11 +154,10 @@ class OidcUserManagerSettings {
   /// the plain JSON is used as-is — preserving out-of-the-box Microsoft Entra /
   /// Azure AD B2C compatibility (those IdPs do not emit `signed_metadata`).
   ///
-  /// On a verification failure the existing [strictJwtVerification] knob decides
-  /// throw-vs-warn (strict = throw + don't persist; lenient = warn + fall back
-  /// to the plain document). Recommend `true` (with
-  /// [allowedSignedMetadataAlgorithms] pinned) for FAPI / high-assurance
-  /// deployments.
+  /// On a verification failure, the document is refused and NOT persisted
+  /// (fail-closed — there is no fall back to the unverified plain document).
+  /// Recommend `true` (with [allowedSignedMetadataAlgorithms] pinned) for
+  /// FAPI / high-assurance deployments.
   final bool verifySignedMetadata;
 
   /// Optional explicit allowlist of JWS algorithms permitted for the

--- a/packages/oidc_core/lib/src/models/user.dart
+++ b/packages/oidc_core/lib/src/models/user.dart
@@ -1,11 +1,8 @@
 import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
 import 'package:jose_plus/jose.dart';
-import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:oidc_core/oidc_core.dart';
-
-final _logger = Logger('Oidc.User');
 
 /// Minimum time between forced cache-busting JWKS refetches triggered by an
 /// id_token verification failure, per issuer. Prevents a forged/garbage `kid`
@@ -60,13 +57,19 @@ class OidcUser {
 
   /// Creates a OidcUser from an encoded id_token passed via [token].
   ///
-  /// You can verify the idToken by passing the [keystore] parameter.
+  /// You can verify the idToken by passing the [keystore] parameter. When
+  /// [keystore] is provided, verification is always strict (fail-closed) per
+  /// OpenID Connect Core §3.1.3.7 / §5.3.2 and the OAuth 2.0 Security BCP
+  /// (RFC 9700): an id_token whose signature cannot be verified throws,
+  /// there is no unverified-fallback opt-out. A `kid` absent from the
+  /// current JWKS view triggers one rate-limited, cache-busting refetch
+  /// before failing (key-rotation self-heal — OIDC Core §10.1.1). When
+  /// [keystore] is omitted, the id_token is parsed but left unverified.
   ///
   /// You can also pass optional [attributes] that will get stored
   /// with the user.
   static Future<OidcUser> fromIdToken({
     required OidcToken token,
-    bool strictVerification = true,
     JsonWebKeyStore? keystore,
     OidcStore? cacheStore,
     List<String>? allowedAlgorithms,
@@ -87,7 +90,6 @@ class OidcUser {
       idToken,
       allowedAlgorithms,
       cacheStore,
-      strictVerification,
       jwksCacheMaxAge,
       httpClient,
     );
@@ -108,7 +110,6 @@ class OidcUser {
     String idToken,
     List<String>? allowedAlgorithms,
     OidcStore? cacheStore,
-    bool strictVerification,
     Duration jwksCacheMaxAge,
     http.Client? httpClient,
   ) async {
@@ -159,31 +160,22 @@ class OidcUser {
       }
 
       try {
-        try {
-          webToken = await attemptVerify(forceFreshJwks: false);
-        } catch (e) {
-          // The id_token's `kid` may reference a signing key that rotated in
-          // after our (possibly cached/CDN-served) JWKS view was read. Per
-          // OIDC Core §10.1.1 and the Entra/Cognito/panva key-rotation
-          // guidance: force exactly ONE fresh, cache-busting JWKS refetch and
-          // retry before giving up — rate-limited per issuer
-          // ([_shouldForceJwksRefetch]) so a forged/garbage `kid` can't be
-          // used to flood the JWKS endpoint.
-          if (!_shouldForceJwksRefetch(idToken)) {
-            rethrow;
-          }
-          webToken = await attemptVerify(forceFreshJwks: true);
-        }
-      } catch (e, st) {
-        if (strictVerification) {
+        webToken = await attemptVerify(forceFreshJwks: false);
+      } catch (e) {
+        // The id_token's `kid` may reference a signing key that rotated in
+        // after our (possibly cached/CDN-served) JWKS view was read. Per
+        // OIDC Core §10.1.1 and the Entra/Cognito/panva key-rotation
+        // guidance: force exactly ONE fresh, cache-busting JWKS refetch and
+        // retry before giving up — rate-limited per issuer
+        // ([_shouldForceJwksRefetch]) so a forged/garbage `kid` can't be used
+        // to flood the JWKS endpoint. A failure past this point is fatal: an
+        // id_token whose signature cannot be verified is always rejected
+        // (OpenID Connect Core §3.1.3.7 / §5.3.2, OAuth 2.0 Security BCP RFC
+        // 9700) — there is no unverified-fallback opt-out.
+        if (!_shouldForceJwksRefetch(idToken)) {
           rethrow;
         }
-        _logger.warning(
-          'Failed to verify id_token, using unverified instead.',
-          e,
-          st,
-        );
-        webToken = JsonWebToken.unverified(idToken);
+        webToken = await attemptVerify(forceFreshJwks: true);
       }
     }
     return webToken;
@@ -240,7 +232,6 @@ class OidcUser {
   Future<OidcUser> replaceToken(
     OidcToken newToken, {
     String? idTokenOverride,
-    bool strictVerification = true,
     OidcStore? cacheStore,
     bool allowExpiredIdToken = false,
     Duration jwksCacheMaxAge = const Duration(days: 1),
@@ -255,7 +246,6 @@ class OidcUser {
         idToken,
         allowedAlgorithms,
         cacheStore,
-        strictVerification,
         jwksCacheMaxAge,
         httpClient,
       );

--- a/packages/oidc_core/lib/src/models/user.dart
+++ b/packages/oidc_core/lib/src/models/user.dart
@@ -1,8 +1,46 @@
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
 import 'package:jose_plus/jose.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:oidc_core/oidc_core.dart';
 
 final _logger = Logger('Oidc.User');
+
+/// Minimum time between forced cache-busting JWKS refetches triggered by an
+/// id_token verification failure, per issuer. Prevents a forged/garbage `kid`
+/// from being used to flood the JWKS endpoint (DoS) while still self-healing
+/// a genuine key rotation quickly.
+///
+/// 5 minutes matches Microsoft Entra's key-rollover guidance and the
+/// panva/WorkOS JWKS guide (OpenID Connect Core 1.0 §10.1.1).
+const _jwksForceRefetchCooldown = Duration(minutes: 5);
+
+/// Tracks, per issuer, the last time a verification failure triggered a
+/// forced JWKS refetch. Process-lifetime only (deliberately not persisted):
+/// the goal is rate-limiting a hot loop within a running process, not
+/// surviving restarts.
+@visibleForTesting
+final Map<String, DateTime> jwksForceRefetchTimestamps = {};
+
+bool _shouldForceJwksRefetch(String idToken) {
+  final issuerKey = _tryGetUnverifiedIssuer(idToken) ?? '<unknown-issuer>';
+  final now = clock.now();
+  final last = jwksForceRefetchTimestamps[issuerKey];
+  if (last != null && now.difference(last) < _jwksForceRefetchCooldown) {
+    return false;
+  }
+  jwksForceRefetchTimestamps[issuerKey] = now;
+  return true;
+}
+
+String? _tryGetUnverifiedIssuer(String idToken) {
+  try {
+    return JsonWebToken.unverified(idToken).claims.issuer?.toString();
+  } on Object catch (_) {
+    return null;
+  }
+}
 
 /// A user is a verified JWT id_token, with an optional access_token.
 class OidcUser {
@@ -36,6 +74,7 @@ class OidcUser {
     Map<String, dynamic>? userInfo,
     String? idTokenOverride,
     Duration jwksCacheMaxAge = const Duration(days: 1),
+    http.Client? httpClient,
   }) async {
     final idToken = idTokenOverride ?? token.idToken;
     if (idToken == null) {
@@ -50,6 +89,7 @@ class OidcUser {
       cacheStore,
       strictVerification,
       jwksCacheMaxAge,
+      httpClient,
     );
 
     return OidcUser._(
@@ -70,6 +110,7 @@ class OidcUser {
     OidcStore? cacheStore,
     bool strictVerification,
     Duration jwksCacheMaxAge,
+    http.Client? httpClient,
   ) async {
     JsonWebToken webToken;
 
@@ -86,22 +127,44 @@ class OidcUser {
       final algs = allowedAlgorithms
           ?.where((a) => a.toLowerCase() != 'none')
           .toList();
-      try {
-        webToken = await JsonWebKeySetLoader.runZoned(
-          () async {
-            return JsonWebToken.decodeAndVerify(
-              idToken,
-              keystore,
-              allowedArguments: algs,
-            );
-          },
+
+      Future<JsonWebToken> attemptVerify({required bool forceFreshJwks}) {
+        return JsonWebKeySetLoader.runZoned(
+          () => JsonWebToken.decodeAndVerify(
+            idToken,
+            keystore,
+            allowedArguments: algs,
+          ),
           loader: cacheStore == null
+              // The no-cacheStore path still reuses the process-wide default
+              // loader on retry here; a dedicated cache-busting loader for
+              // that path is wired in separately.
               ? null
               : OidcJwksStoreLoader(
                   store: cacheStore,
                   staleCacheMaxAge: jwksCacheMaxAge,
+                  forceFresh: forceFreshJwks,
+                  httpClient: httpClient,
                 ),
         );
+      }
+
+      try {
+        try {
+          webToken = await attemptVerify(forceFreshJwks: false);
+        } catch (e) {
+          // The id_token's `kid` may reference a signing key that rotated in
+          // after our (possibly cached/CDN-served) JWKS view was read. Per
+          // OIDC Core §10.1.1 and the Entra/Cognito/panva key-rotation
+          // guidance: force exactly ONE fresh, cache-busting JWKS refetch and
+          // retry before giving up — rate-limited per issuer
+          // ([_shouldForceJwksRefetch]) so a forged/garbage `kid` can't be
+          // used to flood the JWKS endpoint.
+          if (!_shouldForceJwksRefetch(idToken)) {
+            rethrow;
+          }
+          webToken = await attemptVerify(forceFreshJwks: true);
+        }
       } catch (e, st) {
         if (strictVerification) {
           rethrow;
@@ -172,6 +235,7 @@ class OidcUser {
     OidcStore? cacheStore,
     bool allowExpiredIdToken = false,
     Duration jwksCacheMaxAge = const Duration(days: 1),
+    http.Client? httpClient,
   }) async {
     final idToken = idTokenOverride ?? newToken.idToken ?? this.idToken;
 
@@ -184,6 +248,7 @@ class OidcUser {
         cacheStore,
         strictVerification,
         jwksCacheMaxAge,
+        httpClient,
       );
     } else {
       webToken = parsedIdToken;

--- a/packages/oidc_core/lib/src/models/user.dart
+++ b/packages/oidc_core/lib/src/models/user.dart
@@ -136,10 +136,19 @@ class OidcUser {
             allowedArguments: algs,
           ),
           loader: cacheStore == null
-              // The no-cacheStore path still reuses the process-wide default
-              // loader on retry here; a dedicated cache-busting loader for
-              // that path is wired in separately.
-              ? null
+              ? (forceFreshJwks
+                    // No OidcStore to persist an offline fallback to: force a
+                    // brand-new, cache-busted loader instance so the retry
+                    // bypasses BOTH this call's own cache AND the long-lived
+                    // process-wide default loader's TTL cache (which can
+                    // otherwise mask a just-rotated key for its full TTL).
+                    ? OidcForceFreshJwksLoader(httpClient: httpClient)
+                    // First attempt: preserve existing behavior (the
+                    // process-wide default loader) unless a caller supplied
+                    // an explicit httpClient (e.g. for testing).
+                    : (httpClient == null
+                          ? null
+                          : DefaultJsonWebKeySetLoader(httpClient: httpClient)))
               : OidcJwksStoreLoader(
                   store: cacheStore,
                   staleCacheMaxAge: jwksCacheMaxAge,

--- a/packages/oidc_core/test/alg_pinning_test.dart
+++ b/packages/oidc_core/test/alg_pinning_test.dart
@@ -350,7 +350,6 @@ void main() {
         );
       },
     );
-
   });
 
   group('front-channel/hybrid path honours the pin (:1830 site)', () {

--- a/packages/oidc_core/test/alg_pinning_test.dart
+++ b/packages/oidc_core/test/alg_pinning_test.dart
@@ -80,7 +80,6 @@ OidcProviderMetadata _meta(List<String>? algs) =>
 _PinManager _manager({
   List<String>? pin,
   JsonWebKeyStore? keyStore,
-  bool strict = true,
   List<String>? opAlgs,
 }) => _PinManager(
   discoveryDocument: _meta(opAlgs),
@@ -89,7 +88,6 @@ _PinManager _manager({
   settings: OidcUserManagerSettings(
     redirectUri: Uri.parse('com.example.app://cb'),
     allowedIdTokenAlgorithms: pin,
-    strictJwtVerification: strict,
   ),
   keyStore: keyStore,
 );
@@ -353,29 +351,6 @@ void main() {
       },
     );
 
-    test(
-      'strictJwtVerification=false + pin [RS256] + HS256 token => downgraded '
-      'to an unverified token (the pin only hardens the strict path)',
-      () async {
-        const secret = 'a-very-secret-client-secret-value-0123456789';
-        final hsKey = JsonWebKey.fromJson({
-          'kty': 'oct',
-          'k': base64Url.encode(utf8.encode(secret)).replaceAll('=', ''),
-          'alg': 'HS256',
-        })!;
-        final m = _manager(pin: const ['RS256'], strict: false);
-        final ks = JsonWebKeyStore()..addKey(_octFromSecret(secret));
-        final user = await OidcUser.fromIdToken(
-          token: _tokenWith(_signHs(hsKey, _baseClaims())),
-          keystore: ks,
-          strictVerification: false,
-          allowedAlgorithms: m.resolvePin(_meta(const ['RS256', 'HS256'])),
-        );
-        // Built, but NOT verified (fail-open opt-out path).
-        expect(user.parsedIdToken.isVerified, isNot(isTrue));
-        expect(user.claims.subject, 'user-1');
-      },
-    );
   });
 
   group('front-channel/hybrid path honours the pin (:1830 site)', () {

--- a/packages/oidc_core/test/audit_p0_regression_test.dart
+++ b/packages/oidc_core/test/audit_p0_regression_test.dart
@@ -1,6 +1,8 @@
 @TestOn('vm')
 library;
 
+import 'dart:convert';
+
 import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -62,8 +64,16 @@ class _TestManager extends OidcUserManagerBase {
   }) => const Stream.empty();
 }
 
+/// Fixed signing key shared by every id_token this file mints, so a single
+/// mocked `/jwks` response (see [_jwksResponseBody]) can verify all of them
+/// under the now-always-strict verification path.
+final JsonWebKey _signingKey = JsonWebKey.generate('RS256');
+final Uri _jwksUri = Uri.parse('https://op.example.com/jwks');
+
+String _jwksResponseBody() =>
+    jsonEncode(JsonWebKeySet.fromKeys([_signingKey]).toJson());
+
 String _signIdToken([Map<String, dynamic>? extra]) {
-  final key = JsonWebKey.generate('RS256');
   return (JsonWebSignatureBuilder()
         ..jsonContent = {
           'iss': 'https://op.example.com',
@@ -78,7 +88,7 @@ String _signIdToken([Map<String, dynamic>? extra]) {
           'iat': clock.now().millisecondsSinceEpoch ~/ 1000,
           ...?extra,
         }
-        ..addRecipient(key, algorithm: 'RS256'))
+        ..addRecipient(_signingKey, algorithm: 'RS256'))
       .build()
       .toCompactSerialization();
 }
@@ -91,15 +101,16 @@ Future<OidcUser> _user() => OidcUser.fromIdToken(
     refreshToken: 'refresh-token-1',
     tokenType: 'Bearer',
   ),
-  strictVerification: false,
 );
 
-/// Discovery metadata that OMITS `grant_types_supported` (and jwks_uri),
-/// exactly like Facebook and other compliant OPs that don't advertise it.
+/// Discovery metadata that OMITS `grant_types_supported`, exactly like
+/// Facebook and other compliant OPs that don't advertise it. `jwks_uri` IS
+/// present (verification is always-strict now, so a real key set is needed).
 OidcProviderMetadata _metadataNoGrantTypes() => OidcProviderMetadata.fromJson({
   'issuer': 'https://op.example.com',
   'authorization_endpoint': 'https://op.example.com/authorize',
   'token_endpoint': 'https://op.example.com/token',
+  'jwks_uri': _jwksUri.toString(),
 });
 
 Future<_TestManager> _build(http.Client client) async {
@@ -112,7 +123,6 @@ Future<_TestManager> _build(http.Client client) async {
     httpClient: client,
     settings: OidcUserManagerSettings(
       redirectUri: Uri.parse('com.example.app://cb'),
-      strictJwtVerification: false,
     ),
   );
   await manager.init();
@@ -127,6 +137,13 @@ void main() {
       () async {
         final tokenCalls = <http.Request>[];
         final client = MockClient((req) async {
+          if (req.url.path.endsWith('/jwks')) {
+            return http.Response(
+              _jwksResponseBody(),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
           if (req.url.path.endsWith('/token')) {
             tokenCalls.add(req);
             return http.Response(
@@ -161,6 +178,13 @@ void main() {
       () async {
         final tokenCalls = <http.Request>[];
         final client = MockClient((req) async {
+          if (req.url.path.endsWith('/jwks')) {
+            return http.Response(
+              _jwksResponseBody(),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
           if (req.url.path.endsWith('/token')) {
             tokenCalls.add(req);
             return http.Response(

--- a/packages/oidc_core/test/device_code_flow_test.dart
+++ b/packages/oidc_core/test/device_code_flow_test.dart
@@ -221,7 +221,8 @@ void main() {
         // on the backoff-timing test above for why this test uses real async
         // instead of `fakeAsync`.
         final signingKey = JsonWebKey.generate('RS256');
-        final nowSeconds = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+        final nowSeconds =
+            DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
         final idToken = _signedJwt(
           signingKey: signingKey,
           issuer: issuer,

--- a/packages/oidc_core/test/device_code_flow_test.dart
+++ b/packages/oidc_core/test/device_code_flow_test.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:fake_async/fake_async.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
 import 'package:oidc_core/oidc_core.dart';
 import 'package:test/test.dart';
 
@@ -14,6 +15,7 @@ class _TestUserManager extends OidcUserManagerBase {
     required super.store,
     required super.settings,
     super.httpClient,
+    super.keyStore,
   });
 
   @override
@@ -64,34 +66,38 @@ class _TestUserManager extends OidcUserManagerBase {
   }
 }
 
-String _b64UrlJson(Map<String, Object?> json) {
-  final bytes = utf8.encode(jsonEncode(json));
-  return base64Url.encode(bytes).replaceAll('=', '');
-}
-
-String _unsignedJwt({
+String _signedJwt({
+  required JsonWebKey signingKey,
   required String issuer,
   required String audience,
   required String subject,
   required int issuedAt,
   required int expiresAt,
 }) {
-  final header = <String, Object?>{'alg': 'none', 'typ': 'JWT'};
-  final payload = <String, Object?>{
-    'iss': issuer,
-    'aud': audience,
-    'sub': subject,
-    'iat': issuedAt,
-    'exp': expiresAt,
-  };
-  // Compact JWS has 3 parts; with `alg=none` the signature can be empty.
-  return '${_b64UrlJson(header)}.${_b64UrlJson(payload)}.';
+  return (JsonWebSignatureBuilder()
+        ..jsonContent = {
+          'iss': issuer,
+          'aud': audience,
+          'sub': subject,
+          'iat': issuedAt,
+          'exp': expiresAt,
+        }
+        ..addRecipient(signingKey, algorithm: 'RS256'))
+      .build()
+      .toCompactSerialization();
 }
 
 void main() {
   group('OidcUserManagerBase.loginDeviceCodeFlow', () {
+    // This test exercises ONLY the poll-backoff timing (authorization_pending
+    // then slow_down), never the success path — under `fakeAsync`. Real
+    // id_token signature verification (always-strict now) is NOT exercised
+    // here: `jose_plus`'s key resolution goes through an `async*` Stream that
+    // does not settle under `fakeAsync` (a pre-existing jose_plus/fake_async
+    // interaction, unrelated to what this test exercises). The success +
+    // verification path is covered separately, with real async, below.
     test(
-      'polls until success; handles authorization_pending and slow_down',
+      'polls with authorization_pending/slow_down backoff timing',
       () {
         fakeAsync((async) {
           const issuer = 'https://server.example.com';
@@ -103,16 +109,6 @@ void main() {
             'token_endpoint': tokenEndpoint.toString(),
             'device_authorization_endpoint': deviceEndpoint.toString(),
           });
-
-          final nowSeconds =
-              DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
-          final idToken = _unsignedJwt(
-            issuer: issuer,
-            audience: 'client',
-            subject: 'user',
-            issuedAt: nowSeconds,
-            expiresAt: nowSeconds + 3600,
-          );
 
           var tokenCalls = 0;
           final tokenCallOffsets = <Duration>[];
@@ -135,24 +131,15 @@ void main() {
             if (request.url == tokenEndpoint) {
               tokenCalls++;
               tokenCallOffsets.add(async.elapsed);
-              if (tokenCalls == 1) {
-                return http.Response(
-                  jsonEncode({'error': 'authorization_pending'}),
-                  400,
-                );
-              }
               if (tokenCalls == 2) {
                 return http.Response(jsonEncode({'error': 'slow_down'}), 400);
               }
-
+              // Stays pending on every other call (including the 3rd) — this
+              // test only cares about the interval/backoff timing, never
+              // reaches id_token verification.
               return http.Response(
-                jsonEncode({
-                  'access_token': 'access-token',
-                  'id_token': idToken,
-                  'token_type': 'Bearer',
-                  'expires_in': 3600,
-                }),
-                200,
+                jsonEncode({'error': 'authorization_pending'}),
+                400,
               );
             }
 
@@ -161,11 +148,6 @@ void main() {
 
           final settings = OidcUserManagerSettings(
             redirectUri: Uri.parse('com.example:/callback'),
-            // This flow test uses an intentionally-unsigned mock id_token and
-            // does not serve a JWKS, so opt out of the fail-closed signature
-            // verification (now the default) — it exercises device-code
-            // polling, not id_token validation.
-            strictJwtVerification: false,
             userInfoSettings: const OidcUserInfoSettings(
               sendUserInfoRequest: false,
             ),
@@ -181,24 +163,17 @@ void main() {
             httpClient: client,
           );
 
-          OidcUser? result;
-          Object? error;
-
           unawaited(
-            manager
-                .init()
-                .then((_) {
-                  return manager.loginDeviceCodeFlow(
-                    onVerification: (resp) async {
-                      verificationCalls++;
-                      expect(resp.deviceCode, 'device-code');
-                      expect(resp.userCode, 'user-code');
-                      expect(resp.interval, const Duration(seconds: 1));
-                    },
-                  );
-                })
-                .then<void>((u) => result = u)
-                .catchError((Object e) => error = e),
+            manager.init().then(
+              (_) => manager.loginDeviceCodeFlow(
+                onVerification: (resp) async {
+                  verificationCalls++;
+                  expect(resp.deviceCode, 'device-code');
+                  expect(resp.userCode, 'user-code');
+                  expect(resp.interval, const Duration(seconds: 1));
+                },
+              ),
+            ),
           );
 
           async
@@ -212,10 +187,6 @@ void main() {
             // After slow_down, interval increases by 5 seconds.
             ..elapse(const Duration(seconds: 6))
             ..flushMicrotasks();
-
-          expect(error, isNull);
-          expect(result, isNotNull);
-          expect(result!.token.accessToken, 'access-token');
 
           expect(verificationCalls, 1);
           expect(tokenCalls, 3);
@@ -233,6 +204,94 @@ void main() {
           unawaited(manager.dispose());
           async.flushMicrotasks();
         });
+      },
+    );
+
+    test(
+      'completes with a verified user when the device flow succeeds',
+      () async {
+        const issuer = 'https://server.example.com';
+        final deviceEndpoint = Uri.parse('$issuer/device');
+        final tokenEndpoint = Uri.parse('$issuer/token');
+
+        // Signature verification is always-strict now, so the id_token must
+        // be real. The signing key is added directly to the manager's
+        // keyStore (rather than served from a mocked `jwks_uri`) so
+        // verification resolves it synchronously from memory — see the note
+        // on the backoff-timing test above for why this test uses real async
+        // instead of `fakeAsync`.
+        final signingKey = JsonWebKey.generate('RS256');
+        final nowSeconds = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+        final idToken = _signedJwt(
+          signingKey: signingKey,
+          issuer: issuer,
+          audience: 'client',
+          subject: 'user',
+          issuedAt: nowSeconds,
+          expiresAt: nowSeconds + 3600,
+        );
+
+        final metadata = OidcProviderMetadata.fromJson({
+          'issuer': issuer,
+          'token_endpoint': tokenEndpoint.toString(),
+          'device_authorization_endpoint': deviceEndpoint.toString(),
+        });
+
+        final client = MockClient((request) async {
+          if (request.url == deviceEndpoint) {
+            return http.Response(
+              jsonEncode({
+                'device_code': 'device-code',
+                'user_code': 'user-code',
+                'verification_uri': '$issuer/verify',
+                'expires_in': 60,
+                'interval': 0,
+              }),
+              200,
+            );
+          }
+
+          if (request.url == tokenEndpoint) {
+            return http.Response(
+              jsonEncode({
+                'access_token': 'access-token',
+                'id_token': idToken,
+                'token_type': 'Bearer',
+                'expires_in': 3600,
+              }),
+              200,
+            );
+          }
+
+          return http.Response('Not found', 404);
+        });
+
+        final settings = OidcUserManagerSettings(
+          redirectUri: Uri.parse('com.example:/callback'),
+          userInfoSettings: const OidcUserInfoSettings(
+            sendUserInfoRequest: false,
+          ),
+        );
+
+        final manager = _TestUserManager(
+          discoveryDocument: metadata,
+          clientCredentials: const OidcClientAuthentication.none(
+            clientId: 'client',
+          ),
+          store: OidcMemoryStore(),
+          settings: settings,
+          httpClient: client,
+          keyStore: JsonWebKeyStore()..addKey(signingKey),
+        );
+
+        await manager.init();
+        final result = await manager.loginDeviceCodeFlow();
+
+        expect(result, isNotNull);
+        expect(result!.token.accessToken, 'access-token');
+        expect(result.parsedIdToken.isVerified, isTrue);
+
+        await manager.dispose();
       },
     );
 

--- a/packages/oidc_core/test/dual_client_auth_refresh_test.dart
+++ b/packages/oidc_core/test/dual_client_auth_refresh_test.dart
@@ -16,6 +16,7 @@ class _TestManager extends OidcUserManagerBase {
     required super.store,
     required super.settings,
     super.httpClient,
+    super.keyStore,
   });
 
   void seed(OidcUser user) => userSubject.add(user);
@@ -56,8 +57,12 @@ class _TestManager extends OidcUserManagerBase {
   }) => const Stream.empty();
 }
 
+/// Fixed signing key shared by every id_token this file mints, so it
+/// verifies under the now-always-strict verification path when registered
+/// directly on the test manager's keyStore (see [_build]).
+final _signingKey = JsonWebKey.generate('RS256');
+
 String _signIdToken() {
-  final key = JsonWebKey.generate('RS256');
   return (JsonWebSignatureBuilder()
         ..jsonContent = {
           'iss': 'https://op.example.com',
@@ -71,7 +76,7 @@ String _signIdToken() {
               1000,
           'iat': clock.now().millisecondsSinceEpoch ~/ 1000,
         }
-        ..addRecipient(key, algorithm: 'RS256'))
+        ..addRecipient(_signingKey, algorithm: 'RS256'))
       .build()
       .toCompactSerialization();
 }
@@ -84,7 +89,6 @@ Future<OidcUser> _user() => OidcUser.fromIdToken(
     refreshToken: 'refresh-token-1',
     tokenType: 'Bearer',
   ),
-  strictVerification: false,
 );
 
 OidcProviderMetadata _metadata() => OidcProviderMetadata.fromJson({
@@ -106,8 +110,8 @@ Future<_TestManager> _build(http.Client client) async {
     httpClient: client,
     settings: OidcUserManagerSettings(
       redirectUri: Uri.parse('com.example.app://cb'),
-      strictJwtVerification: false,
     ),
+    keyStore: JsonWebKeyStore()..addKey(_signingKey),
   );
   await manager.init();
   manager.seed(await _user());

--- a/packages/oidc_core/test/endpoints/userinfo_test.dart
+++ b/packages/oidc_core/test/endpoints/userinfo_test.dart
@@ -2,23 +2,25 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
 import 'package:oidc_core/oidc_core.dart';
 import 'package:test/test.dart';
 
-String _b64(Object json) =>
-    base64Url.encode(utf8.encode(jsonEncode(json))).replaceAll('=', '');
+/// Signature verification is always-strict now (no `keyStore`-less opt-out),
+/// so these Content-Type-routing tests sign with a real key and provide a
+/// matching keyStore, rather than the previous arbitrary-signature trick.
+final _signingKey = JsonWebKey.generate('RS256');
 
-/// Builds a compact JWS string carrying [claims]. The signature segment is
-/// arbitrary on purpose: these tests exercise the *unverified* parse path
-/// (no key store), which is enough to prove `Content-Type` detection routes an
-/// `application/jwt` body to the JWT branch instead of the JSON parser.
-///
-/// Because the unverified parse path is fail-closed by default
-/// (`strictJwtVerification: true` rejects an unverifiable signed UserInfo
-/// response), these content-type tests explicitly opt out with
-/// `strictJwtVerification: false` — they assert routing, not signature trust.
+/// Builds a compact JWS string carrying [claims], signed by [_signingKey].
+/// Verifying it (rather than parsing unverified) still exercises the thing
+/// under test: that `Content-Type` detection routes an `application/jwt`
+/// body to the JWT branch instead of the JSON parser.
 String _compactJwt(Map<String, dynamic> claims) =>
-    '${_b64(const {'alg': 'RS256', 'typ': 'JWT'})}.${_b64(claims)}.AQID';
+    (JsonWebSignatureBuilder()
+          ..jsonContent = claims
+          ..addRecipient(_signingKey, algorithm: 'RS256'))
+        .build()
+        .toCompactSerialization();
 
 void main() {
   group('OidcEndpoints.userInfo Content-Type handling', () {
@@ -27,9 +29,7 @@ void main() {
         userInfoEndpoint: Uri.parse('https://op.example.com/userinfo'),
         accessToken: 'access-token',
         followDistributedClaims: false,
-        // No keyStore is provided; opt out of the strict (fail-closed) guard so
-        // the unverified application/jwt routing path under test is reached.
-        strictJwtVerification: false,
+        keyStore: JsonWebKeyStore()..addKey(_signingKey),
         client: MockClient((_) async => response),
       );
     }

--- a/packages/oidc_core/test/hybrid_flow_test.dart
+++ b/packages/oidc_core/test/hybrid_flow_test.dart
@@ -16,6 +16,7 @@ class _HybridManager extends OidcUserManagerBase {
     required super.clientCredentials,
     required super.store,
     required super.settings,
+    super.keyStore,
   });
 
   Future<void> validateFrontChannel({
@@ -72,11 +73,15 @@ final _metadata = OidcProviderMetadata.fromJson({
   'token_endpoint': 'https://op.example.com/token',
 });
 
+/// Signature verification is always-strict now, so every id_token this file
+/// mints is signed by this shared key, registered on the test manager's
+/// keyStore (see [_manager]).
+final _signingKey = JsonWebKey.generate('RS256');
+
 Future<String> _signIdToken(Map<String, dynamic> claims) async {
-  final key = JsonWebKey.generate('RS256');
   final builder = JsonWebSignatureBuilder()
     ..jsonContent = claims
-    ..addRecipient(key, algorithm: 'RS256');
+    ..addRecipient(_signingKey, algorithm: 'RS256');
   return builder.build().toCompactSerialization();
 }
 
@@ -97,9 +102,11 @@ Future<_HybridManager> _manager() async {
     store: OidcMemoryStore(),
     settings: OidcUserManagerSettings(
       redirectUri: Uri.parse('com.example.app://cb'),
-      // unsigned/keystore-less: exercise claim binding, not signature.
-      strictJwtVerification: false,
     ),
+    // Signature verification is always-strict now; register the shared
+    // signing key directly so these tests can focus on claim binding
+    // (nonce/c_hash/at_hash/auth_time), not signature trust.
+    keyStore: JsonWebKeyStore()..addKey(_signingKey),
   );
   await m.init();
   return m;

--- a/packages/oidc_core/test/id_token_alg_none_test.dart
+++ b/packages/oidc_core/test/id_token_alg_none_test.dart
@@ -45,7 +45,7 @@ void main() {
       // A real keystore is present (the verify path runs), and the OP-advertised
       // allow-list happens to include `none` — jose_plus only auto-rejects
       // `none` when the list is null, so without an explicit strip this would
-      // accept the forged unsigned token. Default strictVerification=true.
+      // accept the forged unsigned token. Verification is always-strict.
       final keystore = JsonWebKeyStore()..addKey(JsonWebKey.generate('RS256'));
 
       await expectLater(

--- a/packages/oidc_core/test/id_token_strict_verification_test.dart
+++ b/packages/oidc_core/test/id_token_strict_verification_test.dart
@@ -36,7 +36,8 @@ OidcToken _tokenWith(String idToken) => OidcToken(
 
 void main() {
   test(
-    'fromIdToken rejects an unverifiable signature by default (fail-closed)',
+    'fromIdToken always rejects an unverifiable/bad signature (fail-closed, '
+    'no unverified-fallback opt-out)',
     () async {
       final signingKey = JsonWebKey.generate('RS256');
       final idToken = await _signIdToken(signingKey, _baseClaims());
@@ -46,7 +47,6 @@ void main() {
         ..addKey(JsonWebKey.generate('RS256'));
 
       await expectLater(
-        // No strictVerification arg -> exercises the fail-closed DEFAULT.
         OidcUser.fromIdToken(
           token: _tokenWith(idToken),
           keystore: foreignKeystore,
@@ -56,24 +56,6 @@ void main() {
       );
     },
   );
-
-  test('fromIdToken accepts an unverifiable signature only when strict '
-      'verification is explicitly disabled', () async {
-    final signingKey = JsonWebKey.generate('RS256');
-    final idToken = await _signIdToken(signingKey, _baseClaims());
-    final foreignKeystore = JsonWebKeyStore()
-      ..addKey(JsonWebKey.generate('RS256'));
-
-    final user = await OidcUser.fromIdToken(
-      token: _tokenWith(idToken),
-      keystore: foreignKeystore,
-      strictVerification: false,
-      allowedAlgorithms: const ['RS256'],
-    );
-    // The unverified token is still parsed (claims readable) but NOT verified.
-    expect(user.claims.subject, 'user-1');
-    expect(user.parsedIdToken.isVerified, isNot(true));
-  });
 
   test('fromIdToken accepts a signature the keystore can verify', () async {
     final signingKey = JsonWebKey.generate('RS256');

--- a/packages/oidc_core/test/jwks_kid_rotation_no_cache_store_test.dart
+++ b/packages/oidc_core/test/jwks_kid_rotation_no_cache_store_test.dart
@@ -18,7 +18,7 @@ import 'package:test/test.dart';
 /// default [JsonWebKeySetLoader] whose in-memory TTL cache can mask a
 /// just-rotated signing key for its full cache lifetime.
 
-final _jwksUri = Uri.parse('https://op.example.com/jwks');
+final Uri _jwksUri = Uri.parse('https://op.example.com/jwks');
 
 JsonWebKey _withKid(JsonWebKey key, String kid) =>
     JsonWebKey.fromJson({...key.toJson(), 'kid': kid})!;
@@ -52,9 +52,7 @@ OidcToken _tokenWith(String idToken) => OidcToken(
 void main() {
   final t0 = DateTime.utc(2026, 1, 1, 12);
 
-  setUp(() {
-    jwksForceRefetchTimestamps.clear();
-  });
+  setUp(jwksForceRefetchTimestamps.clear);
 
   group('kid-miss JWKS refetch (cacheStore-less path)', () {
     test(

--- a/packages/oidc_core/test/jwks_kid_rotation_no_cache_store_test.dart
+++ b/packages/oidc_core/test/jwks_kid_rotation_no_cache_store_test.dart
@@ -1,0 +1,181 @@
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+/// Gap #2 (audit #324 item 9): the SAME kid-miss-triggered forced JWKS
+/// refetch (see `jwks_kid_rotation_test.dart` for gap #1) must also apply
+/// when no [OidcStore] `cacheStore` is available to verify against — the
+/// advanced/manual `OidcUser.fromIdToken(cacheStore: null)` API surface,
+/// which otherwise falls back to jose_plus's long-lived, process-wide
+/// default [JsonWebKeySetLoader] whose in-memory TTL cache can mask a
+/// just-rotated signing key for its full cache lifetime.
+
+final _jwksUri = Uri.parse('https://op.example.com/jwks');
+
+JsonWebKey _withKid(JsonWebKey key, String kid) =>
+    JsonWebKey.fromJson({...key.toJson(), 'kid': kid})!;
+
+String _jwksBody(Iterable<JsonWebKey> keys) =>
+    jsonEncode(JsonWebKeySet.fromKeys(keys).toJson());
+
+Future<String> _signIdToken(JsonWebKey key) async {
+  final builder = JsonWebSignatureBuilder()
+    ..jsonContent = {
+      'iss': 'https://op.example.com',
+      'sub': 'user-1',
+      'aud': 'client-1',
+      'iat': clock.now().millisecondsSinceEpoch ~/ 1000,
+      'exp':
+          clock.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/
+          1000,
+    }
+    ..addRecipient(key, algorithm: 'RS256');
+  return builder.build().toCompactSerialization();
+}
+
+OidcToken _tokenWith(String idToken) => OidcToken(
+  idToken: idToken,
+  accessToken: 'at',
+  tokenType: 'Bearer',
+  expiresIn: const Duration(hours: 1),
+  creationTime: clock.now(),
+);
+
+void main() {
+  final t0 = DateTime.utc(2026, 1, 1, 12);
+
+  setUp(() {
+    jwksForceRefetchTimestamps.clear();
+  });
+
+  group('kid-miss JWKS refetch (cacheStore-less path)', () {
+    test(
+      'token signed by a NEW key not yet visible to the loader => forced '
+      'refetch picks it up and verifies, with NO cacheStore supplied',
+      () async {
+        await withClock(Clock.fixed(t0), () async {
+          final oldKey = _withKid(JsonWebKey.generate('RS256'), 'kid-old');
+          final newKey = _withKid(JsonWebKey.generate('RS256'), 'kid-new');
+          var callCount = 0;
+          final client = MockClient((req) async {
+            callCount++;
+            final keys = callCount == 1 ? [oldKey] : [oldKey, newKey];
+            return http.Response(_jwksBody(keys), 200);
+          });
+
+          final idToken = await _signIdToken(newKey);
+          final user = await OidcUser.fromIdToken(
+            token: _tokenWith(idToken),
+            keystore: JsonWebKeyStore()..addKeySetUrl(_jwksUri),
+            // No cacheStore: exercises the gap #2 path.
+            allowedAlgorithms: const ['RS256'],
+            httpClient: client,
+          );
+
+          expect(user.parsedIdToken.isVerified, isTrue);
+          expect(user.claims.subject, 'user-1');
+          expect(callCount, 2, reason: 'one normal fetch + one forced retry');
+        });
+      },
+    );
+
+    test(
+      'a second verification failure for the same issuer within the '
+      'cooldown does NOT trigger a second forced refetch (fails closed)',
+      () async {
+        await withClock(Clock.fixed(t0), () async {
+          final knownKey = _withKid(
+            JsonWebKey.generate('RS256'),
+            'kid-known',
+          );
+          var callCount = 0;
+          final client = MockClient((req) async {
+            callCount++;
+            return http.Response(_jwksBody([knownKey]), 200);
+          });
+
+          final bogusKey1 = _withKid(
+            JsonWebKey.generate('RS256'),
+            'kid-bogus-1',
+          );
+          final idToken1 = await _signIdToken(bogusKey1);
+          await expectLater(
+            OidcUser.fromIdToken(
+              token: _tokenWith(idToken1),
+              keystore: JsonWebKeyStore()..addKeySetUrl(_jwksUri),
+              allowedAlgorithms: const ['RS256'],
+              httpClient: client,
+            ),
+            throwsA(anything),
+          );
+          expect(callCount, 2, reason: 'normal fetch + one forced retry');
+
+          final bogusKey2 = _withKid(
+            JsonWebKey.generate('RS256'),
+            'kid-bogus-2',
+          );
+          final idToken2 = await _signIdToken(bogusKey2);
+          await expectLater(
+            OidcUser.fromIdToken(
+              token: _tokenWith(idToken2),
+              keystore: JsonWebKeyStore()..addKeySetUrl(_jwksUri),
+              allowedAlgorithms: const ['RS256'],
+              httpClient: client,
+            ),
+            throwsA(anything),
+          );
+          expect(
+            callCount,
+            3,
+            reason:
+                'only ONE additional (normal) fetch — no second forced '
+                'retry while the per-issuer cooldown is active',
+          );
+        });
+      },
+    );
+
+    test(
+      'a genuinely bogus kid triggers exactly one forced retry and still '
+      'fails (fail-closed)',
+      () async {
+        await withClock(Clock.fixed(t0), () async {
+          final knownKey = _withKid(
+            JsonWebKey.generate('RS256'),
+            'kid-known',
+          );
+          var callCount = 0;
+          final client = MockClient((req) async {
+            callCount++;
+            return http.Response(_jwksBody([knownKey]), 200);
+          });
+
+          final bogusKey = _withKid(JsonWebKey.generate('RS256'), 'kid-bogus');
+          final idToken = await _signIdToken(bogusKey);
+          await expectLater(
+            OidcUser.fromIdToken(
+              token: _tokenWith(idToken),
+              keystore: JsonWebKeyStore()..addKeySetUrl(_jwksUri),
+              allowedAlgorithms: const ['RS256'],
+              httpClient: client,
+            ),
+            throwsA(anything),
+          );
+          expect(
+            callCount,
+            2,
+            reason: 'exactly one normal fetch + one forced retry, no more',
+          );
+        });
+      },
+    );
+  });
+}

--- a/packages/oidc_core/test/jwks_kid_rotation_test.dart
+++ b/packages/oidc_core/test/jwks_kid_rotation_test.dart
@@ -1,0 +1,202 @@
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+/// Gap #1 (audit #324 item 9): on an id_token verification failure, the
+/// manager should force exactly ONE cache-busting JWKS refetch (rate-limited
+/// per issuer) and retry once before giving up — instead of trusting a
+/// possibly-stale JWKS view forever within a single verification call. See
+/// `OidcUser.fromIdToken` / `OidcJwksStoreLoader.forceFresh`.
+///
+/// These tests exercise the path where a [cacheStore] IS supplied (the
+/// `OidcUserManager`-managed flow). The `cacheStore`-less path is covered
+/// separately.
+
+final _jwksUri = Uri.parse('https://op.example.com/jwks');
+
+JsonWebKey _withKid(JsonWebKey key, String kid) =>
+    JsonWebKey.fromJson({...key.toJson(), 'kid': kid})!;
+
+String _jwksBody(Iterable<JsonWebKey> keys) =>
+    jsonEncode(JsonWebKeySet.fromKeys(keys).toJson());
+
+Future<String> _signIdToken(JsonWebKey key) async {
+  final builder = JsonWebSignatureBuilder()
+    ..jsonContent = {
+      'iss': 'https://op.example.com',
+      'sub': 'user-1',
+      'aud': 'client-1',
+      'iat': clock.now().millisecondsSinceEpoch ~/ 1000,
+      'exp':
+          clock.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/
+          1000,
+    }
+    ..addRecipient(key, algorithm: 'RS256');
+  return builder.build().toCompactSerialization();
+}
+
+OidcToken _tokenWith(String idToken) => OidcToken(
+  idToken: idToken,
+  accessToken: 'at',
+  tokenType: 'Bearer',
+  expiresIn: const Duration(hours: 1),
+  creationTime: clock.now(),
+);
+
+Future<OidcStore> _store() async {
+  final store = OidcMemoryStore();
+  await store.init();
+  return store;
+}
+
+void main() {
+  final t0 = DateTime.utc(2026, 1, 1, 12);
+
+  setUp(() {
+    // The per-issuer cooldown tracker is process-lifetime global state; reset
+    // it between tests so they don't interfere with each other.
+    jwksForceRefetchTimestamps.clear();
+  });
+
+  group('kid-miss JWKS refetch (cacheStore path)', () {
+    test(
+      'token signed by a NEW key not yet in the cached JWKS => forced '
+      'refetch picks it up and verifies',
+      () async {
+        await withClock(Clock.fixed(t0), () async {
+          final oldKey = _withKid(JsonWebKey.generate('RS256'), 'kid-old');
+          final newKey = _withKid(JsonWebKey.generate('RS256'), 'kid-new');
+          var callCount = 0;
+          final client = MockClient((req) async {
+            callCount++;
+            // First fetch returns the "stale" view (only the old key); any
+            // later (forced/cache-busted) fetch returns the rotated set —
+            // simulating a key that was published after our first read.
+            final keys = callCount == 1 ? [oldKey] : [oldKey, newKey];
+            return http.Response(_jwksBody(keys), 200);
+          });
+
+          final idToken = await _signIdToken(newKey);
+          final user = await OidcUser.fromIdToken(
+            token: _tokenWith(idToken),
+            keystore: JsonWebKeyStore()..addKeySetUrl(_jwksUri),
+            cacheStore: await _store(),
+            allowedAlgorithms: const ['RS256'],
+            httpClient: client,
+          );
+
+          expect(user.parsedIdToken.isVerified, isTrue);
+          expect(user.claims.subject, 'user-1');
+          expect(callCount, 2, reason: 'one normal fetch + one forced retry');
+        });
+      },
+    );
+
+    test(
+      'a second verification failure for the same issuer within the '
+      'cooldown does NOT trigger a second forced refetch (fails closed)',
+      () async {
+        await withClock(Clock.fixed(t0), () async {
+          final knownKey = _withKid(
+            JsonWebKey.generate('RS256'),
+            'kid-known',
+          );
+          var callCount = 0;
+          // The signing keys used by the bogus tokens below are never
+          // present in the served JWKS, however many times it's fetched.
+          final client = MockClient((req) async {
+            callCount++;
+            return http.Response(_jwksBody([knownKey]), 200);
+          });
+
+          final store = await _store();
+          final bogusKey1 = _withKid(
+            JsonWebKey.generate('RS256'),
+            'kid-bogus-1',
+          );
+          final idToken1 = await _signIdToken(bogusKey1);
+          await expectLater(
+            OidcUser.fromIdToken(
+              token: _tokenWith(idToken1),
+              keystore: JsonWebKeyStore()..addKeySetUrl(_jwksUri),
+              cacheStore: store,
+              allowedAlgorithms: const ['RS256'],
+              httpClient: client,
+            ),
+            throwsA(anything),
+          );
+          expect(callCount, 2, reason: 'normal fetch + one forced retry');
+
+          // A different bogus kid, same issuer, well within the 5-minute
+          // cooldown window (the clock hasn't moved).
+          final bogusKey2 = _withKid(
+            JsonWebKey.generate('RS256'),
+            'kid-bogus-2',
+          );
+          final idToken2 = await _signIdToken(bogusKey2);
+          await expectLater(
+            OidcUser.fromIdToken(
+              token: _tokenWith(idToken2),
+              keystore: JsonWebKeyStore()..addKeySetUrl(_jwksUri),
+              cacheStore: store,
+              allowedAlgorithms: const ['RS256'],
+              httpClient: client,
+            ),
+            throwsA(anything),
+          );
+          expect(
+            callCount,
+            3,
+            reason:
+                'only ONE additional (normal) fetch — no second forced '
+                'retry while the per-issuer cooldown is active',
+          );
+        });
+      },
+    );
+
+    test(
+      'a genuinely bogus kid triggers exactly one forced retry and still '
+      'fails (fail-closed)',
+      () async {
+        await withClock(Clock.fixed(t0), () async {
+          final knownKey = _withKid(
+            JsonWebKey.generate('RS256'),
+            'kid-known',
+          );
+          var callCount = 0;
+          final client = MockClient((req) async {
+            callCount++;
+            return http.Response(_jwksBody([knownKey]), 200);
+          });
+
+          final bogusKey = _withKid(JsonWebKey.generate('RS256'), 'kid-bogus');
+          final idToken = await _signIdToken(bogusKey);
+          await expectLater(
+            OidcUser.fromIdToken(
+              token: _tokenWith(idToken),
+              keystore: JsonWebKeyStore()..addKeySetUrl(_jwksUri),
+              cacheStore: await _store(),
+              allowedAlgorithms: const ['RS256'],
+              httpClient: client,
+            ),
+            throwsA(anything),
+          );
+          expect(
+            callCount,
+            2,
+            reason: 'exactly one normal fetch + one forced retry, no more',
+          );
+        });
+      },
+    );
+  });
+}

--- a/packages/oidc_core/test/jwks_kid_rotation_test.dart
+++ b/packages/oidc_core/test/jwks_kid_rotation_test.dart
@@ -14,13 +14,13 @@ import 'package:test/test.dart';
 /// manager should force exactly ONE cache-busting JWKS refetch (rate-limited
 /// per issuer) and retry once before giving up — instead of trusting a
 /// possibly-stale JWKS view forever within a single verification call. See
-/// `OidcUser.fromIdToken` / `OidcJwksStoreLoader.forceFresh`.
+/// [OidcUser.fromIdToken] and `OidcJwksStoreLoader`'s `forceFresh` flag.
 ///
-/// These tests exercise the path where a [cacheStore] IS supplied (the
+/// These tests exercise the path where a `cacheStore` IS supplied (the
 /// `OidcUserManager`-managed flow). The `cacheStore`-less path is covered
 /// separately.
 
-final _jwksUri = Uri.parse('https://op.example.com/jwks');
+final Uri _jwksUri = Uri.parse('https://op.example.com/jwks');
 
 JsonWebKey _withKid(JsonWebKey key, String kid) =>
     JsonWebKey.fromJson({...key.toJson(), 'kid': kid})!;
@@ -60,11 +60,9 @@ Future<OidcStore> _store() async {
 void main() {
   final t0 = DateTime.utc(2026, 1, 1, 12);
 
-  setUp(() {
-    // The per-issuer cooldown tracker is process-lifetime global state; reset
-    // it between tests so they don't interfere with each other.
-    jwksForceRefetchTimestamps.clear();
-  });
+  // The per-issuer cooldown tracker is process-lifetime global state; reset
+  // it between tests so they don't interfere with each other.
+  setUp(jwksForceRefetchTimestamps.clear);
 
   group('kid-miss JWKS refetch (cacheStore path)', () {
     test(

--- a/packages/oidc_core/test/login_dpop_flow_test.dart
+++ b/packages/oidc_core/test/login_dpop_flow_test.dart
@@ -105,8 +105,6 @@ void main() {
       httpClient: client,
       settings: OidcUserManagerSettings(
         redirectUri: Uri.parse('com.example.app://cb'),
-        // Not testing id_token verification here.
-        strictJwtVerification: false,
         dpop: dpop,
       ),
     );
@@ -214,7 +212,6 @@ void main() {
         httpClient: client,
         settings: OidcUserManagerSettings(
           redirectUri: Uri.parse('com.example.app://cb'),
-          strictJwtVerification: false,
           dpop: const OidcDPoPSettings(),
         ),
       );
@@ -267,7 +264,6 @@ void main() {
         httpClient: client,
         settings: OidcUserManagerSettings(
           redirectUri: Uri.parse('com.example.app://cb'),
-          strictJwtVerification: false,
           dpop: const OidcDPoPSettings(),
           pushedAuthorizationRequestsMode:
               OidcPushedAuthorizationRequestsMode.always,

--- a/packages/oidc_core/test/logout_id_token_hint_test.dart
+++ b/packages/oidc_core/test/logout_id_token_hint_test.dart
@@ -89,7 +89,6 @@ Future<OidcUser> _user() => OidcUser.fromIdToken(
     refreshToken: 'refresh-token-1',
     tokenType: 'Bearer',
   ),
-  strictVerification: false,
 );
 
 OidcProviderMetadata _metadata() => OidcProviderMetadata.fromJson({
@@ -111,7 +110,6 @@ Future<_TestManager> _build({Uri? postLogoutRedirectUri}) async {
     settings: OidcUserManagerSettings(
       redirectUri: Uri.parse('com.example.app://cb'),
       postLogoutRedirectUri: postLogoutRedirectUri,
-      strictJwtVerification: false,
     ),
   );
   await manager.init();

--- a/packages/oidc_core/test/logout_revocation_test.dart
+++ b/packages/oidc_core/test/logout_revocation_test.dart
@@ -91,7 +91,6 @@ Future<OidcUser> _user() async {
       refreshToken: 'refresh-token-1',
       tokenType: 'Bearer',
     ),
-    strictVerification: false,
   );
 }
 
@@ -120,7 +119,6 @@ Future<_LogoutManager> _build(
     httpClient: client,
     settings: OidcUserManagerSettings(
       redirectUri: Uri.parse('com.example.app://cb'),
-      strictJwtVerification: false,
       revokeTokensOnLogout: revokeOnLogout,
     ),
   );

--- a/packages/oidc_core/test/rfc9207_iss_test.dart
+++ b/packages/oidc_core/test/rfc9207_iss_test.dart
@@ -91,7 +91,6 @@ Future<_TestManager> _buildManager({
     ),
     settings: OidcUserManagerSettings(
       redirectUri: Uri.parse('com.example.app://cb'),
-      strictJwtVerification: false,
     ),
     buildErrorResponse: buildErrorResponse,
   );

--- a/packages/oidc_core/test/signed_metadata_test.dart
+++ b/packages/oidc_core/test/signed_metadata_test.dart
@@ -7,7 +7,6 @@ import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:jose_plus/jose.dart';
-import 'package:logging/logging.dart';
 import 'package:oidc_core/oidc_core.dart';
 import 'package:test/test.dart';
 
@@ -123,7 +122,6 @@ _DiscoveryManager _manager({
   required Uri wellKnown,
   required http.Client client,
   bool verify = true,
-  bool strictJwt = true,
   List<String>? allowedSignedMetadataAlgorithms,
   OidcStore? store,
 }) => _DiscoveryManager.lazy(
@@ -134,24 +132,9 @@ _DiscoveryManager _manager({
   settings: OidcUserManagerSettings(
     redirectUri: _redirect,
     verifySignedMetadata: verify,
-    strictJwtVerification: strictJwt,
     allowedSignedMetadataAlgorithms: allowedSignedMetadataAlgorithms,
   ),
 );
-
-Future<List<LogRecord>> _capture(Future<void> Function() action) async {
-  final records = <LogRecord>[];
-  final prev = Logger.root.level;
-  Logger.root.level = Level.ALL;
-  final sub = Logger.root.onRecord.listen(records.add);
-  try {
-    await action();
-  } finally {
-    await sub.cancel();
-    Logger.root.level = prev;
-  }
-  return records;
-}
 
 bool _jwksWasFetched(List<Uri> hits) =>
     hits.any((u) => u.path.endsWith('/jwks'));
@@ -264,49 +247,6 @@ void main() {
     );
 
     test(
-      'tampered signature + lenient => succeeds, one warning, plain retained',
-      () async {
-        final valid = _sign({
-          'iss': _issuer,
-          'token_endpoint': 'https://op.example.com/token-signed',
-        });
-        final parts = valid.split('.');
-        final tamperedPayload = base64Url
-            .encode(
-              utf8.encode(
-                jsonEncode({
-                  'iss': _issuer,
-                  'token_endpoint': 'https://attacker.example/token',
-                }),
-              ),
-            )
-            .replaceAll('=', '');
-        final tampered = '${parts[0]}.$tamperedPayload.${parts[2]}';
-        late _DiscoveryManager m;
-        final records = await _capture(() async {
-          m = _manager(
-            wellKnown: wellKnown,
-            client: _serving(
-              doc: _doc(signedMetadata: tampered),
-              hits: <Uri>[],
-            ),
-            strictJwt: false,
-          );
-          await m.init();
-        });
-        expect(
-          m.discoveryDocument.tokenEndpoint.toString(),
-          'https://op.example.com/token',
-        );
-        final warnings = records.where(
-          (r) =>
-              r.level == Level.WARNING && r.message.contains('signed_metadata'),
-        );
-        expect(warnings, hasLength(1));
-      },
-    );
-
-    test(
       'alg:none signed_metadata (none advertised) => rejected (strict)',
       () async {
         final unsigned = _unsigned({
@@ -355,28 +295,6 @@ void main() {
         ),
       );
       await expectLater(m.init(), throwsA(isA<OidcException>()));
-    });
-
-    test('missing iss claim => warn+fallback (lenient)', () async {
-      final signed = _sign({
-        'token_endpoint': 'https://op.example.com/token-signed',
-      });
-      late _DiscoveryManager m;
-      await _capture(() async {
-        m = _manager(
-          wellKnown: wellKnown,
-          client: _serving(
-            doc: _doc(signedMetadata: signed),
-            hits: <Uri>[],
-          ),
-          strictJwt: false,
-        );
-        await m.init();
-      });
-      expect(
-        m.discoveryDocument.tokenEndpoint.toString(),
-        'https://op.example.com/token',
-      );
     });
 
     test('iss mismatches expected issuer => rejected (strict)', () async {

--- a/packages/oidc_core/test/signed_userinfo_validation_test.dart
+++ b/packages/oidc_core/test/signed_userinfo_validation_test.dart
@@ -210,8 +210,7 @@ void main() {
     }
 
     test(
-      'strictJwtVerification=true (default) => throws OidcException '
-      '(no silent unverified trust)',
+      'always throws OidcException (no silent unverified trust, no opt-out)',
       () async {
         final client = jwtClient(signedJwt(_validClaims()));
         await expectLater(
@@ -226,22 +225,7 @@ void main() {
       },
     );
 
-    test(
-      'strictJwtVerification=false => parses unverified claims (opt-out)',
-      () async {
-        final client = jwtClient(signedJwt(_validClaims()));
-        final resp = await OidcEndpoints.userInfo(
-          userInfoEndpoint: _userInfoEndpoint,
-          accessToken: 'at',
-          followDistributedClaims: false,
-          strictJwtVerification: false,
-          client: client,
-        );
-        expect(resp.sub, 'user-1');
-      },
-    );
-
-    test('forged application/jwt + strict (default) => throws', () async {
+    test('forged application/jwt => throws', () async {
       final signed = signedJwt(_validClaims());
       // Tamper the signature segment so it can never verify.
       final parts = signed.split('.');

--- a/packages/oidc_core/test/userinfo_missing_sub_test.dart
+++ b/packages/oidc_core/test/userinfo_missing_sub_test.dart
@@ -16,6 +16,7 @@ class _TestManager extends OidcUserManagerBase {
     required super.store,
     required super.settings,
     super.httpClient,
+    super.keyStore,
   });
 
   void seed(OidcUser user) => userSubject.add(user);
@@ -53,8 +54,13 @@ class _TestManager extends OidcUserManagerBase {
   }) => const Stream.empty();
 }
 
+/// Fixed signing key shared by every id_token this file mints (including
+/// the refresh response's fresh id_token), so it verifies under the
+/// now-always-strict verification path when registered directly on the
+/// test manager's keyStore (see [_build]).
+final _signingKey = JsonWebKey.generate('RS256');
+
 String _signIdToken() {
-  final key = JsonWebKey.generate('RS256');
   return (JsonWebSignatureBuilder()
         ..jsonContent = {
           'iss': 'https://op.example.com',
@@ -68,7 +74,7 @@ String _signIdToken() {
               1000,
           'iat': clock.now().millisecondsSinceEpoch ~/ 1000,
         }
-        ..addRecipient(key, algorithm: 'RS256'))
+        ..addRecipient(_signingKey, algorithm: 'RS256'))
       .build()
       .toCompactSerialization();
 }
@@ -81,7 +87,6 @@ Future<OidcUser> _user() => OidcUser.fromIdToken(
     refreshToken: 'refresh-token-1',
     tokenType: 'Bearer',
   ),
-  strictVerification: false,
 );
 
 OidcProviderMetadata _metadata() => OidcProviderMetadata.fromJson({
@@ -101,8 +106,8 @@ Future<_TestManager> _build(http.Client client) async {
     httpClient: client,
     settings: OidcUserManagerSettings(
       redirectUri: Uri.parse('com.example.app://cb'),
-      strictJwtVerification: false,
     ),
+    keyStore: JsonWebKeyStore()..addKey(_signingKey),
   );
   await manager.init();
   manager.seed(await _user());


### PR DESCRIPTION
## Summary

Implements audit #324 item 9 per the maintainer's directive: **first** closes the JWKS key-rotation gaps identified by research, **then** removes the `strictJwtVerification`/`strictVerification` fail-open opt-out entirely (breaking, rides the pending major).

Research report: `idp-strict-verification-research.md` (13-IdP verdict table + code-gap analysis). Verdict summary — **no mainstream IdP among the 13 surveyed** (Entra ID v1/v2/B2C/CIAM, Google, Apple Sign-In, AWS Cognito, Auth0, Okta, Keycloak, Duende IdentityServer, Zitadel, Salesforce, PingFederate/PingOne, Facebook Limited Login) signs id_tokens with an algorithm `jose_plus` cannot verify. The **sole systemic risk class** is JWKS key rotation → unknown `kid`, and its severity depends entirely on whether the verification path refetches the JWKS on a `kid` miss — which, before this PR, it did not do explicitly.

### Commits (in order)

1. **`fix(oidc_core): refetch JWKS on unknown kid with per-issuer cooldown`** — Gap #1. On a verification failure, force exactly ONE cache-busting JWKS refetch and retry once, rate-limited per issuer (≥5 min cooldown) to prevent a forged/garbage `kid` from being used to flood the JWKS endpoint (DoS). `OidcJwksStoreLoader` gains a `forceFresh` flag that busts the fetch URI (defeats HTTP/CDN caching) while keeping the persisted offline-fallback keyed by the canonical URI.
2. **`fix(oidc_core): kid-miss refetch on the cacheStore-less verification path`** — Gap #2. The advanced/manual `OidcUser.fromIdToken(cacheStore: null)` path previously fell back to jose_plus's long-lived, process-wide default `JsonWebKeySetLoader`, whose in-memory TTL cache (5 min default, longer with a generous OP `Cache-Control`) could mask a just-rotated key for its full lifetime with no retry. Adds `OidcForceFreshJwksLoader`, a one-shot loader that bypasses both its own cache and the cache-busted URI.
3. **`feat(oidc_core)!: remove the strictJwtVerification fail-open opt-out`** — BREAKING. Deletes `OidcUserManagerSettings.strictJwtVerification`; `OidcUser.fromIdToken`/`replaceToken` no longer accept `strictVerification`; `OidcEndpoints.userInfo` no longer accepts `strictJwtVerification`; the discovery `signed_metadata` verification-failure path always refuses (no more warn+fallback). Also fixes a related latent gap surfaced while updating tests: `OidcUserManagerBase` never threaded its configured `httpClient` into id_token verification, silently falling back to a bare `http.Client()` — masked before by the fail-open fallback, load-bearing now that verification is mandatory.
4. **`docs(oidc_core): document HS256 clientSecret requirement + rotation behavior`** — Updates `docs/oidc-usage.md` and `docs/oidc_core.md` to describe always-strict verification, the JWKS rotation self-heal, and the Auth0-style HS256 `clientSecret` requirement.

### Spec / authoritative references

- **OpenID Connect Core 1.0 §10.1.1** (Rotation of Asymmetric Signing Keys) — the OP publishes new keys ahead of use and keeps old ones during overlap; the RP is expected to re-read the JWKS to pick up rotated keys.
- **OpenID Connect Core 1.0 §3.1.3.7 / §5.3.2** and **OAuth 2.0 Security BCP (RFC 9700)** — an id_token/signed UserInfo response whose signature cannot be verified MUST be rejected; no unverified-fallback is a supported posture.
- **RFC 8414 §2.1/§3.2** — signed authorization-server metadata (`signed_metadata`) verification and fail-closed handling on a verification failure.
- **Microsoft Entra — Signing Key Rollover** (authoritative match for the fix pattern): keys are always pre-published (≥2 valid keys); refresh dynamically on an unknown `kid`; the reference `KeyRefresh` pseudo-code short-circuits when the last successful refresh was more recent than **5 minutes** — the cooldown this PR uses.
- **panva / WorkOS JWKS guide** (independent confirmation): "If a JWT arrives with a `kid` not present in your cached JWKS, refetch the JWKS before rejecting the token… implement a minimum refresh interval (typically 5–10 minutes)" to avoid an unknown-kid-flood DoS.
- **AWS Cognito docs**: "If you receive a token with the correct issuer but a different kid… Refresh the cache from your jwks_uri."

### Migration for callers who previously set `strictJwtVerification: false`

- Relying on it for key rotation tolerance → nothing to do, rotation is now handled automatically (commits 1–2).
- Relying on it for HS256 id_tokens (Auth0's default client signing algorithm) → pass `clientSecret` on `OidcClientAuthentication` so `init()` registers the HS256 verification key.
- Relying on it because the IdP's tokens are genuinely unverifiable → fix the IdP-side configuration; accepting an unverified id_token is a forgery risk.

## Test plan

- [x] `dart analyze packages/oidc_core` — 17 pre-existing info-level lints (verified unrelated to this diff, unchanged from `origin/main`), zero new issues, zero errors.
- [x] `dart test` in `packages/oidc_core` — 377 passed, 0 failed (baseline was 378 on `main` + PR #330; this branch forked from `main` without #330, netted 375 baseline + 6 new JWKS-rotation tests − 5 deleted fail-open tests + 1 net-new from a device-code-flow test split = 377, all green).
- [x] `dart analyze` / `flutter test` in `packages/oidc` (the Flutter facade) — clean, 14/14 passing, after threading real signed test tokens + `keyStore` through `oidc_test.dart`/`mock_client.dart` (mocks previously relied on the removed fail-open opt-out).
- [x] `dart analyze` in `packages/oidc/example` — clean (fixed `add_manager_dialog.dart`, `app_state.dart`, integration-test helpers `conformance/manager.dart` + `shared_offline.dart`, all of which referenced the removed setting).
- [x] Confirmed via `git diff origin/main...HEAD -- packages/oidc_core/lib/src/managers/user_manager_base.dart` that this branch does **not** touch PR #330's region (`~1802–1873`, `tokenExchange`/`introspectToken`) — my edits are at `~1229–1248`, `~1896–1904`, `~2142–2148`, `~2381–2402`.
- [x] New regression coverage: `jwks_kid_rotation_test.dart` (cacheStore path) and `jwks_kid_rotation_no_cache_store_test.dart` (cacheStore-less path), each covering (a) a token signed by a new key not yet visible → forced refetch → verifies, (b) a second failure within the cooldown → no second forced fetch → fails closed, (c) a genuinely bogus `kid` → exactly one forced retry → still fails.

**Do not merge before independent review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoZeDcHumT38zpaTic62Rb