### PR TITLE
ci(tests): retarget ios_canary to macos-26 + coverage (real unpin signal)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -309,15 +309,30 @@ jobs:
           path: packages/oidc/example/coverage/ios-coverage.info
           include-hidden-files: true
           if-no-files-found: error
-  # Non-gating canary for the macos-latest image (currently Xcode 26.5).
-  # Purpose: signal when the pinned `ios` job above can be unpinned. The
-  # structural relaunch failure (patrol#15) does NOT reproduce on Xcode 26.6
-  # locally (2/2 clean offline-suite runs, 2026-07-03) but was real on the GH
-  # image's Xcode 26.5 (run 28593820533). When this canary is consistently
-  # green, move `ios` back to macos-latest and delete this job.
+  # Canary for Xcode 26.5, pinned to the explicit `macos-26` label rather
+  # than `macos-latest`. As of 2026-07-03, `macos-latest` still resolves to
+  # the macos-15-arm64 image (Xcode 16.4) -- confirmed empirically: run
+  # 28665781383 (runs-on: macos-latest) landed on Xcode 16.4, while run
+  # 28667951809 (runs-on: macos-26) landed on Xcode 26.5. Using macos-latest
+  # here would silently test the wrong environment and defeat the purpose
+  # of this canary.
+  #
+  # The structural relaunch failure (patrol#15) appears RESOLVED on Xcode
+  # 26.5: 3/3 offline tests pass with a clean xcresult on both local Xcode
+  # 26.6 and the GH-hosted lab image's Xcode 26.5. This canary now exists to
+  # catch regressions and confirm sustained green on macos-26 before
+  # unpinning the gating `ios` job. When this canary is consistently green,
+  # move `ios` back to a floating label and delete this job.
+  #
+  # --coverage (mirroring the gating `ios` job's flags) is required here even
+  # though this job discards the coverage output: without it, patrol_plus
+  # never exits post-xcodebuild (patrol#24) and the step times out
+  # regardless of whether the tests themselves pass.
+  #
+  # Tracking: Bdaya-Dev/patrol#15, Bdaya-Dev/patrol#24.
   # continue-on-error: its result never gates CI by construction.
   ios_canary:
-    runs-on: macos-latest
+    runs-on: macos-26
     continue-on-error: true
     timeout-minutes: 40
     defaults:
@@ -358,7 +373,9 @@ jobs:
         run: dart pub global activate patrol_cli_plus
       # Offline suite only: 3 sequential patrolTests whose between-test
       # relaunch boundaries are exactly what patrol#15 breaks. No conformance
-      # token needed; no coverage; fast signal.
+      # token needed. --coverage below is required to avoid the patrol#24
+      # CLI-never-exits hang, not to collect coverage data for this
+      # non-gating job.
       - name: Offline relaunch canary (Patrol)
         # Step-level timeout so a hang becomes a STEP FAILURE (maskable by the
         # job's continue-on-error). A job-level timeout instead CANCELS the job,
@@ -369,6 +386,9 @@ jobs:
           export PATH="$PATH:$HOME/.pub-cache/bin"
           patrol_plus test \
             -t patrol_test/offline_mode_test.dart \
+            --coverage \
+            --coverage-ignore="**/*.g.dart" \
+            --coverage-package oidc \
             -d "${SIMULATOR_UDID:?Simulator UDID was not exported}" \
             --ios "${SIMULATOR_OS:?Simulator OS was not exported}" \
             --verbose \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -344,16 +344,40 @@ jobs:
       - name: Set up Environment
         uses: ./.github/actions/integration_test_base
       - name: Start Simulator
+        # `xcrun simctl boot` only *initiates* the boot and returns almost
+        # immediately; `simctl list devices` can report "Booted" before
+        # CoreSimulatorService has actually finished registering the device
+        # with Xcode's destination resolver. patrol_cli_plus's
+        # `test-without-building` invocation targets the simulator by exact
+        # UDID (`-destination id=<udid>`, unambiguous, no `--ios`/OS-string
+        # matching involved for simulators as of patrol_cli_plus 5.2.0) but
+        # pairs it with a hardcoded `-destination-timeout 1` (one second).
+        # On run 28667951809 (macos-26, no --coverage) that 1s window was
+        # enough -- xcodebuild found the device (even logging a "multiple
+        # matching destinations" WARNING for duplicate arm64/x86_64 entries)
+        # and proceeded. On PR #344's first macos-26 canary run
+        # (job 85040957868) the same boot-then-poll-for-"Booted" pattern lost
+        # that race: xcodebuild reported "Unable to find a device matching
+        # the provided destination specifier" for the exact same booted UDID
+        # (exit 70, before any test ran) -- a CoreSimulatorService
+        # registration race, not a destination-string mismatch. `simctl
+        # bootstatus <udid> -b` is Apple's CI-safe boot primitive: it boots
+        # the device (if needed) and blocks until CoreSimulatorService
+        # reports it has *actually* finished booting, closing this race at
+        # the source instead of relying on `simctl list` polling downstream.
         run: |
           SIM_JSON="$(xcrun simctl list devices available --json)"
           RUNTIME_KEY="$(echo "$SIM_JSON" | jq -r '.devices | to_entries[] | select(.key|test("SimRuntime.iOS")) | select([.value[]|select(.name|startswith("iPhone"))]|length>0) | .key' | head -n 1)"
           UDID="$(echo "$SIM_JSON" | jq -r --arg rt "$RUNTIME_KEY" '.devices[$rt][] | select(.name|startswith("iPhone")) | .udid' | head -n 1)"
           OS_VER="$(echo "$RUNTIME_KEY" | sed -E 's/.*SimRuntime\.iOS-([0-9]+)-([0-9]+).*/\1.\2/')"
           echo "Booting UDID=$UDID on iOS $OS_VER (runtime $RUNTIME_KEY)"
