### PR TITLE
ci(tests): fix web conformance by pinning --web-port 22433

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -356,18 +356,18 @@ jobs:
       matrix:
         working-directory: ["packages/oidc/example"]
     runs-on: ubuntu-latest
-    # The OIDC Conformance Test (live IdP redirect flow) hangs on web until
-    # Playwright's own 10-minute per-test timeout kills it -- not an
-    # assertion failure, a genuine timeout (see #337 for the full diagnosis:
-    # the redirect URI is hardcoded to localhost:22433, but the web job never
-    # pins --web-port, so the app boots on a random port and the IdP's
-    # redirect can never land back on it; unlike android/iOS/macOS there's no
-    # web-side flowTimeoutSeconds equivalent to fail fast instead). Excluded
-    # below via `--exclude-tags conformance` (and by not supplying
-    # OIDC_CONFORMANCE_TOKEN, so patrol_test/app_test.dart runs its
-    # token-less smoke test instead) so this job is genuinely green rather
-    # than continue-on-error-masked red. Conformance still gates on
-    # android/iOS/macOS/linux/windows.
+    # Root cause of past web-job flakiness (see #337): the OIDC redirect URI
+    # is hardcoded to localhost:22433 (integration_test/helpers.dart:11), but
+    # this job never pinned --web-port, so Flutter's web server bound to a
+    # random port. The IdP's redirect could never land back on the app's own
+    # origin, so OidcWebCore's response Completer never resolved -- the
+    # conformance test just hung until Playwright's 10-minute per-test
+    # timeout killed it (Total:1/Successful:0/Failed:0, not an assertion
+    # failure). Fixed below by pinning --web-port 22433 to match; confirmed
+    # green with conformance actually executing in run 28666114227 (web job:
+    # "OIDC Conformance Test" passed in 31s). continue-on-error stays on as a
+    # safety net (this is a live third-party IdP dependency), but the job is
+    # expected to be green now, not masked-red.
     continue-on-error: true
     # Patrol web runs through Playwright (patrol_cli activation + npx playwright
     # install + the web build + the live conformance flow); 30 min is headroom.
@@ -392,6 +392,8 @@ jobs:
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Run Web Integration Tests (Patrol + Playwright)
         working-directory: ${{ matrix.working-directory }}
+        env:
+          OIDC_CONFORMANCE_TOKEN: ${{ secrets.OIDC_CONFORMANCE_TOKEN }}
         run: |
           export PATH="$PATH:$HOME/.pub-cache/bin"
           # Patrol serves the Flutter web app and drives Chromium via Playwright
@@ -402,14 +404,13 @@ jobs:
           # an lcov into ./coverage. Only patrol_test/app_test.dart is targeted
           # (the offline entrypoint imports dart:io, unavailable on web).
           #
-          # OIDC_CONFORMANCE_TOKEN is intentionally NOT passed here: without it,
-          # app_test.dart registers its token-less smoke test instead of the
-          # (currently hanging on web -- see #337) OIDC Conformance Test.
-          # --exclude-tags conformance is redundant belt-and-suspenders for the
-          # same exclusion, forwarded by patrol_cli_plus as PATROL_WEB_GREP_INVERT.
+          # --web-port 22433 pins the Flutter web server to the same port the
+          # OIDC redirect URI is hardcoded to (integration_test/helpers.dart:11),
+          # so the IdP's redirect actually lands back on this app's origin. See
+          # #337 for the full diagnosis of the hang this fixes.
           patrol_plus test \
             --target patrol_test/app_test.dart \
-            --exclude-tags conformance \
+            --web-port 22433 \
             --coverage \
             --coverage-ignore="**/*.g.dart" \
             --coverage-package oidc \
@@ -417,7 +418,8 @@ jobs:
             --web-headless true \
             --web-workers 1 \
             --verbose \
-            --dart-define=CI=true
+            --dart-define=CI=true \
+            --dart-define=OIDC_CONFORMANCE_TOKEN=$OIDC_CONFORMANCE_TOKEN
           # Best-effort: web V8->lcov path differs from native; don't fail the
           # job if the file isn't produced.
           cp coverage/patrol_lcov.info coverage/web-coverage.info || \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -356,10 +356,18 @@ jobs:
       matrix:
         working-directory: ["packages/oidc/example"]
     runs-on: ubuntu-latest
