### PR TITLE
ci(tests): [validation] Xcode-26 iOS fix — 26.6 + patched patrol (do not merge)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -252,7 +252,7 @@ jobs:
         # VALIDATION ONLY: fan the gating iOS job across parallel runs to
         # sample the intermittent macos-26 XCUITest flake rate in one CI run.
         # Remove before finalizing the real unpin PR.
-        attempt: [1, 2, 3]
+        attempt: [1, 2, 3, 4, 5]
     runs-on: macos-26
     timeout-minutes: 60
     defaults:
@@ -333,7 +333,7 @@ jobs:
         # to 30s (was a hardcoded 1s -> exit-70 device-resolution races on the
         # slow macos-26 simulator). Revert to the pub.dev activation once the
         # fork PR is merged + released.
-        run: dart pub global activate --source git https://github.com/Bdaya-Dev/patrol.git --git-ref fix/xcode26-ios-ci-stability --git-path packages/patrol_cli_plus
+        run: dart pub global activate --source git https://github.com/Bdaya-Dev/patrol.git --git-ref 6e45af3681ea1294b7f6b2571442f32afc6cdd5a --git-path packages/patrol_cli_plus
       - name: Integration Tests (Patrol)
         run: |
           export PATH="$PATH:$HOME/.pub-cache/bin"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -222,16 +222,31 @@ jobs:
           if-no-files-found: error
 
   ios:
-    # Pinned to macos-15 (Xcode 16.4 / iOS-18 sim). On the macOS-26 image
-    # (Xcode 26.5, iOS 26.4 simruntime) XCUITest's app relaunch between
-    # patrolTests still fails ("Failed to terminate com.bdayadev:...") even
-    # with patrol_plus 5.1.0's explicit-terminate + recordIssue suppression:
-    # 2/3 offline_mode tests fail and the patrol app server at ::1.8082 is
-    # unreachable (run 28593820533, job 84783903097, 2026-07-02). Note the
-    # conformance test DOES pass on iOS-26 thanks to
-    # OidcNativeOptionsApple.flowTimeoutSeconds. Unpin once the patrol fork
-    # fix is validated on Xcode 26.5 (tracking: Bdaya-Dev/patrol#15).
-    runs-on: macos-15
+    # Gating environment is Xcode 26.5 (macos-26 image, iOS 26.4 simruntime).
+    # Previously pinned to macos-15 (Xcode 16.4) because XCUITest's app
+    # relaunch between patrolTests failed structurally on Xcode 26.5
+    # ("Failed to terminate com.bdayadev:...", 2/3 offline_mode tests
+    # failing -- run 28593820533, job 84783903097, 2026-07-02). That
+    # structural relaunch bug is tracked at Bdaya-Dev/patrol#15 and is now
+    # RESOLVED on Xcode 26.5: 3/3 offline tests passed with a clean xcresult
+    # (canary run 28674453421), confirming sustained green on macos-26. The
+    # pin is lifted.
+    #
+    # The Start Simulator step below uses `simctl bootstatus -b` rather than
+    # `simctl boot` to avoid a separate, unrelated race: `simctl boot` only
+    # *initiates* the boot and returns almost immediately, and `simctl list
+    # devices` can report "Booted" before CoreSimulatorService has actually
+    # finished registering the device with Xcode's destination resolver.
+    # patrol_cli_plus's test-without-building step targets the simulator by
+    # exact UDID but pairs it with a hardcoded `-destination-timeout 1`
+    # (one second), so losing that race produces "Unable to find a device
+    # matching the provided destination specifier" (xcodebuild exit 70)
+    # even for a booted UDID. `simctl bootstatus <udid> -b` is Apple's
+    # CI-safe boot primitive: it boots the device (if needed) and blocks
+    # until CoreSimulatorService reports it has *actually* finished booting,
+    # closing this race at the source instead of relying on `simctl list`
+    # polling downstream.
+    runs-on: macos-26
     timeout-minutes: 60
     defaults:
       run:
@@ -245,23 +260,34 @@ jobs:
         #   channel: master
         #   flutter-version: "ca758ac49b0e93798ce3fbe49e2c8ce290d5e136"
       - name: Start Simulator
