### PR TITLE
fix(release): full publish dry-run sweep — oidc_platform_interface meta dependency

### DIFF
--- a/packages/oidc_platform_interface/pubspec.yaml
+++ b/packages/oidc_platform_interface/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   json_annotation: ^4.12.0
+  meta: ^1.16.0
   oidc_core: ^0.16.1+1
   plugin_platform_interface: ^2.1.0
 


### PR DESCRIPTION
## Summary

Full-workspace sweep of `dart pub publish --dry-run` warnings/errors across every publishable package, in the exact post-versioning state CI produces (mirrors `.github/workflows/release-prepare.yml`'s "Prepare release" job / `bluefireteam/melos-action`). #334 fixed the first 3 packages in melos's exec order; this PR fixes the package that failFast was actually blocking on next (`oidc_platform_interface`, exit 65 in run [28655492705](https://github.com/Bdaya-Dev/oidc/actions/runs/28655492705)), and proves every other package in the workspace — including the ones failFast never let CI reach — is already clean.

## Reproducing CI exactly

```
git clone … && cd oidc
dart pub global run melos bootstrap --no-example   # matches bootstrap-no-example: true step
dart pub global run melos version --yes --no-git-tag-version   # matches run-versioning: true
dart pub global run melos publish -y --dry-run      # matches publish-dry-run: true (the exact CI command)
```

`melos version` bumps the same **16 packages** every time (every publishable workspace member — nothing is skipped): `crypto_keys_plus`, `jose_plus`, `x509_plus`, `oidc`, `oidc_android`, `oidc_cli`, `oidc_core`, `oidc_darwin`, `oidc_default_store`, `oidc_desktop`, `oidc_linux`, `oidc_loopback_listener`, `oidc_platform_interface`, `oidc_web_core`, `oidc_windows`, `oidc_web`. That's the full, definitive inventory — confirmed by running `dart pub publish --dry-run` in each of the 16 package directories individually (not relying on melos's failFast exec, which stops early).

## The fix

**`oidc_platform_interface`: missing `meta` dependency (ERROR, not just a warning — exit 65)**

`lib/src/oidc_native.g.dart` (Pigeon-generated native transport) does `import 'package:meta/meta.dart' show immutable, protected, visibleForTesting;`, but `meta` was never declared in this package's `pubspec.yaml` `dependencies`. It only ever resolved because `oidc_core` (a direct dependency of this package) already depends on `meta: ^1.16.0` transitively. pub's publish validator correctly flags any package imported directly from `lib/` that isn't declared — transitive resolution isn't guaranteed for downstream consumers.

Fix: added `meta: ^1.16.0` to `dependencies`, matching the constraint `oidc_core` already uses, so the resolved version in the workspace is unchanged.

This was the actual root cause of the CI failure — it's what failFast was blocking on, cancelling `oidc_darwin`, `oidc_linux`, `oidc`, `oidc_cli`, `oidc_default_store`, and never letting the run reach `oidc_web_core`, `oidc_windows`, `oidc_web` at all.

## Investigated, not fixed (with reasoning)

**`oidc`: "2 checked-in files are modified in git" warning — Windows-local artifact, not a real CI issue.**

On this Windows machine, `melos bootstrap` (`flutter pub get`) regenerates `packages/oidc/example/linux/flutter/generated_plugins.cmake` and `packages/oidc/example/windows/flutter/generated_plugins.cmake` with CRLF line endings, while the checked-in blobs are LF (repo has no `.gitattributes`; local `core.autocrlf=true`). `git diff --ignore-all-space` between the "modified" and checked-in versions is **empty** — zero content difference, whitespace-only. Re-ran the entire sequence in a clone with `core.autocrlf=false` (matching how `ubuntu-latest` — CI's actual runner — checks out and writes files): `git status` stays clean after bootstrap + versioning, and `oidc`'s dry-run comes back with **0 warnings**. This is not a repo defect; no code change addresses it, so it's left as-is. Flagging here per the "report new warning classes before choosing a fix" instruction, even though the conclusion is "no fix needed."

**Non-blocking hints — left as instructed.** 4 packages get a `hint` (not a warning, doesn't affect exit code): `jose_plus`, `oidc_linux`, `oidc_web`, `oidc_windows` all report *"The previous version is X. It seems you are not publishing an incremental update."* This is pub.dev correctly noticing that the actual latest **published** version for each of these is several releases behind what's now computed locally (e.g. `jose_plus`'s local version jumps to 0.6.0 while pub.dev's latest is still 0.4.7) — expected for a repo that bumps versions on every commit but publishes in batches. `dart pub publish --dry-run` exits 0 with hints present; verified empirically (see evidence below), so these don't block anything and require no fix.

## Evidence

### Per-package inventory (post `melos version --yes --no-git-tag-version`, i.e. CI's exact starting state for the dry-run step)

| Package | Before (warnings / errors / hints) | Before exit | After (warnings / errors / hints) | After exit |
|---|---|---|---|---|
| crypto_keys_plus | 0 / 0 / 0 | 0 | 0 / 0 / 0 | 0 |
| jose_plus | 0 / 0 / 1 hint | 0 | 0 / 0 / 1 hint | 0 |
| x509_plus | 0 / 0 / 0 | 0 | 0 / 0 / 0 | 0 |
| oidc | 0 / 0 / 0 (Linux) † | 0 † | 0 / 0 / 0 | 0 |
| oidc_android | 0 / 0 / 0 | 0 | 0 / 0 / 0 | 0 |
| oidc_cli | 0 / 0 / 0 | 0 | 0 / 0 / 0 | 0 |
| oidc_core | 0 / 0 / 0 | 0 | 0 / 0 / 0 | 0 |
| oidc_darwin | 0 / 0 / 0 | 0 | 0 / 0 / 0 | 0 |
| oidc_default_store | 0 / 0 / 0 | 0 | 0 / 0 / 0 | 0 |
| oidc_desktop | 0 / 0 / 0 | 0 | 0 / 0 / 0 | 0 |
| oidc_linux | 0 / 0 / 1 hint | 0 | 0 / 0 / 1 hint | 0 |
| oidc_loopback_listener | 0 / 0 / 0 | 0 | 0 / 0 / 0 | 0 |
| **oidc_platform_interface** | **0 / 1 ERROR / 0** | **65** | **0 / 0 / 0** | **0** |
| oidc_web | 0 / 0 / 1 hint | 0 | 0 / 0 / 1 hint | 0 |
| oidc_web_core | 0 / 0 / 0 | 0 | 0 / 0 / 0 | 0 |
| oidc_windows | 0 / 0 / 1 hint | 0 | 0 / 0 / 1 hint | 0 |

† On Windows with default `core.autocrlf=true`, `oidc` shows a 1-warning/exit-65 result caused by the CRLF artifact described above (identical before and after this PR — this PR doesn't touch `oidc`). With `core.autocrlf=false` (matching CI's Linux runner), it's 0/0/0 both before and after, as shown.

### End-to-end: `melos publish -y --dry-run` (the exact CI command)

**Before** (pristine `origin/main` @ `2145a9b`, post-versioning):
```
$ melos exec
  └> dart pub publish --dry-run
     └> FAILED (in 1 packages)
        └> oidc_platform_interface (with exit code 65)
     └> CANCELED (in 5 packages)
        └> oidc_darwin (due to failFast)
        └> oidc_linux (due to failFast)
        └> oidc (due to failFast)
        └> oidc_cli (due to failFast)
        └> oidc_default_store (due to failFast)
```
(matches the real CI failure in run 28655492705 exactly)

**After** (this branch, `core.autocrlf=false` clone, post-versioning):
```
$ melos exec
  └> dart pub publish --dry-run
     └> SUCCESS

All packages were validated successfully.
```
Exit code: `0`.

### Baselines

- `melos run analyze` (workspace-wide `dart analyze`): `SUCCESS` across all packages — only pre-existing `info`-level lints, unrelated to this diff, unchanged. `oidc_platform_interface` itself: "No issues found!"
- `flutter test` in `oidc_platform_interface` (the only package whose `pubspec.yaml` this PR touches): `8 passed`, unchanged before → after.

**Do not merge before independent review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoZeDcHumT38zpaTic62Rb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to include a new support library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->