### PR TITLE
fix(ci): stop silently discarding every Flutter package's unit coverage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -82,15 +82,17 @@ jobs:
         # no VM hitmap .json, exits 0, and truncates the file to 0 bytes. That
         # silently dropped every Flutter package's unit coverage from the
         # upload with no failing step. Fail loudly if it ever comes back.
+        # This step deliberately avoids two constructs that produced a phantom
+        # exit 1 on its previous two runs even though (per the diagnostics)
+        # every assertion passed: a trailing explicit `exit $missing` under
+        # this workflow's `bash -leo pipefail` login shell, and a
+        # SIGPIPE-generating `grep | head` pipe. The success path now ends by
+        # falling off the end of the script after a successful echo, exactly
+        # like every step of this job that has ever gone green.
         run: |
-          # Diagnostics first: the previous run of this step exited 1 with its
-          # entire stdout/stderr lost from the log, so print the observable
-          # state before asserting anything.
-          echo "guard: pwd=$(pwd)"
-          ls -l coverage/ || true
           wc -c coverage/lcov.info || true
           echo "guard: first 10 SF entries:"
-          grep -o 'SF:[^[:cntrl:]]*' coverage/lcov.info | head -10 || true
+          grep -o -m 10 'SF:[^[:cntrl:]]*' coverage/lcov.info || true
           missing=0
           for p in oidc oidc_default_store oidc_platform_interface oidc_desktop; do
             n=$(grep -c "packages/$p/lib/" coverage/lcov.info || true)
@@ -101,7 +103,10 @@ jobs:
               missing=1
             fi
           done
-          exit $missing
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+          echo "guard: all four Flutter packages present in the combined lcov"
       - name: Upload Unit Test Coverage Report
         uses: actions/upload-artifact@v7
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,6 +75,22 @@ jobs:
       - name: "[Coverage] Format & print test coverage"
         if: ${{ matrix.sdk == 'stable' }}
         run: melos run coverage:combine
+      - name: "[Coverage] Assert Flutter package coverage survived"
+        if: ${{ matrix.sdk == 'stable' }}
+        # Regression guard. `flutter test --coverage` writes coverage/lcov.info
+        # directly; running coverage:format_coverage over that directory finds
+        # no VM hitmap .json, exits 0, and truncates the file to 0 bytes. That
+        # silently dropped every Flutter package's unit coverage from the
+        # upload with no failing step. Fail loudly if it ever comes back.
+        run: |
+          missing=0
+          for p in oidc oidc_default_store oidc_platform_interface oidc_desktop; do
+            if ! grep -q "packages/$p/lib/" coverage/lcov.info; then
+              echo "::error::no unit coverage recorded for packages/$p — Flutter coverage is being discarded again"
+              missing=1
+            fi
+          done
+          exit $missing
       - name: Upload Unit Test Coverage Report
         uses: actions/upload-artifact@v7
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,10 +83,21 @@ jobs:
         # silently dropped every Flutter package's unit coverage from the
         # upload with no failing step. Fail loudly if it ever comes back.
         run: |
+          # Diagnostics first: the previous run of this step exited 1 with its
+          # entire stdout/stderr lost from the log, so print the observable
+          # state before asserting anything.
+          echo "guard: pwd=$(pwd)"
+          ls -l coverage/ || true
+          wc -c coverage/lcov.info || true
+          echo "guard: first 10 SF entries:"
+          grep -o 'SF:[^[:cntrl:]]*' coverage/lcov.info | head -10 || true
           missing=0
           for p in oidc oidc_default_store oidc_platform_interface oidc_desktop; do
-            if ! grep -q "packages/$p/lib/" coverage/lcov.info; then
-              echo "::error::no unit coverage recorded for packages/$p — Flutter coverage is being discarded again"
+            n=$(grep -c "packages/$p/lib/" coverage/lcov.info || true)
+            n=${n:-0}
+            echo "guard: packages/$p/lib/ -> $n match(es)"
+            if [ "$n" -eq 0 ]; then
+              echo "::error::no unit coverage recorded for packages/$p - Flutter coverage is being discarded again"
               missing=1
             fi
           done

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -223,6 +223,13 @@ melos:
       name: Format coverage for each package
       exec: dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
       packageFilters:
+        # Dart-only. `dart test --coverage=<dir>` writes VM hitmap JSON that
+        # still needs format_coverage to become lcov; `flutter test --coverage`
+        # already writes coverage/lcov.info directly. Running format_coverage
+        # over a Flutter package's coverage/ dir finds no .json, exits 0, and
+        # truncates that lcov.info to 0 bytes -- silently discarding every
+        # Flutter package's unit coverage before it is ever uploaded.
+        flutter: false
         dirExists: coverage
 
     coverage:combine:


### PR DESCRIPTION
Fixes the coverage pipeline silently discarding every Flutter package's unit coverage.

`melos run test:flutter` writes `coverage/lcov.info` directly, but `coverage:format:package` then ran `format_coverage --in=coverage --out=coverage/lcov.info` over every package with a `coverage/` dir. For Flutter packages it finds no VM hitmap `.json`, exits 0, and truncates the lcov to 0 bytes — so the `package-coverage` artifact only ever contained the seven pure-Dart packages.

- `coverage:format:package` now excludes Flutter packages (`flutter: false`); they already emit lcov.
- A guard step asserts the combined lcov actually contains the Flutter packages, so this can't regress silently.