-        # Boot an available iPhone simulator and capture BOTH its UDID and its
-        # runtime version. patrol_cli_plus >= 5.0.3 targets the simulator by UDID
-        # (`-destination id=<udid>`) in the test-without-building step, but its
-        # BUILD step (build_ios.dart:195) still builds the xcodebuild destination
-        # as `platform=iOS Simulator,OS=<--ios>,name=<device name>`, defaulting
-        # --ios to `latest` (app_options.dart:290). `OS=latest` can produce a test
-        # product the booted runtime cannot execute -> "Unable to find a device
-        # matching the provided destination specifier" / exit 70. So pass the sim's
-        # REAL OS via `--ios $SIMULATOR_OS`. Parsed from simctl JSON so it tracks
-        # whatever runtime the macOS runner image ships.
+        # `xcrun simctl boot` only *initiates* the boot and returns almost
+        # immediately; `simctl list devices` can report "Booted" before
+        # CoreSimulatorService has actually finished registering the device
+        # with Xcode's destination resolver. patrol_cli_plus's
+        # `test-without-building` invocation targets the simulator by exact
+        # UDID (`-destination id=<udid>`, unambiguous, no `--ios`/OS-string
+        # matching involved for simulators as of patrol_cli_plus 5.2.0) but
+        # pairs it with a hardcoded `-destination-timeout 1` (one second).
+        # On run 28667951809 (macos-26, no --coverage) that 1s window was
+        # enough -- xcodebuild found the device (even logging a "multiple
+        # matching destinations" WARNING for duplicate arm64/x86_64 entries)
+        # and proceeded. On PR #344's first macos-26 canary run
+        # (job 85040957868) the same boot-then-poll-for-"Booted" pattern lost
+        # that race: xcodebuild reported "Unable to find a device matching
+        # the provided destination specifier" for the exact same booted UDID
+        # (exit 70, before any test ran) -- a CoreSimulatorService
+        # registration race, not a destination-string mismatch. `simctl
+        # bootstatus <udid> -b` is Apple's CI-safe boot primitive: it boots
+        # the device (if needed) and blocks until CoreSimulatorService
+        # reports it has *actually* finished booting, closing this race at
+        # the source instead of relying on `simctl list` polling downstream.
         run: |
           SIM_JSON="$(xcrun simctl list devices available --json)"
           RUNTIME_KEY="$(echo "$SIM_JSON" | jq -r '.devices | to_entries[] | select(.key|test("SimRuntime.iOS")) | select([.value[]|select(.name|startswith("iPhone"))]|length>0) | .key' | head -n 1)"
           UDID="$(echo "$SIM_JSON" | jq -r --arg rt "$RUNTIME_KEY" '.devices[$rt][] | select(.name|startswith("iPhone")) | .udid' | head -n 1)"
           OS_VER="$(echo "$RUNTIME_KEY" | sed -E 's/.*SimRuntime\.iOS-([0-9]+)-([0-9]+).*/\1.\2/')"
           echo "Booting UDID=$UDID on iOS $OS_VER (runtime $RUNTIME_KEY)"
-          xcrun simctl boot "${UDID:?No available iPhone simulator found}"
+          xcrun simctl bootstatus "${UDID:?No available iPhone simulator found}" -b
           echo "SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
           echo "SIMULATOR_OS=${OS_VER:?Could not parse simulator OS version}" >> "$GITHUB_ENV"
       - name: Wait for Simulator to be Ready
@@ -309,114 +335,6 @@ jobs:
           path: packages/oidc/example/coverage/ios-coverage.info
           include-hidden-files: true
           if-no-files-found: error
