### PR TITLE
feat(oidc_web_core): encrypt secureTokens at rest (AES-GCM via WebCrypto) (#324 item 15)

### DIFF
--- a/packages/oidc_web/pubspec.yaml
+++ b/packages/oidc_web/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
 
   oidc_core: ^0.16.1+1
   oidc_platform_interface: ^0.7.0+3
-  oidc_web_core: ^0.4.0+3
+  oidc_web_core: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/oidc_web_core/CHANGELOG.md
+++ b/packages/oidc_web_core/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 0.5.0
+
+- **FEAT**: encrypt the `secureTokens` namespace (access/refresh/id tokens,
+  the OIDC nonce) at rest in `OidcWebStore`. AES-GCM via WebCrypto, with a
+  non-extractable 256-bit key persisted (as a structured-clone `CryptoKey`
+  object, never its raw bytes) in IndexedDB and a fresh random IV per write.
+  Values are stored as a versioned `oidcenc.v1.<iv>.<ciphertext>` envelope.
+  This is **defense-in-depth against disk/backup scraping and casual
+  inspection -- it is NOT protection against XSS**: same-origin script can
+  still call `crypto.subtle.decrypt` or simply read decrypted tokens back
+  out through the `OidcStore` API. Harden against XSS itself (CSP, trusted
+  types, dependency hygiene) and prefer a BFF for high-value applications.
+  (audit #324 item 15)
+  - No new required settings: `const OidcWebStore()` still works, and
+    encryption is on by default (`OidcWebStoreEncryption.preferred`).
+  - Values written before this feature (or written by the `preferred`
+    fallback) are read through transparently and re-encrypted on next write
+    -- no forced re-login. This migration is **forward-only**: downgrading
+    to a version predating this feature will see encrypted values as opaque
+    strings.
+  - If WebCrypto/IndexedDB are unavailable (a non-secure-context origin, or
+    IndexedDB disabled/ephemeral in some private-browsing modes), the
+    default `preferred` mode falls back to the previous plaintext behavior
+    with a one-shot warning; pass `encryption: OidcWebStoreEncryption.required`
+    to throw an `OidcException` instead of ever writing plaintext.
+  - No new dependencies: WebCrypto and IndexedDB are both already exposed by
+    `package:web`.
+
 ## 0.4.0+3
 
  - **DOCS**: remove logo branding from screenshots. ([2acf65d3](https://github.com/Bdaya-Dev/oidc/commit/2acf65d34fb47c0449653a73373168df3deb1735))

--- a/packages/oidc_web_core/lib/src/oidc_web_crypto.dart
+++ b/packages/oidc_web_core/lib/src/oidc_web_crypto.dart
@@ -1,0 +1,357 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+import 'package:web/web.dart' as web;
+
+// coverage:ignore-line
+final _logger = Logger('Oidc.WebStore.Crypto');
+
+/// The literal prefix (scheme + version) that identifies an
+/// [OidcWebCrypto]-encrypted envelope, as opposed to a legacy plaintext
+/// value.
+///
+/// See the `oidc_web_core` design proposal for audit #324 item 15:
+/// `oidcenc.<version>.<iv-b64url>.<ciphertext-b64url>`.
+const oidcWebCryptoEnvelopePrefixV1 = 'oidcenc.v1.';
+
+const _dbName = 'oidc_web_core';
+const _cryptoKeysStoreName = 'crypto_keys';
+const _algorithmName = 'AES-GCM';
+const _keyLengthBits = 256;
+const _ivLengthBytes = 12;
+
+/// AES-GCM key-generation parameters.
+///
+/// `package:web` doesn't model WebCrypto's algorithm-specific dictionaries
+/// (there is no generated `AesKeyGenParams`), so this mirrors the pattern
+/// already used by the same package's own generated dictionaries (e.g.
+/// `JsonWebKey`, `RsaOtherPrimesInfo` in `webcryptoapi.dart`): a tiny
+/// `extension type` with an `external factory` to build the JS object
+/// literal `crypto.subtle.generateKey` expects.
+extension type _AesKeyGenParams._(JSObject _) implements JSObject {
+  external factory _AesKeyGenParams({String name, int length});
+}
+
+/// AES-GCM encrypt/decrypt parameters (`{name, iv}`). See [_AesKeyGenParams].
+extension type _AesGcmParams._(JSObject _) implements JSObject {
+  external factory _AesGcmParams({String name, JSUint8Array iv});
+}
+
+/// A decoded `oidcenc.v1.` envelope: the random IV used for the write, and
+/// the AES-GCM ciphertext (which already includes the appended auth tag).
+class _DecodedEnvelope {
+  const _DecodedEnvelope(this.iv, this.ciphertext);
+
+  final Uint8List iv;
+  final Uint8List ciphertext;
+}
+
+/// {@template oidc_web_crypto}
+/// Implements at-rest encryption for the `secureTokens` namespace of
+/// `OidcWebStore`, per audit #324 item 15's design proposal:
+///
+/// - a non-extractable AES-GCM 256-bit `CryptoKey`, generated once per
+///   `storagePrefix` and persisted as a structured-clone `CryptoKey` object
+///   (never its raw bytes) in an IndexedDB object store;
+/// - a versioned envelope, `oidcenc.v1.<iv-b64url>.<ciphertext-b64url>`, with
+///   a fresh random 12-byte IV per write;
+/// - loud, once-per-prefix logging (never a silent downgrade) when
+///   WebCrypto/IndexedDB are unavailable.
+///
+/// **Threat model (read this before assuming more than it provides):**
+/// this raises the bar against disk/backup scraping and casual inspection
+/// (e.g. DevTools, a copied browser profile). It is **not** protection
+/// against XSS: a script running in the page's own origin can call the same
+/// `crypto.subtle.decrypt` (or just read decrypted values back out of
+/// `OidcStore`) that this code does. A non-extractable key stops the raw key
+/// bytes from ever leaving the browser, but does not stop `decrypt()` calls
+/// made by same-origin script. Harden against XSS itself (CSP, trusted
+/// types, dependency hygiene) and prefer a BFF for high-value applications.
+///
+/// This class is intentionally **not** exported from `package:oidc_web_core`
+/// -- it's an internal implementation detail of `OidcWebStore`, reachable
+/// from tests via its `lib/src/` import path only.
+/// {@endtemplate}
+class OidcWebCrypto {
+  const OidcWebCrypto._();
+
+  /// Set (only) by tests to force the "WebCrypto/IndexedDB unavailable"
+  /// fallback path.
+  ///
+  /// There is no supported way to make a real headless-browser test runner
+  /// (which DOES expose `window.crypto.subtle` and `window.indexedDB` on a
+  /// secure `http://localhost` context) actually lack these APIs: both are
+  /// non-configurable accessors on the real `Window`/`Crypto` prototypes, so
+  /// they can't be deleted or stubbed out from Dart via js-interop. This
+  /// boolean escape hatch mirrors `OidcDefaultStore.testIsWeb` and is the
+  /// only implementable version of the two testing seams the design
+  /// proposal offered for this branch.
+  @visibleForTesting
+  static bool debugForceUnavailable = false;
+
+  static final Map<String, Future<web.CryptoKey?>> _keyFutures = {};
+
+  static final Set<String> _warnedRecordKeys = {};
+
+  /// Clears all memoized keys/flags. Call from `setUp`/`tearDown` between
+  /// tests that exercise [debugForceUnavailable] or rely on a fresh
+  /// warn-once state, so one test can't leak state into the next.
+  @visibleForTesting
+  static void debugReset() {
+    _keyFutures.clear();
+    _warnedRecordKeys.clear();
+    debugForceUnavailable = false;
+  }
+
+  /// True if [raw] looks like an [oidcWebCryptoEnvelopePrefixV1] envelope
+  /// produced by [encrypt], as opposed to a legacy (or fallback-written)
+  /// plaintext value.
+  ///
+  /// A real token/JSON value can never collide with this prefix (JWTs start
+  /// with `eyJ`, JSON starts with `{`), and even a false positive is safe:
+  /// [decryptEnvelope] treats anything it can't decrypt as a miss rather
+  /// than throwing or returning corrupted data.
+  static bool isEncryptedEnvelope(String raw) =>
+      raw.startsWith(oidcWebCryptoEnvelopePrefixV1);
+
+  /// Best-effort warm-up of the encryption key for [recordKey] (normally the
+  /// store's `storagePrefix`), so the first real `getMany`/`setMany` call
+  /// doesn't pay the IndexedDB round trip. Never throws: unavailability is
+  /// surfaced lazily by [encrypt]/[decryptEnvelope] returning `null`.
+  static Future<void> warmUpKey(String recordKey) async {
+    await _ensureKey(recordKey);
+  }
+
+  /// Encrypts [plaintext] under the key for [recordKey] and returns the
+  /// encoded `oidcenc.v1.` envelope, or `null` if WebCrypto/IndexedDB are
+  /// unavailable or the operation otherwise failed. Never throws.
+  static Future<String?> encrypt(
+    String plaintext, {
+    required String recordKey,
+  }) async {
+    final key = await _ensureKey(recordKey);
+    if (key == null) {
+      return null;
+    }
+    try {
+      final iv = _randomIv();
+      final plaintextBytes = Uint8List.fromList(utf8.encode(plaintext)).toJS;
+      final cipherResult = await web.window.crypto.subtle
+          .encrypt(
+            _AesGcmParams(name: _algorithmName, iv: iv.toJS),
+            key,
+            plaintextBytes,
+          )
+          .toDart;
+      final cipherBytes = (cipherResult! as JSArrayBuffer).toDart.asUint8List();
+      return '$oidcWebCryptoEnvelopePrefixV1'
+          '${base64Url.encode(iv)}.${base64Url.encode(cipherBytes)}';
+    } catch (e, st) {
+      _logger.warning(
+        'OidcWebStore: failed to encrypt a secureTokens value even though '
+        'the encryption key was available; treating as unavailable for this '
+        'write.',
+        e,
+        st,
+      );
+      return null;
+    }
+  }
+
+  /// Decrypts an [envelope] (an [isEncryptedEnvelope]-true string) under the
+  /// key for [recordKey]. Returns `null` (a miss, never a throw) if the
+  /// envelope is malformed, the key is unavailable, or decryption fails
+  /// (wrong/rotated key, corrupted data -- the GCM auth tag mismatches).
+  static Future<String?> decryptEnvelope(
+    String envelope, {
+    required String recordKey,
+  }) async {
+    final decoded = _tryDecodeEnvelope(envelope);
+    if (decoded == null) {
+      return null;
+    }
+    final key = await _ensureKey(recordKey);
+    if (key == null) {
+      return null;
+    }
+    try {
+      final plainResult = await web.window.crypto.subtle
+          .decrypt(
+            _AesGcmParams(name: _algorithmName, iv: decoded.iv.toJS),
+            key,
+            decoded.ciphertext.toJS,
+          )
+          .toDart;
+      final plainBytes = (plainResult! as JSArrayBuffer).toDart.asUint8List();
+      return utf8.decode(plainBytes);
+    } catch (e, st) {
+      _logger.fine(
+        'OidcWebStore: failed to decrypt a secureTokens envelope (bad tag, '
+        'rotated/evicted key, or corrupt data); treating it as a miss '
+        'rather than throwing.',
+        e,
+        st,
+      );
+      return null;
+    }
+  }
+
+  /// Logs (once per [recordKey]) that `secureTokens` is being persisted
+  /// UNENCRYPTED because WebCrypto/IndexedDB were unavailable, mirroring
+  /// `OidcDefaultStore`'s `_warnInsecureSecureTokensFallback`.
+  static void warnInsecureFallbackOnce(String recordKey) {
+    if (!_warnedRecordKeys.add(recordKey)) {
+      return;
+    }
+    _logger.warning(
+      'OidcWebStore: WebCrypto/IndexedDB unavailable -- secureTokens '
+      '(access/refresh/id tokens and the OIDC nonce, storagePrefix '
+      '"$recordKey") is persisted UNENCRYPTED in localStorage. This can '
+      'happen on a non-secure-context (plain http://) origin, or when '
+      'IndexedDB is disabled/ephemeral (some private-browsing modes). '
+      'Encryption at rest is defense-in-depth against disk/backup scraping, '
+      'not XSS protection either way -- harden against XSS (CSP, trusted '
+      'types) and prefer a BFF for high-value applications.',
+    );
+  }
+
+  static Future<web.CryptoKey?> _ensureKey(String recordKey) {
+    // `Map.putIfAbsent` synchronously reserves the entry on first call, so
+    // concurrent callers in the same event-loop turn all await the SAME
+    // future instead of racing separate `generateKey`/`put` calls. This is
+    // a dependency-free equivalent of `AsyncMemoizer` (the design proposal's
+    // suggested mirror of `OidcDefaultStore`) -- `package:async` isn't a
+    // dependency of `oidc_web_core`, and the proposal explicitly promises no
+    // new dependencies for this feature.
+    return _keyFutures.putIfAbsent(
+      recordKey,
+      () => _loadOrCreateKey(recordKey),
+    );
+  }
+
+  static Future<web.CryptoKey?> _loadOrCreateKey(String recordKey) async {
+    if (debugForceUnavailable) {
+      return null;
+    }
+    try {
+      final db = await _openDatabase();
+      try {
+        final store = db
+            .transaction(_cryptoKeysStoreName.toJS, 'readwrite')
+            .objectStore(_cryptoKeysStoreName);
+        final existing = await _requestResult(store.get(recordKey.toJS));
+        if (existing != null) {
+          await _requestPersistBestEffort();
+          return existing as web.CryptoKey;
+        }
+        final generated = await _generateKey();
+        await _requestResult(store.put(generated, recordKey.toJS));
+        await _requestPersistBestEffort();
+        return generated;
+      } finally {
+        db.close();
+      }
+    } catch (e, st) {
+      _logger.warning(
+        'OidcWebStore: WebCrypto/IndexedDB are unavailable while acquiring '
+        'the secureTokens encryption key for storagePrefix "$recordKey".',
+        e,
+        st,
+      );
+      return null;
+    }
+  }
+
+  static Future<web.CryptoKey> _generateKey() async {
+    final result = await web.window.crypto.subtle
+        .generateKey(
+          _AesKeyGenParams(name: _algorithmName, length: _keyLengthBits),
+          // extractable: false -- the raw key bytes can never be exported
+          // back out to JS via exportKey()/wrapKey(). This is the crux of
+          // the design: even a full-origin XSS that calls decrypt() can't
+          // exfiltrate the key material itself for offline use.
+          false,
+          <JSString>['encrypt'.toJS, 'decrypt'.toJS].toJS,
+        )
+        .toDart;
+    return result! as web.CryptoKey;
+  }
+
+  static Future<web.IDBDatabase> _openDatabase() {
+    final completer = Completer<web.IDBDatabase>();
+    late final web.IDBOpenDBRequest request;
+    request = web.window.indexedDB.open(_dbName, 1)
+      ..onupgradeneeded = ((web.Event _) {
+        final db = request.result! as web.IDBDatabase;
+        if (!db.objectStoreNames.contains(_cryptoKeysStoreName)) {
+          db.createObjectStore(_cryptoKeysStoreName);
+        }
+      }).toJS
+      ..onsuccess = ((web.Event _) {
+        completer.complete(request.result! as web.IDBDatabase);
+      }).toJS
+      ..onerror = ((web.Event _) {
+        completer.completeError(
+          request.error ?? StateError('Failed to open IndexedDB "$_dbName"'),
+        );
+      }).toJS;
+    return completer.future;
+  }
+
+  static Future<JSAny?> _requestResult(web.IDBRequest request) {
+    final completer = Completer<JSAny?>();
+    request
+      ..onsuccess = ((web.Event _) {
+        completer.complete(request.result);
+      }).toJS
+      ..onerror = ((web.Event _) {
+        completer.completeError(
+          request.error ?? StateError('IndexedDB request failed'),
+        );
+      }).toJS;
+    return completer.future;
+  }
+
+  /// Best-effort `navigator.storage.persist()` request, so the origin's
+  /// storage (including this key) is less likely to be evicted under
+  /// pressure. Failures here must never fail key acquisition -- this is
+  /// pure hardening, not a correctness requirement (see the design
+  /// proposal's persistence/eviction trade-off section).
+  static Future<void> _requestPersistBestEffort() async {
+    try {
+      await web.window.navigator.storage.persist().toDart;
+    } catch (_) {
+      // Not all browsers/contexts implement the Storage Manager API; a
+      // failure here just means we didn't get the (best-effort) hardening.
+    }
+  }
+
+  static Uint8List _randomIv() {
+    final jsBytes = Uint8List(_ivLengthBytes).toJS;
+    web.window.crypto.getRandomValues(jsBytes);
+    return jsBytes.toDart;
+  }
+
+  static _DecodedEnvelope? _tryDecodeEnvelope(String raw) {
+    if (!raw.startsWith(oidcWebCryptoEnvelopePrefixV1)) {
+      return null;
+    }
+    final rest = raw.substring(oidcWebCryptoEnvelopePrefixV1.length);
+    final parts = rest.split('.');
+    if (parts.length != 2) {
+      return null;
+    }
+    try {
+      return _DecodedEnvelope(
+        base64Url.decode(parts[0]),
+        base64Url.decode(parts[1]),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/packages/oidc_web_core/lib/src/oidc_web_store.dart
+++ b/packages/oidc_web_core/lib/src/oidc_web_store.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:oidc_core/oidc_core.dart';
+import 'package:oidc_web_core/src/oidc_web_crypto.dart';
 import 'package:web/web.dart';
 
 /// where to store the values when using the [OidcStoreNamespace.session] namespace.
@@ -12,8 +13,60 @@ enum OidcWebStoreSessionManagementLocation {
   localStorage,
 }
 
+/// controls how [OidcWebStore] handles encrypting the
+/// [OidcStoreNamespace.secureTokens] namespace at rest.
+///
+/// See [OidcWebStore] for the full threat model: this is defense-in-depth
+/// against disk/backup scraping and casual inspection, **not** protection
+/// against XSS.
+enum OidcWebStoreEncryption {
+  /// Encrypt `secureTokens` (AES-GCM via WebCrypto, key in IndexedDB) when
+  /// possible.
+  ///
+  /// If WebCrypto or IndexedDB are unavailable (a non-secure-context origin,
+  /// or IndexedDB disabled/ephemeral in some private-browsing modes), falls
+  /// back to the previous plaintext-in-`localStorage` behavior, logging a
+  /// one-shot warning naming exactly what is insecure and why. This is the
+  /// default, and preserves backward compatibility: the package keeps
+  /// working in every context it worked in before.
+  preferred,
+
+  /// Encrypt `secureTokens`, or throw an [OidcException] instead of ever
+  /// writing plaintext.
+  ///
+  /// Opt-in, for deployments that would rather fail loudly than persist an
+  /// unencrypted token.
+  required,
+}
+
 /// {@template oidc_web_store}
 /// an implementation of OidcStore for web that doesn't depend on flutter
+///
+/// ## Encryption at rest (`secureTokens`)
+///
+/// The [OidcStoreNamespace.secureTokens] namespace (access/refresh/id
+/// tokens and the OIDC nonce) is encrypted at rest by default: AES-GCM via
+/// WebCrypto, with a non-extractable key persisted in IndexedDB and a fresh
+/// random IV per write. See [OidcWebStoreEncryption] to opt into a hard
+/// failure instead of the default plaintext fallback when WebCrypto/
+/// IndexedDB are unavailable.
+///
+/// **This is defense-in-depth against disk/backup scraping and casual
+/// inspection (e.g. DevTools, a copied browser profile) -- it is NOT
+/// protection against XSS.** A script running in this page's own origin can
+/// call the exact same `crypto.subtle.decrypt`, or more simply just read
+/// tokens back out through the `OidcStore` API after this code decrypts
+/// them; a non-extractable key stops the raw key bytes from ever leaving
+/// the browser, but doesn't stop same-origin `decrypt()` calls. Harden
+/// against XSS itself (CSP, trusted types, dependency hygiene) and prefer a
+/// BFF (tokens behind HttpOnly cookies) for high-value applications.
+///
+/// Values written before this feature existed (or written by the
+/// [OidcWebStoreEncryption.preferred] fallback) are read back correctly:
+/// [getMany] transparently reads through legacy plaintext, and the next
+/// [setMany] for that key re-writes it encrypted. This migration is
+/// forward-only: downgrading to an `oidc_web_core` version predating this
+/// feature will see encrypted values as opaque strings.
 /// {@endtemplate}
 class OidcWebStore implements OidcStore {
   /// {@macro oidc_web_store}
@@ -23,6 +76,7 @@ class OidcWebStore implements OidcStore {
     this.storagePrefix = 'oidc',
     this.webSessionManagementLocation =
         OidcWebStoreSessionManagementLocation.sessionStorage,
+    this.encryption = OidcWebStoreEncryption.preferred,
   });
 
   /// prefix to put before the keys.
@@ -32,6 +86,14 @@ class OidcWebStore implements OidcStore {
 
   /// if true, we use the `sessionStorage` on web for the [OidcStoreNamespace.session] namespace.
   final OidcWebStoreSessionManagementLocation webSessionManagementLocation;
+
+  /// controls how the [OidcStoreNamespace.secureTokens] namespace is
+  /// encrypted at rest. Defaults to [OidcWebStoreEncryption.preferred].
+  final OidcWebStoreEncryption encryption;
+
+  /// the record key used to look up (and, if absent, generate) this store's
+  /// `secureTokens` encryption key in [OidcWebCrypto].
+  String get _cryptoRecordKey => storagePrefix ?? 'oidc';
 
   String _getKey(OidcStoreNamespace namespace, String key, String? managerId) {
     return [storagePrefix, managerId, namespace.value, key].nonNulls.join('.');
@@ -47,8 +109,12 @@ class OidcWebStore implements OidcStore {
   }
 
   @override
-  Future<void> init() {
-    return Future.value();
+  Future<void> init() async {
+    // Best-effort warm-up of the secureTokens encryption key so the
+    // IndexedDB round trip doesn't land on the first token read/write.
+    // Never throws: unavailability is handled lazily by getMany/setMany
+    // (warn-once + plaintext fallback, or a required hard-fail).
+    await OidcWebCrypto.warmUpKey(_cryptoRecordKey);
   }
 
   Future<void> _registerKeyForNamespace(
@@ -135,6 +201,75 @@ class OidcWebStore implements OidcStore {
     }
   }
 
+  /// [OidcStoreNamespace.secureTokens] read path: reads the raw stored
+  /// strings (same as [_defaultGetMany]), then for each value either
+  /// decrypts it (if it's an [OidcWebCrypto.isEncryptedEnvelope] envelope)
+  /// or reads it through as-is (legacy plaintext, written before this
+  /// feature existed or by the [OidcWebStoreEncryption.preferred] fallback).
+  ///
+  /// A value that fails to decrypt (wrong/rotated key, corrupt data) is
+  /// dropped from the result -- a miss, never a throw.
+  Future<Map<String, String>> _secureGetMany(
+    OidcStoreNamespace namespace,
+    Set<String> keys,
+    String? managerId,
+  ) async {
+    final raw = await _defaultGetMany(namespace, keys, managerId);
+    final result = <String, String>{};
+    for (final entry in raw.entries) {
+      if (OidcWebCrypto.isEncryptedEnvelope(entry.value)) {
+        final plain = await OidcWebCrypto.decryptEnvelope(
+          entry.value,
+          recordKey: _cryptoRecordKey,
+        );
+        if (plain != null) {
+          result[entry.key] = plain;
+        }
+      } else {
+        result[entry.key] = entry.value;
+      }
+    }
+    return result;
+  }
+
+  /// [OidcStoreNamespace.secureTokens] write path: encrypts every value in
+  /// [values] and writes the whole batch as ciphertext envelopes.
+  ///
+  /// If encryption is unavailable (WebCrypto/IndexedDB missing) or fails,
+  /// the batch is written as plaintext instead -- unless [encryption] is
+  /// [OidcWebStoreEncryption.required], in which case nothing is written and
+  /// an [OidcException] is thrown. Either way this is an all-or-nothing
+  /// decision per call: encryption availability is a single memoized
+  /// per-[storagePrefix] outcome, not something that can differ key-by-key
+  /// within one batch.
+  Future<void> _secureSetMany(
+    OidcStoreNamespace namespace,
+    Map<String, String> values,
+    String? managerId,
+  ) async {
+    final encrypted = <String, String>{};
+    for (final entry in values.entries) {
+      final envelope = await OidcWebCrypto.encrypt(
+        entry.value,
+        recordKey: _cryptoRecordKey,
+      );
+      if (envelope == null) {
+        if (encryption == OidcWebStoreEncryption.required) {
+          throw OidcException(
+            'OidcWebStore: secureTokens encryption is required '
+            '(OidcWebStoreEncryption.required) but WebCrypto/IndexedDB are '
+            'unavailable for storagePrefix "$_cryptoRecordKey".',
+          );
+        }
+        OidcWebCrypto.warnInsecureFallbackOnce(_cryptoRecordKey);
+        _defaultSetMany(namespace, values, managerId);
+        return;
+      }
+      encrypted[entry.key] = envelope;
+    }
+    _defaultSetMany(namespace, encrypted, managerId);
+  }
+
   @override
   Future<Map<String, String>> getMany(
     OidcStoreNamespace namespace, {
@@ -143,8 +278,7 @@ class OidcWebStore implements OidcStore {
   }) async {
     switch (namespace) {
       case OidcStoreNamespace.secureTokens:
-        //TODO: find a way to secure these tokens
-        return _defaultGetMany(namespace, keys, managerId);
+        return _secureGetMany(namespace, keys, managerId);
       case OidcStoreNamespace.session:
         if (webSessionManagementLocation ==
             OidcWebStoreSessionManagementLocation.sessionStorage) {
@@ -178,8 +312,7 @@ class OidcWebStore implements OidcStore {
 
     switch (namespace) {
       case OidcStoreNamespace.secureTokens:
-        //TODO: find a way to secure these tokens
-        return _defaultSetMany(namespace, values, managerId);
+        return _secureSetMany(namespace, values, managerId);
 
       case OidcStoreNamespace.session:
         if (webSessionManagementLocation ==
@@ -211,7 +344,9 @@ class OidcWebStore implements OidcStore {
     // final mappedKeys = keys.map((e) => _getKey(namespace, e)).toSet();
     switch (namespace) {
       case OidcStoreNamespace.secureTokens:
-        // TODO: find a way to secure these tokens
+        // Encryption is transparent to removal: deleting a key doesn't
+        // depend on whether its stored value is an `oidcenc.v1.` envelope
+        // or legacy plaintext.
         _defaultRemoveMany(namespace, keys, managerId);
 
       case OidcStoreNamespace.session:

--- a/packages/oidc_web_core/pubspec.yaml
+++ b/packages/oidc_web_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: oidc_web_core
 description: dart web package for oidc protocol
-version: 0.4.0+3
+version: 0.5.0
 repository: https://github.com/Bdaya-Dev/oidc/tree/main/packages/oidc_web_core
 topics: ["oidc", "openidconnect", "oauth", "authentication"]
 homepage: https://bdaya-dev.github.io/oidc/
@@ -12,6 +12,7 @@ environment:
 dependencies:
   collection: ^1.18.0
   logging: ^1.2.0
+  meta: ^1.16.0
   oidc_core: ^0.16.1+1
   web: "^1.1.1"
 

--- a/packages/oidc_web_core/test/oidc_web_store_test.dart
+++ b/packages/oidc_web_core/test/oidc_web_store_test.dart
@@ -1,0 +1,244 @@
+@TestOn('js')
+library;
+
+// ignore_for_file: prefer_const_constructors
+
+import 'package:oidc_core/oidc_core.dart';
+import 'package:oidc_web_core/oidc_web_core.dart';
+import 'package:oidc_web_core/src/oidc_web_crypto.dart';
+import 'package:test/test.dart';
+import 'package:web/web.dart' as web;
+
+/// Flips a single character of a base64url segment, keeping it a
+/// well-formed base64url string (so decoding still succeeds) but changing
+/// the underlying bytes -- used to simulate a corrupted/tampered ciphertext
+/// (GCM auth-tag mismatch) rather than a malformed envelope.
+String _tamperBase64Url(String segment) {
+  const alphabet =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+  final chars = segment.split('');
+  final index = chars.lastIndexWhere((c) => c != '=');
+  final current = chars[index];
+  final replacement =
+      alphabet[(alphabet.indexOf(current) + 1) % alphabet.length];
+  chars[index] = replacement;
+  return chars.join();
+}
+
+void main() {
+  setUp(() {
+    web.window.localStorage.clear();
+    OidcWebCrypto.debugReset();
+  });
+
+  group('OidcWebStore secureTokens encryption at rest', () {
+    test('round-trips a value through setMany/getMany', () async {
+      const store = OidcWebStore(storagePrefix: 'roundtrip');
+      await store.init();
+
+      await store.setMany(
+        OidcStoreNamespace.secureTokens,
+        values: {'access_token': 'super-secret-token-value'},
+      );
+      final result = await store.getMany(
+        OidcStoreNamespace.secureTokens,
+        keys: {'access_token'},
+      );
+
+      expect(result['access_token'], 'super-secret-token-value');
+    });
+
+    test(
+      'persists ciphertext (an oidcenc.v1. envelope), not plaintext',
+      () async {
+        const store = OidcWebStore(storagePrefix: 'ciphertext');
+        await store.init();
+        const plaintext = 'super-secret-token-value';
+
+        await store.setMany(
+          OidcStoreNamespace.secureTokens,
+          values: {'access_token': plaintext},
+        );
+
+        final raw = web.window.localStorage.getItem(
+          'ciphertext.secureTokens.access_token',
+        );
+        expect(raw, isNotNull);
+        expect(raw, startsWith(oidcWebCryptoEnvelopePrefixV1));
+        expect(raw, isNot(contains(plaintext)));
+      },
+    );
+
+    test('uses a fresh random IV per write', () async {
+      const store = OidcWebStore(storagePrefix: 'ivunique');
+      await store.init();
+      const rawKey = 'ivunique.secureTokens.k';
+
+      await store.setMany(
+        OidcStoreNamespace.secureTokens,
+        values: {'k': 'same-value'},
+      );
+      final first = web.window.localStorage.getItem(rawKey);
+
+      await store.setMany(
+        OidcStoreNamespace.secureTokens,
+        values: {'k': 'same-value'},
+      );
+      final second = web.window.localStorage.getItem(rawKey);
+
+      expect(first, isNotNull);
+      expect(second, isNotNull);
+      // Same plaintext, same key -> different envelopes (different IVs).
+      expect(first, isNot(equals(second)));
+
+      final result = await store.getMany(
+        OidcStoreNamespace.secureTokens,
+        keys: {'k'},
+      );
+      expect(result['k'], 'same-value');
+    });
+
+    test('reads a legacy plaintext value through, then upgrades it to an '
+        'envelope on the next write', () async {
+      const store = OidcWebStore(storagePrefix: 'legacy');
+      await store.init();
+      const rawKey = 'legacy.secureTokens.refresh_token';
+
+      // Simulate a value written before this feature existed.
+      web.window.localStorage.setItem(rawKey, 'legacy-plaintext-value');
+
+      final readBefore = await store.getMany(
+        OidcStoreNamespace.secureTokens,
+        keys: {'refresh_token'},
+      );
+      expect(readBefore['refresh_token'], 'legacy-plaintext-value');
+      // Reading doesn't rewrite -- still plaintext on disk.
+      expect(web.window.localStorage.getItem(rawKey), 'legacy-plaintext-value');
+
+      await store.setMany(
+        OidcStoreNamespace.secureTokens,
+        values: {'refresh_token': 'legacy-plaintext-value'},
+      );
+
+      final rawAfter = web.window.localStorage.getItem(rawKey);
+      expect(rawAfter, startsWith(oidcWebCryptoEnvelopePrefixV1));
+
+      final readAfter = await store.getMany(
+        OidcStoreNamespace.secureTokens,
+        keys: {'refresh_token'},
+      );
+      expect(readAfter['refresh_token'], 'legacy-plaintext-value');
+    });
+
+    test('a tampered envelope (bad GCM auth tag) is treated as a miss, not a '
+        'throw', () async {
+      const store = OidcWebStore(storagePrefix: 'corrupt');
+      await store.init();
+      const rawKey = 'corrupt.secureTokens.k';
+
+      await store.setMany(
+        OidcStoreNamespace.secureTokens,
+        values: {'k': 'value'},
+      );
+      final original = web.window.localStorage.getItem(rawKey)!;
+      final parts = original
+          .substring(oidcWebCryptoEnvelopePrefixV1.length)
+          .split('.');
+      final tampered =
+          '$oidcWebCryptoEnvelopePrefixV1'
+          '${parts[0]}.${_tamperBase64Url(parts[1])}';
+      web.window.localStorage.setItem(rawKey, tampered);
+
+      final result = await store.getMany(
+        OidcStoreNamespace.secureTokens,
+        keys: {'k'},
+      );
+
+      expect(result.containsKey('k'), isFalse);
+    });
+
+    test('removeMany deletes the stored value', () async {
+      const store = OidcWebStore(storagePrefix: 'remove');
+      await store.init();
+
+      await store.setMany(OidcStoreNamespace.secureTokens, values: {'k': 'v'});
+      expect(
+        web.window.localStorage.getItem('remove.secureTokens.k'),
+        isNotNull,
+      );
+
+      await store.removeMany(OidcStoreNamespace.secureTokens, keys: {'k'});
+
+      expect(web.window.localStorage.getItem('remove.secureTokens.k'), isNull);
+      final result = await store.getMany(
+        OidcStoreNamespace.secureTokens,
+        keys: {'k'},
+      );
+      expect(result.containsKey('k'), isFalse);
+    });
+
+    test('non-secureTokens namespaces (e.g. state) remain plaintext '
+        '(regression guard)', () async {
+      const store = OidcWebStore(storagePrefix: 'plain');
+      await store.init();
+
+      await store.setMany(
+        OidcStoreNamespace.state,
+        values: {'s': 'state-value'},
+      );
+
+      final raw = web.window.localStorage.getItem('plain.state.s');
+      expect(raw, 'state-value');
+    });
+  });
+
+  group('when WebCrypto/IndexedDB are unavailable', () {
+    test('OidcWebStoreEncryption.preferred falls back to a warned plaintext '
+        'write', () async {
+      const store = OidcWebStore(storagePrefix: 'fallback-preferred');
+      OidcWebCrypto.debugForceUnavailable = true;
+      await store.init();
+
+      await store.setMany(
+        OidcStoreNamespace.secureTokens,
+        values: {'k': 'plain-fallback-value'},
+      );
+
+      final raw = web.window.localStorage.getItem(
+        'fallback-preferred.secureTokens.k',
+      );
+      expect(raw, 'plain-fallback-value');
+
+      final result = await store.getMany(
+        OidcStoreNamespace.secureTokens,
+        keys: {'k'},
+      );
+      expect(result['k'], 'plain-fallback-value');
+    });
+
+    test(
+      'OidcWebStoreEncryption.required throws instead of writing plaintext',
+      () async {
+        const store = OidcWebStore(
+          storagePrefix: 'fallback-required',
+          encryption: OidcWebStoreEncryption.required,
+        );
+        OidcWebCrypto.debugForceUnavailable = true;
+        await store.init();
+
+        await expectLater(
+          store.setMany(
+            OidcStoreNamespace.secureTokens,
+            values: {'k': 'value'},
+          ),
+          throwsA(isA<OidcException>()),
+        );
+
+        expect(
+          web.window.localStorage.getItem('fallback-required.secureTokens.k'),
+          isNull,
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Implements audit #324 item 15 exactly per the approved design proposal (`web-token-encryption-proposal.md`): the `OidcStoreNamespace.secureTokens` namespace in `oidc_web_core`'s `OidcWebStore` (access/refresh/id tokens, the OIDC nonce) was persisted as **plaintext in `localStorage`**. It is now encrypted at rest:

- **AES-GCM 256-bit**, key generated via WebCrypto (`crypto.subtle.generateKey`) with `extractable: false` -- the raw key bytes can never leave the browser via `exportKey`/`wrapKey`.
- The `CryptoKey` **object** (never its raw bytes) is persisted via structured clone in **IndexedDB** (db `oidc_web_core`, store `crypto_keys`), one key per `storagePrefix`, so it survives restarts like `secureTokens` always has.
- A fresh **random 12-byte IV per write**, encoded into a versioned envelope: `oidcenc.v1.<iv-b64url>.<ciphertext-b64url>`.
- **Forward-only, lazy migration**: `getMany` reads legacy plaintext through as-is; `setMany` always encrypts, so existing plaintext values are naturally upgraded to `v1` envelopes on the next token refresh/nonce write. No forced re-login. Downgrading to a version predating this feature will see encrypted values as opaque strings (documented in the CHANGELOG).
- **Unavailability handling** (`OidcWebStoreEncryption`, default `preferred`): if WebCrypto/IndexedDB are unavailable (non-secure-context origin, or IndexedDB disabled/ephemeral in some private-browsing modes), falls back to the previous plaintext behavior with a one-shot warning naming exactly what's insecure -- no regression versus today. `encryption: OidcWebStoreEncryption.required` opts into throwing an `OidcException` instead of ever writing plaintext.
- **Zero new required settings** (`const OidcWebStore()` still compiles and works) and **zero new dependencies** (WebCrypto + IndexedDB are both already exposed by `package:web`, already a dependency; only added `meta` for the `@visibleForTesting` test seam).

### Threat-model honesty (please read before assuming more than this provides)

This is **defense-in-depth against disk/backup scraping and casual inspection** (a copied browser profile, DevTools showing bearer tokens in the clear, etc.) -- it is **explicitly NOT protection against XSS**. A script running in the page's own origin can call the exact same `crypto.subtle.decrypt`, or more simply just read decrypted tokens back out through the `OidcStore` API after this code decrypts them. A non-extractable key stops the raw key bytes from ever leaving the browser, but does not stop same-origin `decrypt()` calls -- this is intrinsic to the WebCrypto platform, not a gap in this design (MSAL states the identical caveat for their own localStorage encryption). Harden against XSS itself (CSP, trusted types, dependency hygiene) and prefer a BFF (tokens behind HttpOnly cookies) for high-value applications. This mirrors the existing honest posture already in `oidc_default_store`'s docs.

This threat-model paragraph is embedded directly in `OidcWebStore`'s dartdoc (shows up in the pub.dev API reference), not just this PR description.

### Deviations from the proposal (both minor, both justified)

1. **Testing seam for "WebCrypto/IndexedDB unavailable"**: the proposal offered two options -- inject a fake `SubtleCrypto?`/`IDBFactory?`, or a `@visibleForTesting` boolean mirroring `OidcDefaultStore.testIsWeb`. Headless Chrome/Firefox on `http://localhost` is a secure context with real, non-configurable `window.crypto`/`window.indexedDB` accessors that can't be stubbed via js-interop, so only the boolean-flag option is actually implementable. Used `OidcWebCrypto.debugForceUnavailable` (+ `debugReset()` for test isolation).
2. **Key-acquisition memoization**: the proposal suggested mirroring `OidcDefaultStore`'s `AsyncMemoizer` (from `package:async`), but `package:async` isn't a dependency of `oidc_web_core` and the proposal's own §6 explicitly promises "no new dependencies." Used a dependency-free equivalent (`Map<String, Future<CryptoKey?>>.putIfAbsent`), which gives the same single-threaded memoize-once guarantee.

## Test plan

- [x] New `packages/oidc_web_core/test/oidc_web_store_test.dart` (`@TestOn('js')`, real headless-browser crypto path, no mocking): round-trip, stored-form-is-ciphertext, IV-uniqueness-per-write, legacy-plaintext-read-through-then-upgrade, tampered-envelope-(bad GCM tag)-is-a-miss-not-a-throw, `removeMany` deletes, non-`secureTokens` namespaces stay plaintext (regression guard), `preferred`-mode fallback, `required`-mode hard-fail.
- [x] `dart test --platform chrome` in `oidc_web_core`: 11/11 passing (2 pre-existing + 9 new).
- [x] `dart analyze` in `oidc_web_core` and `oidc_web` (its dependent, constraint bumped to `^0.5.0`): 0 issues in both.
- [x] `dart format --set-exit-if-changed`: clean.
- [ ] `dart test --platform firefox`: attempted locally but Firefox failed to launch in this sandboxed dev environment even on the pre-existing, untouched `main_test.dart` (`Firefox exited before connecting`) -- an environment/harness issue unrelated to this change, not reproducible against real CI (which runs `melos run test:web:firefox` on a properly provisioned Ubuntu runner).
- [ ] `--compiler=dart2wasm`: confirmed this is filtered out by `@TestOn('js')` for every test file in this package (including the pre-existing, untouched ones) and is not part of the gating CI path (`WITH_WASM: false` in the root melos scripts) -- pre-existing repo behavior, not a regression.

**Do not merge before independent review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoZeDcHumT38zpaTic62Rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secure token storage is now encrypted at rest by default, adding stronger protection for access, refresh, ID tokens, and nonce values.
  * Added an optional strict mode that requires encryption and prevents plaintext storage when encryption isn’t available.

* **Bug Fixes**
  * Existing plaintext token data is now read transparently and upgraded on next write.
  * Corrupted or unreadable encrypted entries are safely treated as missing instead of causing errors.
  * Non-secure storage areas continue to behave as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->