### PR TITLE
fix(jose_plus): normalize crypto_keys_plus/x509_plus constraints to caret syntax

### DIFF
--- a/packages/jose_plus/pubspec.yaml
+++ b/packages/jose_plus/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
   sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
-  crypto_keys_plus: ">=0.4.0 <1.0.0"
+  crypto_keys_plus: ^0.5.0
   meta: ^1.1.6
   typed_data: ^1.0.0
-  x509_plus: ">=0.3.3 <1.0.0"
+  x509_plus: ^0.3.3
   http: ">=0.13.0 <2.0.0"
   http_parser: ^4.0.0
   asn1lib: ^1.0.0


### PR DESCRIPTION
## Do not merge before independent review.

## Problem

The "Prepare release" workflow (`.github/workflows/release-prepare.yml`) has been failing since `melos version --yes --no-git-tag-version` corrupts `packages/jose_plus/pubspec.yaml`. Run [28638001109](https://github.com/Bdaya-Dev/oidc/actions/runs/28638001109) on `main` (`d60f050`) died with:

```
Error on line 14, column 21 of packages\jose_plus\pubspec.yaml: Invalid version constraint: Cannot include other constraints with "^" constraint in "^0.6.0 <1.0.0"".
```

## Root cause (evidence-first)

Reproduced locally by cloning `d60f050` fresh and running the exact commands `bluefireteam/melos-action` runs in CI (confirmed by reading that action's `action.yml`):

```
melos version --yes --no-git-tag-version
melos publish -y --dry-run
```

`melos version` (resolved to **melos 7.8.2**, per `pubspec.lock`) rewrote `packages/jose_plus/pubspec.yaml` line 14 from
`crypto_keys_plus: ">=0.4.0 <1.0.0"` to `crypto_keys_plus: ^0.5.0+1 <1.0.0"` -- an invalid mixed constraint. Line 17 (`x509_plus`) got the same treatment. Every *other* dependency across the whole workspace (all plain `^x.y.z` carets) updated cleanly; these two were the only lines using the quoted, space-separated range style.

Traced to melos's own source (`lib/src/package.dart:75-76`, package `melos-7.8.2`):

```dart
const _versionConstraintRegExp =
    r"""(?<version>any|["'^<>=]*\d+\.\d+\.\d+['"<>=\w\-.+_]*)""";
```

The **trailing** character class `['"<>=\w\-.+_]*` does not include a space. Against `">=0.4.0 <1.0.0"`, the regex matches only the leading `">=0.4.0` (quote + operator + first version number) -- the space right after `0.4.0` isn't in that class, so matching stops there. `_setDependencyVersionForPackage` (`lib/src/commands/version.dart:639-644`) then does a naive `replaceAllMapped` splice: it replaces only the matched substring with the new caret value, leaving the untouched second half of the old range (` <1.0.0"`) as literal text immediately after it -- producing `^0.5.0+1 <1.0.0"`.

I confirmed this byte-for-byte with a standalone Dart script that mirrors melos's exact regex construction (including its actual string-escaping) against the real `pubspec.yaml` line -- the match, unmatched tail, and resulting corrupted line are identical to what the real `melos version` run produced.

## Upstream status

- **melos 8.0.0** (latest published release) and melos's **unreleased `main` branch** both have this exact regex, byte-identical to 7.8.2 -- confirmed via `git diff` between the `melos-v7.8.2` and `melos-v8.0.0` tags, and between `melos-v8.0.0` and `origin/main`, in `invertase/melos`. **A melos upgrade does not fix this.**
- Searched `invertase/melos` issues for "Cannot include other constraints", "constraint quoted range", "dependencyVersionReplaceRegex" -- no existing issue or PR found. This appears to be previously unreported.
- The CLI has `-d/--[no-]dependent-constraints` (`melos.yaml`: `command.version.updateDependentsConstraints`), confirmed via `melos version --help`. It is a **workspace-wide, all-or-nothing** switch -- not scopable per-package or per-dependency. Disabling it would stop melos from correctly bumping *every* other package's caret constraints too, which is not acceptable.

## Why this fix (not a fork, not a config flag)

melos's own `_setDependencyVersionForDependentPackage` (`lib/src/commands/version.dart:541-547`) *unconditionally* rewrites any non-exact internal dependency constraint to caret syntax (`VersionConstraint.compatibleWith(version)`) whenever that dependency's version changes -- there is no mode that preserves a wider range. So `crypto_keys_plus`/`x509_plus`'s wide-range constraints in `jose_plus` were already going to collapse to caret the next time either package was bumped, corruption or not -- melos was never going to keep them wide. Git history confirms the wide-range style is a holdover from before these packages were folded into the monorepo (`3fffc6c`, May 29); every other internal dependency here already uses caret.

This PR just performs that inevitable normalization cleanly, once, ourselves -- instead of letting melos's buggy regex do it destructively on the next real release. `crypto_keys_plus: ^0.5.0` and `x509_plus: ^0.3.3` match the versions currently committed on `main` (note: not the historical `0.4.0`/`0.3.3` floor of the old range -- `crypto_keys_plus` had already silently drifted to `0.5.0` on disk while the old wide constraint went unbumped, so a caret of `^0.4.0` would actually fail to resolve against the current committed version).

**External-consumer semantics note:** both packages are pre-1.0, so caret (`^0.x.y`) is narrower than the old `">=0.4.0 <1.0.0"`-style range -- it only allows patch releases within the current minor, not any 0.x minor. Since `jose_plus`, `crypto_keys_plus`, and `x509_plus` are now versioned together in lockstep by melos, their constraints stay in sync automatically on every future release, so this has no practical effect on that release train. It only tightens the window for third parties who pin an independently-versioned copy of `crypto_keys_plus`/`x509_plus` elsewhere in their own dependency tree alongside an older `jose_plus`.

## Validation

Reproduced against a fresh clone of `d60f050` and confirmed the fix:
- `dart pub get` resolves the workspace both before and after the change.
- `melos version --yes --no-git-tag-version` now rewrites `crypto_keys_plus`/`x509_plus` cleanly (e.g. `crypto_keys_plus: ^0.5.0+1`), no corruption, no crash.
- `dart pub get` still resolves post-bump.

## Known separate blocker (not fixed here, flagging for visibility)

With this fix applied, `melos publish -y --dry-run` gets much further (melos no longer crashes parsing the workspace) but still exits non-zero -- due to an **entirely separate, pre-existing** issue: `dart pub publish --dry-run` on `crypto_keys_plus` reports 2 pub.dev validation warnings (exit 65) that are unrelated to melos or versioning:
1. `lib/crypto_keys.dart` doesn't match the package name `crypto_keys_plus` (a leftover from the `crypto_keys` -> `crypto_keys_plus` rename during monorepo consolidation).
2. The `ed25519_edwards: 0.3.1` exact pin is "too tight" per pub.dev's linter -- but this is already a deliberate, documented decision (see the `TODO(#324)` comment directly above that line in `packages/crypto_keys_plus/pubspec.yaml`).

I verified both warnings reproduce identically on a pristine, **unmodified, unbumped** `main` clone -- completely independent of this fix or of any version change. "Prepare release" will not go fully green until that's separately addressed; I left it out of this PR to keep this change scoped to the constraint-mangling bug I was asked to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoZeDcHumT38zpaTic62Rb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version constraints for a couple of dependencies to use newer caret-based ranges.
  * This should help keep dependency requirements clearer and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->