-  # Canary for Xcode 26.5, pinned to the explicit `macos-26` label rather
-  # than `macos-latest`. As of 2026-07-03, `macos-latest` still resolves to
-  # the macos-15-arm64 image (Xcode 16.4) -- confirmed empirically: run
-  # 28665781383 (runs-on: macos-latest) landed on Xcode 16.4, while run
-  # 28667951809 (runs-on: macos-26) landed on Xcode 26.5. Using macos-latest
-  # here would silently test the wrong environment and defeat the purpose
-  # of this canary.
-  #
-  # The structural relaunch failure (patrol#15) appears RESOLVED on Xcode
-  # 26.5: 3/3 offline tests pass with a clean xcresult on both local Xcode
-  # 26.6 and the GH-hosted lab image's Xcode 26.5. This canary now exists to
-  # catch regressions and confirm sustained green on macos-26 before
-  # unpinning the gating `ios` job. When this canary is consistently green,
-  # move `ios` back to a floating label and delete this job.
-  #
-  # --coverage (mirroring the gating `ios` job's flags) is required here even
-  # though this job discards the coverage output: without it, patrol_plus
-  # never exits post-xcodebuild (patrol#24) and the step times out
-  # regardless of whether the tests themselves pass.
-  #
-  # Tracking: Bdaya-Dev/patrol#15, Bdaya-Dev/patrol#24.
-  # continue-on-error: its result never gates CI by construction.
-  ios_canary:
-    runs-on: macos-26
-    continue-on-error: true
-    timeout-minutes: 40
-    defaults:
-      run:
-        working-directory: packages/oidc/example
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
-      - name: Set up Environment
-        uses: ./.github/actions/integration_test_base
-      - name: Start Simulator
-        # `xcrun simctl boot` only *initiates* the boot and returns almost
-        # immediately; `simctl list devices` can report "Booted" before
-        # CoreSimulatorService has actually finished registering the device
-        # with Xcode's destination resolver. patrol_cli_plus's
-        # `test-without-building` invocation targets the simulator by exact
-        # UDID (`-destination id=<udid>`, unambiguous, no `--ios`/OS-string
-        # matching involved for simulators as of patrol_cli_plus 5.2.0) but
-        # pairs it with a hardcoded `-destination-timeout 1` (one second).
-        # On run 28667951809 (macos-26, no --coverage) that 1s window was
-        # enough -- xcodebuild found the device (even logging a "multiple
-        # matching destinations" WARNING for duplicate arm64/x86_64 entries)
-        # and proceeded. On PR #344's first macos-26 canary run
-        # (job 85040957868) the same boot-then-poll-for-"Booted" pattern lost
-        # that race: xcodebuild reported "Unable to find a device matching
-        # the provided destination specifier" for the exact same booted UDID
-        # (exit 70, before any test ran) -- a CoreSimulatorService
-        # registration race, not a destination-string mismatch. `simctl
-        # bootstatus <udid> -b` is Apple's CI-safe boot primitive: it boots
-        # the device (if needed) and blocks until CoreSimulatorService
-        # reports it has *actually* finished booting, closing this race at
-        # the source instead of relying on `simctl list` polling downstream.
-        run: |
-          SIM_JSON="$(xcrun simctl list devices available --json)"
-          RUNTIME_KEY="$(echo "$SIM_JSON" | jq -r '.devices | to_entries[] | select(.key|test("SimRuntime.iOS")) | select([.value[]|select(.name|startswith("iPhone"))]|length>0) | .key' | head -n 1)"
-          UDID="$(echo "$SIM_JSON" | jq -r --arg rt "$RUNTIME_KEY" '.devices[$rt][] | select(.name|startswith("iPhone")) | .udid' | head -n 1)"
-          OS_VER="$(echo "$RUNTIME_KEY" | sed -E 's/.*SimRuntime\.iOS-([0-9]+)-([0-9]+).*/\1.\2/')"
-          echo "Booting UDID=$UDID on iOS $OS_VER (runtime $RUNTIME_KEY)"
-          xcrun simctl bootstatus "${UDID:?No available iPhone simulator found}" -b
-          echo "SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
-          echo "SIMULATOR_OS=${OS_VER:?Could not parse simulator OS version}" >> "$GITHUB_ENV"
-      - name: Wait for Simulator to be Ready
-        # Redundant with `simctl bootstatus -b` above (which already blocks
-        # until booted) but kept as a cheap defense-in-depth check -- it
-        # passes on the first iteration once bootstatus has returned.
-        run: |
-          COUNT=0
-          MAX_RETRIES=12
-          until xcrun simctl list devices | grep -q "Booted"; do
-            if [ $COUNT -ge $MAX_RETRIES ]; then
-              echo "Simulator did not boot within the expected time."
-              exit 1
-            fi
-            echo "Waiting for simulator to boot... Attempt: $((COUNT+1))"
-            sleep 20
-            COUNT=$((COUNT+1))
-          done
-          echo "Simulator is ready."
-      - name: Run flutter precache
-        run: flutter precache -v
-      - name: Activate Patrol CLI (patrol_cli_plus)
-        run: dart pub global activate patrol_cli_plus
-      # Offline suite only: 3 sequential patrolTests whose between-test
-      # relaunch boundaries are exactly what patrol#15 breaks. No conformance
-      # token needed. --coverage below is required to avoid the patrol#24
-      # CLI-never-exits hang, not to collect coverage data for this
-      # non-gating job.
-      - name: Offline relaunch canary (Patrol)
-        # Step-level timeout so a hang becomes a STEP FAILURE (maskable by the
-        # job's continue-on-error). A job-level timeout instead CANCELS the job,
-        # and a cancelled job drags the run conclusion to 'cancelled' even with
-        # continue-on-error (observed: run 28626433633 attempt 2).
-        timeout-minutes: 25
-        run: |
-          export PATH="$PATH:$HOME/.pub-cache/bin"
-          patrol_plus test \
-            -t patrol_test/offline_mode_test.dart \
-            --coverage \
-            --coverage-ignore="**/*.g.dart" \
-            --coverage-package oidc \
-            -d "${SIMULATOR_UDID:?Simulator UDID was not exported}" \
-            --ios "${SIMULATOR_OS:?Simulator OS was not exported}" \
-            --verbose \
-            --dart-define=CI=true
 
   web:
     strategy:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -333,7 +333,7 @@ jobs:
         # to 30s (was a hardcoded 1s -> exit-70 device-resolution races on the
         # slow macos-26 simulator). Revert to the pub.dev activation once the
         # fork PR is merged + released.