-    # Patrol web-runner double-initializes Flutter's engine on 3.44 ("Bad state:
-    # initializeEngineServices already started"). Root cause is in the fork's
-    # web_runner setup.ts $dartRunMain handling, not the test-tree polling.
-    # Conformance gates on android/iOS/macOS/linux/windows meanwhile.
+    # The OIDC Conformance Test (live IdP redirect flow) hangs on web until
+    # Playwright's own 10-minute per-test timeout kills it -- not an
+    # assertion failure, a genuine timeout (see #337 for the full diagnosis:
+    # the redirect URI is hardcoded to localhost:22433, but the web job never
+    # pins --web-port, so the app boots on a random port and the IdP's
+    # redirect can never land back on it; unlike android/iOS/macOS there's no
+    # web-side flowTimeoutSeconds equivalent to fail fast instead). Excluded
+    # below via `--exclude-tags conformance` (and by not supplying
+    # OIDC_CONFORMANCE_TOKEN, so patrol_test/app_test.dart runs its
+    # token-less smoke test instead) so this job is genuinely green rather
+    # than continue-on-error-masked red. Conformance still gates on
+    # android/iOS/macOS/linux/windows.
     continue-on-error: true
     # Patrol web runs through Playwright (patrol_cli activation + npx playwright
     # install + the web build + the live conformance flow); 30 min is headroom.
@@ -384,8 +392,6 @@ jobs:
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Run Web Integration Tests (Patrol + Playwright)
         working-directory: ${{ matrix.working-directory }}
-        env:
-          OIDC_CONFORMANCE_TOKEN: ${{ secrets.OIDC_CONFORMANCE_TOKEN }}
         run: |
           export PATH="$PATH:$HOME/.pub-cache/bin"
           # Patrol serves the Flutter web app and drives Chromium via Playwright
@@ -395,8 +401,15 @@ jobs:
           # On web, --coverage collects V8/JS coverage via Playwright and emits
           # an lcov into ./coverage. Only patrol_test/app_test.dart is targeted
           # (the offline entrypoint imports dart:io, unavailable on web).
+          #
+          # OIDC_CONFORMANCE_TOKEN is intentionally NOT passed here: without it,
+          # app_test.dart registers its token-less smoke test instead of the
+          # (currently hanging on web -- see #337) OIDC Conformance Test.
+          # --exclude-tags conformance is redundant belt-and-suspenders for the
+          # same exclusion, forwarded by patrol_cli_plus as PATROL_WEB_GREP_INVERT.
           patrol_plus test \
             --target patrol_test/app_test.dart \
+            --exclude-tags conformance \
             --coverage \
             --coverage-ignore="**/*.g.dart" \
             --coverage-package oidc \
@@ -404,8 +417,7 @@ jobs:
             --web-headless true \
             --web-workers 1 \
             --verbose \
-            --dart-define=CI=true \
-            --dart-define=OIDC_CONFORMANCE_TOKEN=$OIDC_CONFORMANCE_TOKEN
+            --dart-define=CI=true
           # Best-effort: web V8->lcov path differs from native; don't fail the
           # job if the file isn't produced.
           cp coverage/patrol_lcov.info coverage/web-coverage.info || \

--- a/packages/oidc/example/patrol_test/app_test.dart
+++ b/packages/oidc/example/patrol_test/app_test.dart
@@ -50,7 +50,11 @@ void main() {
       await runManagerSmokeTest(() => _launch($));
     });
   } else {
-    patrolTest('OIDC Conformance Test', ($) async {
+    // Tagged so CI can exclude it selectively (currently only the web job
+    // does, via `--exclude-tags conformance`; see tests.yaml and
+    // https://github.com/Bdaya-Dev/oidc/issues/337 — the live IdP redirect
+    // flow hangs on web until Playwright's per-test timeout kills it).
+    patrolTest('OIDC Conformance Test', tags: const ['conformance'], ($) async {
       await runOidcConformanceTest(() => _launch($));
     });
   }

--- a/packages/oidc/example/patrol_test/app_test.dart
+++ b/packages/oidc/example/patrol_test/app_test.dart
@@ -50,11 +50,7 @@ void main() {
       await runManagerSmokeTest(() => _launch($));
     });
   } else {
-    // Tagged so CI can exclude it selectively (currently only the web job
-    // does, via `--exclude-tags conformance`; see tests.yaml and
-    // https://github.com/Bdaya-Dev/oidc/issues/337 — the live IdP redirect
-    // flow hangs on web until Playwright's per-test timeout kills it).
-    patrolTest('OIDC Conformance Test', tags: const ['conformance'], ($) async {
+    patrolTest('OIDC Conformance Test', ($) async {
       await runOidcConformanceTest(() => _launch($));
     });
   }


### PR DESCRIPTION
Fixes #337.

The web job's conformance test hung until Playwright's 10-minute per-test timeout: the OIDC redirect URI is hardcoded to `localhost:22433` (`integration_test/helpers.dart:11`), but the web server bound a random port, so the IdP redirect never landed back on the app's origin and the response `Completer` never resolved.

Pins `--web-port 22433` on the web job's `patrol_plus test` invocation. Web job: 10m timeout → ~3m pass.