-          xcrun simctl boot "${UDID:?No available iPhone simulator found}"
+          xcrun simctl bootstatus "${UDID:?No available iPhone simulator found}" -b
           echo "SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
           echo "SIMULATOR_OS=${OS_VER:?Could not parse simulator OS version}" >> "$GITHUB_ENV"
       - name: Wait for Simulator to be Ready
+        # Redundant with `simctl bootstatus -b` above (which already blocks
+        # until booted) but kept as a cheap defense-in-depth check -- it
+        # passes on the first iteration once bootstatus has returned.
         run: |
           COUNT=0
           MAX_RETRIES=12


### PR DESCRIPTION
## Summary

The `ios_canary` job (patrol#15 comment [4878042709](https://github.com/Bdaya-Dev/oidc/issues/311#issuecomment-4878042709)) was doubly misconfigured, making it a no-op rather than a meaningful unpin signal for the gating `ios` job (pinned to `macos-15` since the Xcode 26.5 patrol relaunch regression).

1. **Wrong environment.** It ran on `runs-on: macos-latest`, which does **not** currently resolve to Xcode 26.5 -- it resolves to Xcode 16.4 (the `macos-15-arm64` image). The canary was never actually testing the environment it exists to validate.
2. **Hangs regardless of test outcome.** It invoked `patrol_plus test` **without** `--coverage`. Per [Bdaya-Dev/patrol#24](https://github.com/Bdaya-Dev/patrol/issues/24), the CLI never exits post-`xcodebuild` without `--coverage`, so the step times out no matter what the tests do. The gating `ios` job passes `--coverage` and does not hit this.

## Empirical verification (macos-latest vs macos-26)

Per the task's instruction to verify before touching the pin, I compared two `workflow_dispatch` diagnostic runs:

| Run | `runs-on` | Runner image | Xcode |
|---|---|---|---|
| [28665781383](https://github.com/Bdaya-Dev/oidc/actions/runs/28665781383) | `macos-latest` | `macos-15-arm64` (20260630.0202) | **16.4** |
| [28667951809](https://github.com/Bdaya-Dev/oidc/actions/runs/28667951809) | `macos-26` | `macos-26-arm64` (20260630.0213.1) | **26.5** |

Confirmed via each job's raw log (`xcodebuild -version` step and the `##[group]Runner Image` block from the GitHub API job logs, not just the UI summary).

I cross-checked this against GitHub's `actions/runner-images` README, which as of today still lists `macos-latest` under the macOS 15 Arm64 row (`macos-latest, macos-15, or macos-15-xlarge`), and confirms `macos-26` / `macos-26-arm64` as the documented hosted-runner labels for the Xcode 26.5 image. The `-latest` label migration is explicitly gradual ("1-2 months"), so run 28665781383's annotation about the pending migration is consistent with `macos-latest` not having flipped yet. **Conclusion: the diagnosis holds, no adjustment needed** -- `macos-latest` must be replaced with the explicit `macos-26` label for this canary to mean anything.

## Fix

In `.github/workflows/tests.yaml`'s `ios_canary` job:
- `runs-on: macos-latest` → `runs-on: macos-26` (explicit, documented GitHub-hosted arm64 label; confirmed working in run 28667951809 above).
- Added `--coverage --coverage-ignore="**/*.g.dart" --coverage-package oidc` to the canary's `patrol_plus test` invocation, mirroring the gating `ios` job's flags, solely to avoid the patrol#24 hang (this job doesn't upload the resulting coverage file -- it's non-gating). Still targets only `patrol_test/offline_mode_test.dart`, still `continue-on-error: true`, still has its step-level 25-minute timeout.
- Rewrote the job's comment block: the patrol#15 structural relaunch bug appears **resolved** on Xcode 26.5 (3/3 offline tests pass, clean xcresult on both local Xcode 26.6 and the GH lab image's Xcode 26.5). The canary now exists to catch regressions and confirm sustained green on `macos-26` before unpinning the gating `ios` job. Links [patrol#15](https://github.com/Bdaya-Dev/patrol/issues/15) and [patrol#24](https://github.com/Bdaya-Dev/patrol/issues/24).

## Validation

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/tests.yaml', encoding='utf-8'))"` -- parses cleanly.
- `actionlint .github/workflows/tests.yaml` -- zero findings.

## Test plan

- [ ] CI runs on this PR; `ios_canary` should now genuinely exercise Xcode 26.5 and complete (pass or fail) within its step timeout instead of hanging.
- [ ] Once `ios_canary` is consistently green on `macos-26` across several runs, open a follow-up PR to unpin the gating `ios` job.

**Do not merge before independent review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoZeDcHumT38zpaTic62Rb