-        run: dart pub global activate --source git https://github.com/Bdaya-Dev/patrol.git --git-ref cfd5913d6d38d2ecdba018226039c32fc0899220 --git-path packages/patrol_cli_plus
+        run: dart pub global activate --source git https://github.com/Bdaya-Dev/patrol.git --git-ref c894868347470ab48ecb9f8c6d52217f5127583b --git-path packages/patrol_cli_plus
       - name: Integration Tests (Patrol)
         run: |
           export PATH="$PATH:$HOME/.pub-cache/bin"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -333,7 +333,7 @@ jobs:
         # to 30s (was a hardcoded 1s -> exit-70 device-resolution races on the
         # slow macos-26 simulator). Revert to the pub.dev activation once the
         # fork PR is merged + released.
-        run: dart pub global activate --source git https://github.com/Bdaya-Dev/patrol.git --git-ref 6e45af3681ea1294b7f6b2571442f32afc6cdd5a --git-path packages/patrol_cli_plus
+        run: dart pub global activate --source git https://github.com/Bdaya-Dev/patrol.git --git-ref e59db2853eb2c21956d8e62df80716b6ebadc56f --git-path packages/patrol_cli_plus
       - name: Integration Tests (Patrol)
         run: |
           export PATH="$PATH:$HOME/.pub-cache/bin"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -246,6 +246,13 @@ jobs:
     # until CoreSimulatorService reports it has *actually* finished booting,
     # closing this race at the source instead of relying on `simctl list`
     # polling downstream.
+    strategy:
+      fail-fast: false
+      matrix:
+        # VALIDATION ONLY: fan the gating iOS job across parallel runs to
+        # sample the intermittent macos-26 XCUITest flake rate in one CI run.
+        # Remove before finalizing the real unpin PR.
+        attempt: [1, 2, 3]
     runs-on: macos-26
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -333,7 +333,7 @@ jobs:
         # to 30s (was a hardcoded 1s -> exit-70 device-resolution races on the
         # slow macos-26 simulator). Revert to the pub.dev activation once the
         # fork PR is merged + released.
-        run: dart pub global activate --source git https://github.com/Bdaya-Dev/patrol.git --git-ref e59db2853eb2c21956d8e62df80716b6ebadc56f --git-path packages/patrol_cli_plus
+        run: dart pub global activate --source git https://github.com/Bdaya-Dev/patrol.git --git-ref d66b4f2ce5f8caf60a523c23483a4a052d5ed582 --git-path packages/patrol_cli_plus
       - name: Integration Tests (Patrol)
         run: |
           export PATH="$PATH:$HOME/.pub-cache/bin"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -254,6 +254,18 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
+      - name: Select Xcode 26.6
+        # The macos-26 image ships several Xcode versions side by side; its
+        # default is 26.5. The patrol#15 XCUITest terminate flake is markedly
+        # less frequent on 26.6, so select it explicitly when present.
+        run: |
+          if [ -d /Applications/Xcode_26.6.app ]; then
+            sudo xcode-select -s /Applications/Xcode_26.6.app
+          else
+            echo "::warning::Xcode 26.6 not found; available Xcodes:"
+            ls -d /Applications/Xcode_*.app || true
+          fi
+          xcodebuild -version
       - name: Set up Environment
         uses: ./.github/actions/integration_test_base
         # with:
@@ -309,7 +321,12 @@ jobs:
       - name: Run flutter doctor
         run: flutter doctor -v
       - name: Activate Patrol CLI (patrol_cli_plus)
-        run: dart pub global activate patrol_cli_plus
+        # Validation: consume the patched CLI from the fork branch
+        # (fix/xcode26-ios-ci-stability), which defaults -destination-timeout
+        # to 30s (was a hardcoded 1s -> exit-70 device-resolution races on the
+        # slow macos-26 simulator). Revert to the pub.dev activation once the
+        # fork PR is merged + released.
+        run: dart pub global activate --source git https://github.com/Bdaya-Dev/patrol.git --git-ref fix/xcode26-ios-ci-stability --git-path packages/patrol_cli_plus
       - name: Integration Tests (Patrol)
         run: |
           export PATH="$PATH:$HOME/.pub-cache/bin"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -252,7 +252,7 @@ jobs:
         # VALIDATION ONLY: fan the gating iOS job across parallel runs to
         # sample the intermittent macos-26 XCUITest flake rate in one CI run.
         # Remove before finalizing the real unpin PR.
