### PR TITLE
ci(release): auto-close superseded release PRs

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -3,6 +3,13 @@ on:
   push:
     branches: [main]
 
+# Serialize runs so two Prepare-release jobs never race each other while
+# opening/closing the release PR (otherwise each could close the other's
+# freshly-created PR and leave zero, or two, PRs open).
+concurrency:
+  group: release-prepare-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   prepare-release:
     name: Prepare release
@@ -20,8 +27,8 @@ jobs:
       - uses: bluefireteam/melos-action@main
         continue-on-error: true
         with:
-          run-bootstrap: true          
-          bootstrap-no-example: false      
+          run-bootstrap: true
+          bootstrap-no-example: false
       - uses: bluefireteam/melos-action@main
         with:
           run-bootstrap: true
@@ -32,3 +39,41 @@ jobs:
           run-versioning: true
           publish-dry-run: true
           create-pr: true
+      # melos-action (peter-evans/create-pull-request under the hood) always
+      # opens a *new* PR from a run-id-suffixed branch (release-<run_id>), it
+      # never reuses/updates a previous one. Without this step every push to
+      # main that touches package versions piles up another open release PR.
+      # melos-action doesn't expose the PR number/branch as an action output,
+      # so the keeper is derived as "the newest open release-* PR".
+      - name: Close superseded release PRs
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Must match melos-action's `pr-title` default (not overridden above).
+          RELEASE_PR_TITLE: "chore(release): Publish packages"
+        run: |
+          set -euo pipefail
+
+          mapfile -t PR_NUMBERS < <(
+            gh pr list \
+              --repo "${{ github.repository }}" \
+              --state open \
+              --json number,headRefName,title \
+              --jq '.[] | select(.title == env.RELEASE_PR_TITLE and (.headRefName | startswith("release-"))) | .number' \
+            | sort -rn
+          )
+
+          if [ "${#PR_NUMBERS[@]}" -le 1 ]; then
+            echo "No superseded release PRs to close (found ${#PR_NUMBERS[@]})."
+            exit 0
+          fi
+
+          keeper="${PR_NUMBERS[0]}"
+          echo "Keeping newest release PR #$keeper"
+
+          for number in "${PR_NUMBERS[@]:1}"; do
+            echo "Closing superseded release PR #$number"
+            gh pr comment "$number" --repo "${{ github.repository }}" \
+              --body "Superseded by the latest Prepare release run."
+            gh pr close "$number" --repo "${{ github.repository }}"
+          done


### PR DESCRIPTION
## Description

The **Prepare release** workflow (`.github/workflows/release-prepare.yml`) runs on every push to `main` and uses `bluefireteam/melos-action` (`create-pr: true`) to open a PR with the version bumps. Under the hood that action delegates to `peter-evans/create-pull-request` with a hardcoded branch name of `release-${{ github.run_id }}` — a *new, unique* branch on every single run. It has no notion of "the existing release PR," so it can never update or reuse one; it just opens another one.

The result: the repo has accumulated **dozens** of stale `release-<run_id>` branches/PRs (`release-11995056595`, `release-11995079492`, … `release-26643472089`, etc.) that pile up forever unless someone manually closes them.

## Fix

Added a step **after** the `create-pr: true` melos-action step that closes any previously-open release PRs, keeping exactly one perpetually-ready release PR:

- Lists all **open** PRs via `gh pr list --json number,headRefName,title`.
- Filters to PRs whose `headRefName` starts with `release-` **and** whose `title` exactly matches `chore(release): Publish packages` (melos-action's `pr-title` default, which this workflow doesn't override) — this guards against ever touching an unrelated PR that happens to share one of the two signals.
- `melos-action` doesn't expose the PR number/branch as an action output (confirmed by reading its `action.yml` — no `outputs:` block at all), so the **keeper is derived as the newest matching open PR** (highest PR number), matching the guidance in the task. Everything else matching gets a `Superseded by the latest Prepare release run.` comment and is closed via `gh pr close`.
- Uses `secrets.GITHUB_TOKEN` via `GH_TOKEN` env, relying on the `pull-requests: write` permission the job already has.

### Edge cases handled

- **First-ever run / no changes to version (no PR created this run):** at most 1 matching open PR exists → step is a no-op (`${#PR_NUMBERS[@]} -le 1`).
- **Multiple pre-existing stale PRs (the current state of this repo):** on the first run after this merges, the step self-heals by closing all but the newest one.
- **Non-release PRs with a similar branch or title:** excluded by requiring *both* the `release-` head-branch prefix *and* the exact title match.
- **Concurrent runs racing each other:** the workflow had **no concurrency group** at all, so two `Prepare release` runs triggered by rapid successive pushes to `main` could interleave and each close the other's freshly-opened PR (or leave two open). Added:
  ```yaml
  concurrency:
    group: release-prepare-${{ github.ref }}
    cancel-in-progress: false
  ```
  This serializes runs on `main` (queued, not cancelled — publishing/versioning shouldn't be dropped) so the close-stale step always sees a consistent PR list.
- **Step runs even if an earlier step in the job failed** (`if: always()`), so a broken versioning run doesn't also leave the stale-PR cleanup un-run.

## Validation

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/release-prepare.yml'))"` → parses cleanly.
- `actionlint` (both the single file and the whole `.github/workflows/` directory) → 0 findings.
- Manually exercised the `mapfile`/`sort -rn`/loop bash logic and the `jq`/`env.RELEASE_PR_TITLE` filter expression against mocked `gh pr list` JSON output (0 PRs / 1 PR / multiple PRs, including a decoy non-release-branch PR and a decoy differently-titled PR) — all cases behaved as intended (no `shellcheck` available in this environment to lint further).

**Do not merge before independent review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoZeDcHumT38zpaTic62Rb