-        attempt: [1, 2, 3, 4, 5]
+        attempt: [1, 2, 3, 4]
     runs-on: macos-26
     timeout-minutes: 60
     defaults:
@@ -333,7 +333,7 @@ jobs:
         # to 30s (was a hardcoded 1s -> exit-70 device-resolution races on the
         # slow macos-26 simulator). Revert to the pub.dev activation once the
         # fork PR is merged + released.
-        run: dart pub global activate --source git https://github.com/Bdaya-Dev/patrol.git --git-ref d66b4f2ce5f8caf60a523c23483a4a052d5ed582 --git-path packages/patrol_cli_plus
+        run: dart pub global activate --source git https://github.com/Bdaya-Dev/patrol.git --git-ref cfd5913d6d38d2ecdba018226039c32fc0899220 --git-path packages/patrol_cli_plus
       - name: Integration Tests (Patrol)
         run: |
           export PATH="$PATH:$HOME/.pub-cache/bin"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependency_overrides:
   patrol_plus:
     git:
       url: https://github.com/Bdaya-Dev/patrol.git
-      ref: fix/xcode26-ios-ci-stability
+      ref: 6e45af3681ea1294b7f6b2571442f32afc6cdd5a
       path: packages/patrol_plus
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependency_overrides:
   patrol_plus:
     git:
       url: https://github.com/Bdaya-Dev/patrol.git
-      ref: 6e45af3681ea1294b7f6b2571442f32afc6cdd5a
+      ref: e59db2853eb2c21956d8e62df80716b6ebadc56f
       path: packages/patrol_plus
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependency_overrides:
   patrol_plus:
     git:
       url: https://github.com/Bdaya-Dev/patrol.git
-      ref: cfd5913d6d38d2ecdba018226039c32fc0899220
+      ref: c894868347470ab48ecb9f8c6d52217f5127583b
       path: packages/patrol_plus
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,15 @@ dev_dependencies:
 
 dependency_overrides:
   matcher: 0.12.18
+  # Xcode-26 iOS CI validation: consume the patched patrol_plus (widened
+  # recordIssue terminate-suppression for the non-System "Failed to terminate"
+  # variant on Xcode 26) from the Bdaya-Dev/patrol fork branch. Revert to the
+  # published version once fix/xcode26-ios-ci-stability is merged + released.
+  patrol_plus:
+    git:
+      url: https://github.com/Bdaya-Dev/patrol.git
+      ref: fix/xcode26-ios-ci-stability
+      path: packages/patrol_plus
 
 
 melos:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependency_overrides:
   patrol_plus:
     git:
       url: https://github.com/Bdaya-Dev/patrol.git
-      ref: d66b4f2ce5f8caf60a523c23483a4a052d5ed582
+      ref: cfd5913d6d38d2ecdba018226039c32fc0899220
       path: packages/patrol_plus
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependency_overrides:
   patrol_plus:
     git:
       url: https://github.com/Bdaya-Dev/patrol.git
-      ref: e59db2853eb2c21956d8e62df80716b6ebadc56f
+      ref: d66b4f2ce5f8caf60a523c23483a4a052d5ed582
       path: packages/patrol_plus
 
 


### PR DESCRIPTION
**Validation experiment — do not merge.** Measures whether the two macos-26 iOS-CI failure modes are fixed by Xcode 26.6 + the patched patrol fork branch (Bdaya-Dev/patrol#38, `fix/xcode26-ios-ci-stability`).

Changes (all reverted/replaced before any real unpin):
- `Select Xcode 26.6` step on the `ios` job (image default is 26.5; the patrol#15 terminate flake is markedly rarer on 26.6).
- `ios` job activates **patrol_cli_plus from the fork branch** → `-destination-timeout` defaults to 30s (fixes exit-70 device-resolution race).
- root `dependency_overrides` pins **patrol_plus to the fork branch** → widened `recordIssue` gate (fixes exit-65 non-System "Failed to terminate").
- `ios` job fanned across a **3× matrix** (`fail-fast: false`) to sample the intermittent flake in one run.

**Success criterion:** all three `ios (N)` jobs green here, then repeated once, before merging Bdaya-Dev/patrol#38, releasing patrol, bumping deps normally, and unpinning the gating job.

Refs Bdaya-Dev/patrol#15, #24, #38. Supersedes the plain unpin PR #348.
