### PR TITLE
test: raise unit coverage across 10 packages (+1285 covered lines)

### DIFF
--- a/packages/crypto_keys_plus/test/coverage_gaps_test.dart
+++ b/packages/crypto_keys_plus/test/coverage_gaps_test.dart
@@ -1,0 +1,353 @@
+import 'dart:typed_data';
+
+import 'package:crypto_keys_plus/crypto_keys.dart';
+import 'package:test/test.dart';
+
+/// Targeted tests for previously-uncovered branches: the algorithm registry
+/// tables, JWA name lookup, key value semantics (== / hashCode), error paths in
+/// the operators, and the AES-CBC-HMAC decrypt / AES-KeyWrap guards.
+
+/// An `Object`-typed value of an unrelated runtime type, used to drive the
+/// `other is XKey` false branch of the various `operator ==` overrides without
+/// tripping the `unrelated_type_equality_checks` lint.
+final Object _unrelated = ['not a key'];
+
+void main() {
+  group('digest algorithm registry', () {
+    // Exercising createAlgorithm() runs each factory closure and returns a real
+    // pointycastle digest, so we can assert its identity and output size.
+    test('SHA family maps to correct digest sizes', () {
+      expect(algorithms.digest.sha1.createAlgorithm().digestSize, 20);
+      expect(algorithms.digest.sha224.createAlgorithm().digestSize, 28);
+      expect(algorithms.digest.sha256.createAlgorithm().digestSize, 32);
+      expect(algorithms.digest.sha384.createAlgorithm().digestSize, 48);
+      expect(algorithms.digest.sha512.createAlgorithm().digestSize, 64);
+    });
+
+    test('SHA names are canonical', () {
+      expect(algorithms.digest.sha1.createAlgorithm().algorithmName, 'SHA-1');
+      expect(
+          algorithms.digest.sha256.createAlgorithm().algorithmName, 'SHA-256');
+      expect(
+          algorithms.digest.sha512.createAlgorithm().algorithmName, 'SHA-512');
+    });
+
+    test('MD family maps to correct digest sizes', () {
+      expect(algorithms.digest.md2.createAlgorithm().digestSize, 16);
+      expect(algorithms.digest.md4.createAlgorithm().digestSize, 16);
+      expect(algorithms.digest.md5.createAlgorithm().digestSize, 16);
+    });
+
+    test('SHA-512/t honours the requested truncated size', () {
+      final d = algorithms.digest.sha512t(28);
+      expect(d.name, 'digest/SHA-512/224');
+      // sha512t is declared as the base AlgorithmIdentifier<Algorithm>, so
+      // reach digestSize dynamically.
+      expect((d.createAlgorithm() as dynamic).digestSize, 28);
+    });
+  });
+
+  group('encryption algorithm registry', () {
+    test('deprecated aes cbc getter aliases encryption.aes.cbc', () {
+      // ignore: deprecated_member_use
+      expect(
+          algorithms.encrypting_aes_cbc, same(algorithms.encryption.aes.cbc));
+    });
+
+    test('AES EAX factory is unimplemented', () {
+      expect(algorithms.encryption.aes.eax.createAlgorithm,
+          throwsUnimplementedError);
+    });
+
+    test('AES key wrap and rsa identifiers expose their names', () {
+      expect(algorithms.encryption.aes.keyWrap.name, 'enc/AES/KW');
+      expect(algorithms.encryption.rsa.pkcs1.name, 'enc/RSA/PKCS1');
+      expect(algorithms.encryption.aes.keyWrap.createAlgorithm().algorithmName,
+          'AESWrap');
+    });
+
+    test('hybrid withParameters builds a HKDF key derivator', () {
+      final id = algorithms.encryption.hybrid.withParameters(
+        keySize: 256,
+        curve: curves.p256,
+        hkdfHash: algorithms.digest.sha256,
+      );
+      expect(id.name, 'enc/hybrid');
+      expect(id.createAlgorithm().algorithmName, contains('HKDF'));
+    });
+  });
+
+  group('EdDSA registry placeholder', () {
+    test('Ed25519 placeholder algorithm reports its name', () {
+      expect(algorithms.signing.eddsa.ed25519.createAlgorithm().algorithmName,
+          'Ed25519');
+      expect(algorithms.signing.eddsa.ed25519.name, 'sig/EdDSA/Ed25519');
+    });
+  });
+
+  group('AlgorithmIdentifier.getByJwaName', () {
+    test('resolves known JWS/JWE identifiers', () {
+      expect(AlgorithmIdentifier.getByJwaName('HS256'),
+          same(algorithms.signing.hmac.sha256));
+      expect(AlgorithmIdentifier.getByJwaName('RS512'),
+          same(algorithms.signing.rsa.sha512));
+      expect(AlgorithmIdentifier.getByJwaName('ES256'),
+          same(algorithms.signing.ecdsa.sha256));
+      expect(AlgorithmIdentifier.getByJwaName('PS384'),
+          same(algorithms.signing.rsa.pss.sha384));
+      expect(AlgorithmIdentifier.getByJwaName('EdDSA'),
+          same(algorithms.signing.eddsa.ed25519));
+      expect(AlgorithmIdentifier.getByJwaName('A128GCM'),
+          same(algorithms.encryption.aes.gcm));
+      expect(AlgorithmIdentifier.getByJwaName('A256CBC-HS512'),
+          same(algorithms.encryption.aes.cbcWithHmac.sha512));
+    });
+
+    test('returns null for the "none" algorithm', () {
+      expect(AlgorithmIdentifier.getByJwaName('none'), isNull);
+    });
+
+    test('throws UnimplementedError for a known-but-unimplemented alg', () {
+      // 'dir' is present in the table mapped to null (a placeholder), so it is
+      // reported as not-yet-implemented rather than unsupported.
+      expect(() => AlgorithmIdentifier.getByJwaName('dir'),
+          throwsA(isA<UnimplementedError>()));
+      expect(() => AlgorithmIdentifier.getByJwaName('ECDH-ES'),
+          throwsA(isA<UnimplementedError>()));
+    });
+
+    test('throws UnsupportedError for an entirely unknown alg', () {
+      expect(() => AlgorithmIdentifier.getByJwaName('NOPE-999'),
+          throwsA(isA<UnsupportedError>()));
+    });
+  });
+
+  group('key value semantics (== / hashCode)', () {
+    test('RsaPublicKey', () {
+      final a =
+          RsaPublicKey(modulus: BigInt.from(3233), exponent: BigInt.from(17));
+      final b =
+          RsaPublicKey(modulus: BigInt.from(3233), exponent: BigInt.from(17));
+      final c =
+          RsaPublicKey(modulus: BigInt.from(3233), exponent: BigInt.from(19));
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+      expect(a == _unrelated, isFalse);
+      expect(identical(a, a) && a == a, isTrue);
+    });
+
+    test('RsaPrivateKey', () {
+      RsaPrivateKey make(BigInt d) => RsaPrivateKey(
+            privateExponent: d,
+            firstPrimeFactor: BigInt.from(61),
+            secondPrimeFactor: BigInt.from(53),
+            modulus: BigInt.from(3233),
+          );
+      final a = make(BigInt.from(413));
+      final b = make(BigInt.from(413));
+      final c = make(BigInt.from(999));
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+      expect(a == _unrelated, isFalse);
+    });
+
+    test('EcPublicKey', () {
+      EcPublicKey make(BigInt x) => EcPublicKey(
+          xCoordinate: x, yCoordinate: BigInt.two, curve: curves.p256);
+      final a = make(BigInt.one);
+      final b = make(BigInt.one);
+      final c = make(BigInt.from(7));
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+      // Same coordinates, different curve -> not equal.
+      expect(
+          a,
+          isNot(equals(EcPublicKey(
+              xCoordinate: BigInt.one,
+              yCoordinate: BigInt.two,
+              curve: curves.p384))));
+      expect(a == _unrelated, isFalse);
+    });
+
+    test('EcPrivateKey', () {
+      final a = EcPrivateKey(eccPrivateKey: BigInt.from(5), curve: curves.p256);
+      final b = EcPrivateKey(eccPrivateKey: BigInt.from(5), curve: curves.p256);
+      final c = EcPrivateKey(eccPrivateKey: BigInt.from(6), curve: curves.p256);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+      expect(
+          a,
+          isNot(equals(EcPrivateKey(
+              eccPrivateKey: BigInt.from(5), curve: curves.p384))));
+      expect(a == _unrelated, isFalse);
+    });
+
+    test('OkpPublicKey', () {
+      OkpPublicKey make(List<int> raw, [Identifier? crv]) => OkpPublicKey(
+          rawBytes: Uint8List.fromList(raw), curve: crv ?? curves.ed25519);
+      final a = make([1, 2, 3]);
+      final b = make([1, 2, 3]);
+      final c = make([1, 2, 4]);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+      expect(a == _unrelated, isFalse);
+    });
+
+    test('OkpPrivateKey', () {
+      OkpPrivateKey make(List<int> raw) => OkpPrivateKey(
+          rawBytes: Uint8List.fromList(raw), curve: curves.ed25519);
+      final a = make([9, 8, 7]);
+      final b = make([9, 8, 7]);
+      final c = make([9, 8, 6]);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+      expect(a == _unrelated, isFalse);
+    });
+
+    test('SymmetricKey', () {
+      SymmetricKey make(List<int> raw) =>
+          SymmetricKey(keyValue: Uint8List.fromList(raw));
+      final a = make([0, 1, 2, 3]);
+      final b = make([0, 1, 2, 3]);
+      final c = make([0, 1, 2, 4]);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+      expect(a == _unrelated, isFalse);
+    });
+
+    test('Signature', () {
+      final a = Signature(Uint8List.fromList([1, 2, 3]));
+      final b = Signature(Uint8List.fromList([1, 2, 3]));
+      final c = Signature(Uint8List.fromList([1, 2, 9]));
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+      expect(a == _unrelated, isFalse);
+    });
+
+    test('EncryptionResult', () {
+      EncryptionResult make(List<int> data) => EncryptionResult(
+            Uint8List.fromList(data),
+            initializationVector: Uint8List.fromList([9, 9]),
+            authenticationTag: Uint8List.fromList([8]),
+            additionalAuthenticatedData: Uint8List.fromList([7, 6]),
+          );
+      final a = make([1, 2, 3]);
+      final b = make([1, 2, 3]);
+      final c = make([1, 2, 4]);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+      expect(a == _unrelated, isFalse);
+    });
+  });
+
+  group('operator error paths', () {
+    test('generateEc rejects an unsupported curve', () {
+      // curves.ed25519 is not an EC curve, so createCurveParameters throws.
+      expect(() => KeyPair.generateEc(curves.ed25519), throwsArgumentError);
+    });
+
+    test('EdDSA signer/verifier reject a non-Ed25519 OKP curve', () {
+      final priv = OkpPrivateKey(
+          rawBytes: Uint8List(32), curve: curves.p256); // wrong curve
+      final pub = OkpPublicKey(rawBytes: Uint8List(32), curve: curves.p256);
+      expect(
+          () => priv.createSigner(algorithms.signing.eddsa.ed25519).sign([1]),
+          throwsA(isA<UnsupportedError>()));
+      expect(
+          () => pub.createVerifier(algorithms.signing.eddsa.ed25519).verify(
+              Uint8List.fromList([1]), Signature(Uint8List.fromList([0]))),
+          throwsA(isA<UnsupportedError>()));
+    });
+
+    test('SymmetricKey.generate rejects a non-byte-aligned bit length', () {
+      expect(() => SymmetricKey.generate(100), throwsArgumentError);
+    });
+
+    test('KeyPair without a private key cannot create a signer', () {
+      final pair = KeyPair(
+        publicKey:
+            RsaPublicKey(modulus: BigInt.from(3233), exponent: BigInt.from(17)),
+        privateKey: null,
+      );
+      expect(() => pair.createSigner(algorithms.signing.rsa.sha256),
+          throwsStateError);
+    });
+
+    test('KeyPair without a public key cannot create a verifier', () {
+      final pair = KeyPair(
+        publicKey: null,
+        privateKey: RsaPrivateKey(
+          privateExponent: BigInt.from(413),
+          firstPrimeFactor: BigInt.from(61),
+          secondPrimeFactor: BigInt.from(53),
+          modulus: BigInt.from(3233),
+        ),
+      );
+      expect(() => pair.createVerifier(algorithms.signing.rsa.sha256),
+          throwsStateError);
+    });
+  });
+
+  group('RSA operators with a generated key', () {
+    // One 2048-bit key shared by the RSA-specific paths below.
+    final rsa = KeyPair.generateRsa(bitStrength: 2048);
+    final message = Uint8List.fromList([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+    test('verify returns false for an oversized/garbage signature', () {
+      final verifier = rsa.createVerifier(algorithms.signing.rsa.sha256);
+      // A signature far larger than the modulus makes pointycastle throw an
+      // ArgumentError internally; verify() must swallow it and return false.
+      final bogus = Signature(Uint8List(400)..fillRange(0, 400, 0xff));
+      expect(verifier.verify(message, bogus), isFalse);
+    });
+
+    test('RSASSA-PSS with an explicit custom salt length round-trips', () {
+      final alg = algorithms.signing.rsa.pss.withParameters(
+        sigHash: algorithms.digest.sha256,
+        mgf1Hash: algorithms.digest.sha256,
+        saltLength: 48,
+      );
+      expect(alg.name, contains('/salt48'));
+      // Building the signer runs the withParameters factory closure.
+      final signer = rsa.createSigner(alg);
+      final verifier = rsa.createVerifier(alg);
+      final sig = signer.sign(message);
+      expect(verifier.verify(message, sig), isTrue);
+      // Tampered signature must fail.
+      final tampered = Signature(Uint8List.fromList(sig.data)..[0] ^= 0x01);
+      expect(verifier.verify(message, tampered), isFalse);
+    });
+  });
+
+  group('symmetric AEAD guards', () {
+    test('AES-128-CBC-HMAC-SHA-256 encrypt/decrypt round trip', () {
+      final key = SymmetricKey.generate(256); // 16-byte mac + 16-byte enc
+      final enc =
+          key.createEncrypter(algorithms.encryption.aes.cbcWithHmac.sha256);
+      final plaintext =
+          Uint8List.fromList(List<int>.generate(40, (i) => i & 0xff));
+      final result = enc.encrypt(plaintext,
+          additionalAuthenticatedData: Uint8List.fromList([1, 2, 3, 4]));
+      expect(result.authenticationTag, isNotNull);
+      // Decrypt drives the auth-tag verification branch of process().
+      expect(enc.decrypt(result), equals(plaintext));
+    });
+
+    test('AES key wrap rejects input that is not a multiple of 64 bits', () {
+      final kek = SymmetricKey.generate(128);
+      final enc = kek.createEncrypter(algorithms.encryption.aes.keyWrap);
+      // 5 bytes is not a multiple of 8 -> ArgumentError from AESKeyWrap.process.
+      expect(() => enc.encrypt(Uint8List.fromList([1, 2, 3, 4, 5])),
+          throwsArgumentError);
+    });
+  });
+}

--- a/packages/jose_plus/test/ecdh_error_test.dart
+++ b/packages/jose_plus/test/ecdh_error_test.dart
@@ -1,0 +1,181 @@
+import 'dart:typed_data';
+
+import 'package:jose_plus/jose.dart';
+import 'package:jose_plus/src/ecdh.dart';
+import 'package:jose_plus/src/util.dart';
+import 'package:test/test.dart';
+
+/// Builds a bare EC JWK (public + private) with only the crypto parameters,
+/// stripping the alg/use/key_ops fields that [JsonWebKey.generate] adds.
+JsonWebKey _bareEcKey(String sigAlgorithm) {
+  final generated = JsonWebKey.generate(sigAlgorithm);
+  final jsonKey = Map<String, dynamic>.from(generated.toJson())
+    ..remove('alg')
+    ..remove('use')
+    ..remove('key_ops');
+  return JsonWebKey.fromJson(jsonKey)!;
+}
+
+void main() {
+  group('ecdhKeyDataLen / ecdhAlgorithmId', () {
+    test('direct ECDH-ES uses the content encryption algorithm', () {
+      expect(ecdhAlgorithmId('ECDH-ES', 'A128GCM'), 'A128GCM');
+      expect(ecdhKeyDataLen('ECDH-ES', 'A128GCM'), 128);
+      expect(ecdhKeyDataLen('ECDH-ES', 'A256CBC-HS512'), 512);
+    });
+
+    test('ECDH-ES+A*KW uses the wrapping algorithm key length', () {
+      expect(ecdhAlgorithmId('ECDH-ES+A192KW', 'A128GCM'), 'ECDH-ES+A192KW');
+      expect(ecdhKeyDataLen('ECDH-ES+A192KW', 'A128GCM'), 192);
+    });
+
+    test('throws for an unsupported content/wrapping algorithm', () {
+      expect(
+        () => ecdhKeyDataLen('ECDH-ES', 'BOGUS-ENC'),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('ecdhEsDerive', () {
+    test('throws when the recipient key is not an EC public key', () {
+      final rsaKey = JsonWebKey.generate('RS256');
+      expect(
+        () => ecdhEsDerive(
+          recipientPublicKey: rsaKey,
+          algorithmId: 'A128GCM',
+          keyDataLen: 128,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('derives a key and ephemeral public key for a valid EC recipient', () {
+      final ecKey = _bareEcKey('ES256');
+      final result = ecdhEsDerive(
+        recipientPublicKey: ecKey,
+        algorithmId: 'A128GCM',
+        keyDataLen: 128,
+      );
+      expect(result.derivedKey, hasLength(16));
+      expect(result.ephemeralPublicKey.keyType, 'EC');
+      // Sender and recipient derive the same secret.
+      final recovered = ecdhEsDecrypt(
+        recipientPrivateKey: ecKey,
+        ephemeralPublicKey: result.ephemeralPublicKey,
+        algorithmId: 'A128GCM',
+        keyDataLen: 128,
+      );
+      expect(recovered, result.derivedKey);
+    });
+  });
+
+  group('ecdhEsDecrypt', () {
+    test('throws when the recipient key has no EC private key', () {
+      final rsaKey = JsonWebKey.generate('RS256');
+      final ecEphemeral = ecdhEsDerive(
+        recipientPublicKey: _bareEcKey('ES256'),
+        algorithmId: 'A128GCM',
+        keyDataLen: 128,
+      ).ephemeralPublicKey;
+      expect(
+        () => ecdhEsDecrypt(
+          recipientPrivateKey: rsaKey,
+          ephemeralPublicKey: ecEphemeral,
+          algorithmId: 'A128GCM',
+          keyDataLen: 128,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws when the ephemeral key is not an EC public key', () {
+      final recipient = _bareEcKey('ES256');
+      final rsaEphemeral = JsonWebKey.generate('RS256');
+      expect(
+        () => ecdhEsDecrypt(
+          recipientPrivateKey: recipient,
+          ephemeralPublicKey: rsaEphemeral,
+          algorithmId: 'A128GCM',
+          keyDataLen: 128,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws when the ephemeral curve does not match the recipient curve',
+        () {
+      final recipient = _bareEcKey('ES256'); // P-256
+      final ephemeral = ecdhEsDerive(
+        recipientPublicKey: _bareEcKey('ES384'), // P-384
+        algorithmId: 'A128GCM',
+        keyDataLen: 128,
+      ).ephemeralPublicKey;
+      expect(
+        () => ecdhEsDecrypt(
+          recipientPrivateKey: recipient,
+          ephemeralPublicKey: ephemeral,
+          algorithmId: 'A128GCM',
+          keyDataLen: 128,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws when the ephemeral point is not on the curve', () {
+      final recipient = _bareEcKey('ES256');
+      // Take a valid ephemeral key on P-256, then replace its y-coordinate with
+      // that of a different P-256 key so the (x, y) pair no longer lies on the
+      // curve.
+      final validEphemeral = ecdhEsDerive(
+        recipientPublicKey: recipient,
+        algorithmId: 'A128GCM',
+        keyDataLen: 128,
+      ).ephemeralPublicKey;
+      final otherKey = _bareEcKey('ES256');
+
+      final tamperedJson = Map<String, dynamic>.from(validEphemeral.toJson());
+      tamperedJson['y'] = otherKey['y'];
+      final tampered = JsonWebKey.fromJson(tamperedJson)!;
+
+      expect(
+        () => ecdhEsDecrypt(
+          recipientPrivateKey: recipient,
+          ephemeralPublicKey: tampered,
+          algorithmId: 'A128GCM',
+          keyDataLen: 128,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('AES key wrap helpers', () {
+    test('ecdhEsWrapKey rejects a CEK whose length is not a multiple of 8', () {
+      // 5-byte "key" -> not a multiple of 8.
+      final cek = JsonWebKey.fromJson({
+        'kty': 'oct',
+        'k': 'AAAAAAA', // decodes to 5 bytes
+      })!;
+      expect(
+        () => ecdhEsWrapKey(Uint8List(16), cek),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('ecdhEsUnwrapKey rejects ciphertext that is too short', () {
+      expect(
+        () => ecdhEsUnwrapKey(Uint8List(16), [1, 2, 3]),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('wrap/unwrap round-trips a 16-byte content key', () {
+      final derivedKey = Uint8List.fromList(List.generate(16, (i) => i));
+      final cek = JsonWebKey.generate('A128GCM');
+      final wrapped = ecdhEsWrapKey(derivedKey, cek);
+      final unwrapped = ecdhEsUnwrapKey(derivedKey, wrapped);
+      expect(unwrapped, decodeBase64EncodedBytes(cek['k']));
+    });
+  });
+}

--- a/packages/jose_plus/test/jose_test.dart
+++ b/packages/jose_plus/test/jose_test.dart
@@ -1,0 +1,153 @@
+import 'dart:convert';
+
+import 'package:jose_plus/jose.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JoseHeader', () {
+    test('exposes header parameters', () {
+      final header = JoseHeader.fromJson({
+        'alg': 'RS256',
+        'jku': 'https://example.com/keys.json',
+        'kid': 'key-1',
+        'typ': 'JWT',
+        'cty': 'example',
+        'enc': 'A128GCM',
+        'zip': 'DEF',
+        'apu': 'dGVzdA',
+        'apv': 'dGVzdA',
+      });
+
+      expect(header.algorithm, 'RS256');
+      expect(header.jwkSetUrl, Uri.parse('https://example.com/keys.json'));
+      expect(header.keyId, 'key-1');
+      expect(header.type, 'JWT');
+      expect(header.contentType, 'example');
+      expect(header.encryptionAlgorithm, 'A128GCM');
+      expect(header.compressionAlgorithm, 'DEF');
+      expect(header.agreementPartyUInfo, 'dGVzdA');
+      expect(header.agreementPartyVInfo, 'dGVzdA');
+    });
+
+    test('parses an embedded jwk header parameter', () {
+      final header = JoseHeader.fromJson({
+        'alg': 'ES256',
+        'jwk': {
+          'kty': 'EC',
+          'crv': 'P-256',
+          'x': 'f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU',
+          'y': 'x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0',
+        },
+      });
+
+      final jwk = header.jsonWebKey;
+      expect(jwk, isNotNull);
+      expect(jwk!.keyType, 'EC');
+    });
+
+    test('fromBase64EncodedString decodes an encoded header', () {
+      final encoded = base64Url
+          .encode(utf8.encode(json.encode({'alg': 'HS256'})))
+          .replaceAll('=', '');
+      final header = JoseHeader.fromBase64EncodedString(encoded);
+      expect(header.algorithm, 'HS256');
+    });
+  });
+
+  group('JoseObject.fromJson', () {
+    test('builds a JsonWebSignature from a payload-bearing map', () {
+      final obj = JoseObject.fromJson({
+        'payload': 'eyJpc3MiOiJqb2UifQ',
+        'protected': 'eyJhbGciOiJub25lIn0',
+        'signature': '',
+      });
+      expect(obj, isA<JsonWebSignature>());
+    });
+
+    test('builds a JsonWebEncryption from a ciphertext-bearing map', () {
+      final obj = JoseObject.fromJson({
+        'protected': 'eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0',
+        'iv': 'AAAAAAAAAAAAAAAA',
+        'ciphertext': 'AAAA',
+        'tag': 'AAAAAAAAAAAAAAAAAAAAAA',
+      });
+      expect(obj, isA<JsonWebEncryption>());
+    });
+
+    test('throws for a map that is neither JWS nor JWE', () {
+      expect(
+        () => JoseObject.fromJson({'foo': 'bar'}),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('JoseObject.fromCompactSerialization', () {
+    test('dispatches to JWS for 3-part serializations', () {
+      const jws = 'eyJhbGciOiJub25lIn0.eyJpc3MiOiJqb2UifQ.';
+      expect(JoseObject.fromCompactSerialization(jws), isA<JsonWebSignature>());
+    });
+
+    test('throws for an invalid number of parts', () {
+      expect(
+        () => JoseObject.fromCompactSerialization('only.two'),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => JoseObject.fromCompactSerialization('a.b.c.d'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('JoseObject.commonProtectedHeader', () {
+    test('contains protected parameters shared across signatures', () {
+      // A general JSON serialization with two signatures both protecting
+      // the same `alg`.
+      final jws = JsonWebSignature.fromJson({
+        'payload': 'eyJpc3MiOiJqb2UifQ',
+        'signatures': [
+          {'protected': 'eyJhbGciOiJSUzI1NiJ9', 'signature': 'AAAA'},
+          {'protected': 'eyJhbGciOiJSUzI1NiJ9', 'signature': 'BBBB'},
+        ],
+      });
+
+      expect(jws.commonProtectedHeader.algorithm, 'RS256');
+    });
+  });
+
+  group('JoseObjectBuilder', () {
+    test('content setter accepts a byte list payload', () {
+      final builder = JsonWebSignatureBuilder()..content = <int>[1, 2, 3];
+      expect(builder.payload!.data, [1, 2, 3]);
+    });
+
+    test('content setter accepts a String payload', () {
+      final builder = JsonWebSignatureBuilder()..content = 'hi';
+      expect(utf8.decode(builder.payload!.data), 'hi');
+    });
+
+    test('content setter accepts a JSON payload', () {
+      final builder = JsonWebSignatureBuilder()..content = {'a': 1};
+      expect(json.decode(utf8.decode(builder.payload!.data)), {'a': 1});
+    });
+
+    test('mediaType getter and setter round-trip through the cty header', () {
+      final builder = JsonWebSignatureBuilder()..mediaType = 'JWT';
+      expect(builder.mediaType, 'JWT');
+      expect(builder.protectedHeader['cty'], 'JWT');
+    });
+
+    test('payload is null until content is set', () {
+      expect(JsonWebSignatureBuilder().payload, isNull);
+    });
+  });
+
+  group('JoseException', () {
+    test('toString includes the message', () {
+      final e = JoseException('something went wrong');
+      expect(e.message, 'something went wrong');
+      expect(e.toString(), 'JoseException: something went wrong');
+    });
+  });
+}

--- a/packages/jose_plus/test/jwa_error_test.dart
+++ b/packages/jose_plus/test/jwa_error_test.dart
@@ -1,0 +1,76 @@
+import 'package:jose_plus/jose.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonWebAlgorithm.getByName', () {
+    test('returns the algorithm for a known name', () {
+      expect(JsonWebAlgorithm.getByName('HS256'), JsonWebAlgorithm.hs256);
+      expect(JsonWebAlgorithm.getByName('RS256').type, 'RSA');
+    });
+
+    test('throws UnsupportedError for an unknown name', () {
+      expect(
+        () => JsonWebAlgorithm.getByName('NOPE-999'),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('JsonWebAlgorithm.find', () {
+    test('filters by operation', () {
+      final signers = JsonWebAlgorithm.find(operation: 'sign').toList();
+      expect(signers, isNotEmpty);
+      expect(signers.every((a) => a.keyOperations.contains('sign')), isTrue);
+    });
+
+    test('filters by key type', () {
+      final ecAlgs = JsonWebAlgorithm.find(keyType: 'EC').toList();
+      expect(ecAlgs, isNotEmpty);
+      expect(ecAlgs.every((a) => a.type == 'EC'), isTrue);
+    });
+
+    test('filters by both operation and key type', () {
+      final result =
+          JsonWebAlgorithm.find(operation: 'sign', keyType: 'RSA').toList();
+      expect(result, contains(JsonWebAlgorithm.rs256));
+      expect(result, isNot(contains(JsonWebAlgorithm.es256)));
+    });
+  });
+
+  group('JsonWebAlgorithm.keyOperations', () {
+    test('maps each supported use to its operations', () {
+      expect(JsonWebAlgorithm.hs256.keyOperations, ['sign', 'verify']);
+      expect(JsonWebAlgorithm.a128kw.keyOperations, ['wrapKey', 'unwrapKey']);
+      expect(JsonWebAlgorithm.a128gcm.keyOperations, ['encrypt', 'decrypt']);
+    });
+
+    test('throws for an unsupported use', () {
+      const bogus = JsonWebAlgorithm('X', type: 'oct', use: 'mystery');
+      expect(() => bogus.keyOperations, throwsA(isA<UnsupportedError>()));
+    });
+  });
+
+  group('JsonWebAlgorithm.generateCryptoKeyPair', () {
+    test('throws for an unsupported key type', () {
+      const bogus = JsonWebAlgorithm('X', type: 'weird-type', use: 'sig');
+      expect(
+        () => bogus.generateCryptoKeyPair(),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('JsonWebAlgorithm key length validation', () {
+    test('rejects a key length below the algorithm minimum', () {
+      expect(
+        () => JsonWebKey.generate('HS256', keyBitLength: 8),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('accepts a key length at or above the minimum', () {
+      final key = JsonWebKey.generate('HS256', keyBitLength: 256);
+      expect(key.keyType, 'oct');
+    });
+  });
+}

--- a/packages/jose_plus/test/jwe_error_test.dart
+++ b/packages/jose_plus/test/jwe_error_test.dart
@@ -1,0 +1,232 @@
+import 'dart:convert';
+
+import 'package:jose_plus/jose.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final octKw = JsonWebKey.fromJson({
+    'kty': 'oct',
+    'alg': 'A128KW',
+    'k': 'GawgguFyGrWKav7AX4VKUg',
+  })!;
+
+  group('JsonWebEncryption.fromCompactSerialization', () {
+    test('throws when the serialization does not have five parts', () {
+      expect(
+        () => JsonWebEncryption.fromCompactSerialization('a.b.c'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('JsonWebEncryption.toCompactSerialization guards', () {
+    test('throws when there are multiple recipients', () {
+      final key2 = JsonWebKey.fromJson({
+        'kty': 'oct',
+        'alg': 'A128KW',
+        'k': 'AAECAwQFBgcICQoLDA0ODw',
+      })!;
+      final jwe = (JsonWebEncryptionBuilder()
+            ..encryptionAlgorithm = 'A128CBC-HS256'
+            ..content = 'multi'
+            ..addRecipient(octKw, algorithm: 'A128KW')
+            ..addRecipient(key2, algorithm: 'A128KW'))
+          .build();
+      expect(() => jwe.toCompactSerialization(), throwsStateError);
+    });
+
+    test('throws when a shared unprotected header is present', () {
+      // Using additionalAuthenticatedData forces the non-compact build path,
+      // which produces a shared unprotected header.
+      final jwe = (JsonWebEncryptionBuilder()
+            ..encryptionAlgorithm = 'A128CBC-HS256'
+            ..content = 'aad-forces-json'
+            ..additionalAuthenticatedData = utf8.encode('extra')
+            ..addRecipient(octKw, algorithm: 'A128KW'))
+          .build();
+      expect(() => jwe.toCompactSerialization(), throwsStateError);
+    });
+
+    test('throws when only a per-recipient unprotected header is present', () {
+      // Build a valid compact JWE, then re-serialize it as flattened JSON with
+      // a per-recipient `header` (and no shared `unprotected`).
+      final dirKey = JsonWebKey.generate('A128CBC-HS256');
+      final compact = (JsonWebEncryptionBuilder()
+            ..encryptionAlgorithm = 'A128CBC-HS256'
+            ..content = 'hi'
+            ..addRecipient(dirKey, algorithm: 'dir'))
+          .build()
+          .toCompactSerialization()
+          .split('.');
+      final flattened = JsonWebEncryption.fromJson({
+        'protected': compact[0],
+        'header': {'kid': 'x'},
+        'iv': compact[2],
+        'ciphertext': compact[3],
+        'tag': compact[4],
+      });
+      expect(() => flattened.toCompactSerialization(), throwsStateError);
+    });
+  });
+
+  group('JsonWebEncryptionBuilder.build guards', () {
+    test('throws when the encryption algorithm is null', () {
+      final builder = JsonWebEncryptionBuilder()
+        ..encryptionAlgorithm = null
+        ..content = 'x'
+        ..addRecipient(octKw, algorithm: 'A128KW');
+      expect(() => builder.build(), throwsStateError);
+    });
+
+    test('throws when the encryption algorithm is `none`', () {
+      final builder = JsonWebEncryptionBuilder()
+        ..encryptionAlgorithm = 'none'
+        ..content = 'x'
+        ..addRecipient(octKw, algorithm: 'A128KW');
+      expect(() => builder.build(), throwsStateError);
+    });
+
+    test('throws when there are no recipients', () {
+      final builder = JsonWebEncryptionBuilder()
+        ..encryptionAlgorithm = 'A128CBC-HS256'
+        ..content = 'x';
+      expect(() => builder.build(), throwsStateError);
+    });
+
+    test('throws when no payload has been set', () {
+      final builder = JsonWebEncryptionBuilder()
+        ..encryptionAlgorithm = 'A128CBC-HS256'
+        ..addRecipient(octKw, algorithm: 'A128KW');
+      expect(() => builder.build(), throwsStateError);
+    });
+
+    test('throws when using `dir` with more than one recipient', () {
+      final k1 = JsonWebKey.generate('A128CBC-HS256');
+      final k2 = JsonWebKey.generate('A128CBC-HS256');
+      final builder = JsonWebEncryptionBuilder()
+        ..encryptionAlgorithm = 'A128CBC-HS256'
+        ..content = 'x'
+        ..addRecipient(k1, algorithm: 'dir')
+        ..addRecipient(k2, algorithm: 'dir');
+      expect(() => builder.build(), throwsStateError);
+    });
+
+    test('throws when using ECDH-ES direct with more than one recipient', () {
+      final k1 = JsonWebKey.generate('ECDH-ES');
+      final k2 = JsonWebKey.generate('ECDH-ES');
+      final builder = JsonWebEncryptionBuilder()
+        ..encryptionAlgorithm = 'A128GCM'
+        ..content = 'x'
+        ..addRecipient(k1, algorithm: 'ECDH-ES')
+        ..addRecipient(k2, algorithm: 'ECDH-ES');
+      expect(() => builder.build(), throwsStateError);
+    });
+
+    test('throws JoseException for an unsupported compression algorithm', () {
+      final dirKey = JsonWebKey.generate('A128CBC-HS256');
+      final builder = JsonWebEncryptionBuilder()
+        ..encryptionAlgorithm = 'A128CBC-HS256'
+        ..compressionAlgorithm = 'GZIP'
+        ..content = 'x'
+        ..addRecipient(dirKey, algorithm: 'dir');
+      expect(() => builder.build(), throwsA(isA<JoseException>()));
+    });
+  });
+
+  group('JsonWebEncryption with DEF compression', () {
+    test('round-trips a payload through deflate/inflate', () async {
+      final dirKey = JsonWebKey.generate('A128CBC-HS256');
+      final payload = 'compress me ' * 20;
+      final jwe = (JsonWebEncryptionBuilder()
+            ..encryptionAlgorithm = 'A128CBC-HS256'
+            ..compressionAlgorithm = 'DEF'
+            ..content = payload
+            ..addRecipient(dirKey, algorithm: 'dir'))
+          .build();
+
+      final parsed = JsonWebEncryption.fromCompactSerialization(
+          jwe.toCompactSerialization());
+      final keyStore = JsonWebKeyStore()..addKey(dirKey);
+      final result = await parsed.getPayload(keyStore);
+      expect(result.stringContent, payload);
+    });
+  });
+
+  group('ECDH-ES decryption error paths', () {
+    // Re-encodes a compact JWE after mutating its protected header JSON.
+    String withMutatedHeader(
+      String compact,
+      void Function(Map<String, dynamic>) mutate,
+    ) {
+      final parts = compact.split('.');
+      final header = json.decode(
+              utf8.decode(base64Url.decode(base64Url.normalize(parts[0]))))
+          as Map<String, dynamic>;
+      mutate(header);
+      parts[0] = base64Url
+          .encode(utf8.encode(json.encode(header)))
+          .replaceAll('=', '');
+      return parts.join('.');
+    }
+
+    test('fails when the ephemeral public key is missing from the header',
+        () async {
+      final ecKey = JsonWebKey.generate('ECDH-ES');
+      final compact = (JsonWebEncryptionBuilder()
+            ..encryptionAlgorithm = 'A128GCM'
+            ..content = 'secret'
+            ..addRecipient(ecKey, algorithm: 'ECDH-ES'))
+          .build()
+          .toCompactSerialization();
+
+      final tampered = withMutatedHeader(compact, (h) => h.remove('epk'));
+      final parsed = JsonWebEncryption.fromCompactSerialization(tampered);
+      final keyStore = JsonWebKeyStore()..addKey(ecKey);
+      // The missing-epk JoseException is swallowed per-recipient; the overall
+      // decryption then fails.
+      expect(parsed.getPayload(keyStore), throwsA(isA<JoseException>()));
+    });
+
+    test('processes apu/apv agreement info during key derivation', () async {
+      final ecKey = JsonWebKey.generate('ECDH-ES');
+      final compact = (JsonWebEncryptionBuilder()
+            ..encryptionAlgorithm = 'A128GCM'
+            ..content = 'secret'
+            ..addRecipient(ecKey, algorithm: 'ECDH-ES'))
+          .build()
+          .toCompactSerialization();
+
+      // Inject apu/apv that the sender did not use; derivation will run the
+      // apu/apv branches and produce a different key, so decryption ultimately
+      // fails.
+      final tampered = withMutatedHeader(compact, (h) {
+        h['apu'] = 'QWxpY2U'; // "Alice"
+        h['apv'] = 'Qm9i'; // "Bob"
+      });
+      final parsed = JsonWebEncryption.fromCompactSerialization(tampered);
+      final keyStore = JsonWebKeyStore()..addKey(ecKey);
+      expect(parsed.getPayload(keyStore), throwsA(isA<JoseException>()));
+    });
+  });
+
+  group('JsonWebEncryption with additional authenticated data', () {
+    test('toJson exposes aad and the payload round-trips via JSON', () async {
+      final dirKey = JsonWebKey.generate('A128CBC-HS256');
+      final payload = 'protected by aad';
+      final jwe = (JsonWebEncryptionBuilder()
+            ..encryptionAlgorithm = 'A128CBC-HS256'
+            ..additionalAuthenticatedData = utf8.encode('bound-data')
+            ..content = payload
+            ..addRecipient(dirKey, algorithm: 'dir'))
+          .build();
+
+      final asJson = jwe.toJson();
+      expect(asJson['aad'], isNotNull);
+
+      final parsed = JsonWebEncryption.fromJson(asJson);
+      final keyStore = JsonWebKeyStore()..addKey(dirKey);
+      final result = await parsed.getPayload(keyStore);
+      expect(result.stringContent, payload);
+    });
+  });
+}

--- a/packages/jose_plus/test/jwk_error_test.dart
+++ b/packages/jose_plus/test/jwk_error_test.dart
@@ -1,0 +1,282 @@
+import 'dart:convert';
+
+import 'package:crypto_keys_plus/crypto_keys.dart';
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:jose_plus/src/jwk.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonWebKey.fromCryptoKeys', () {
+    test('throws when both publicKey and privateKey are null', () {
+      expect(
+        () => JsonWebKey.fromCryptoKeys(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws when an RSA private key is paired with a non-RSA public key',
+        () {
+      final rsaPriv = JsonWebKey.generate('RS256').cryptoKeyPair.privateKey
+          as RsaPrivateKey;
+      final ecPub =
+          JsonWebKey.generate('ES256').cryptoKeyPair.publicKey as EcPublicKey;
+      expect(
+        () => JsonWebKey.fromCryptoKeys(privateKey: rsaPriv, publicKey: ecPub),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws when an EC private key is paired with a non-EC public key',
+        () {
+      final ecPriv =
+          JsonWebKey.generate('ES256').cryptoKeyPair.privateKey as EcPrivateKey;
+      final rsaPub =
+          JsonWebKey.generate('RS256').cryptoKeyPair.publicKey as RsaPublicKey;
+      expect(
+        () => JsonWebKey.fromCryptoKeys(privateKey: ecPriv, publicKey: rsaPub),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws UnsupportedError for an unsupported public-only key type', () {
+      final okpPub = JsonWebKey.generate('EdDSA').cryptoKeyPair.publicKey;
+      expect(
+        () => JsonWebKey.fromCryptoKeys(publicKey: okpPub),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('throws UnsupportedError for an unsupported private key type', () {
+      final okpPriv = JsonWebKey.generate('EdDSA').cryptoKeyPair.privateKey;
+      expect(
+        () => JsonWebKey.fromCryptoKeys(privateKey: okpPriv),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('builds an RSA public JWK from a public key', () {
+      final rsaPub =
+          JsonWebKey.generate('RS256').cryptoKeyPair.publicKey as RsaPublicKey;
+      final jwk = JsonWebKey.fromCryptoKeys(publicKey: rsaPub, keyId: 'r1');
+      expect(jwk.keyType, 'RSA');
+      expect(jwk.keyId, 'r1');
+      expect(jwk.cryptoKeyPair.privateKey, isNull);
+    });
+
+    test('builds an EC public JWK from a public key', () {
+      final ecPub =
+          JsonWebKey.generate('ES256').cryptoKeyPair.publicKey as EcPublicKey;
+      final jwk = JsonWebKey.fromCryptoKeys(publicKey: ecPub, keyId: 'e1');
+      expect(jwk.keyType, 'EC');
+      expect(jwk.keyId, 'e1');
+    });
+  });
+
+  group('JsonWebKey factory constructors', () {
+    test('rsa honours keyId and algorithm', () {
+      final jwk = JsonWebKey.rsa(
+        modulus: BigInt.parse('12345678'),
+        exponent: BigInt.parse('65537'),
+        keyId: 'rsa-key',
+        algorithm: 'RS256',
+      );
+      expect(jwk.keyType, 'RSA');
+      expect(jwk.keyId, 'rsa-key');
+      expect(jwk.algorithm, 'RS256');
+    });
+
+    test('ec honours keyId and algorithm', () {
+      final source = JsonWebKey.generate('ES256');
+      final pub = source.cryptoKeyPair.publicKey as EcPublicKey;
+      final jwk = JsonWebKey.ec(
+        curve: 'P-256',
+        xCoordinate: pub.xCoordinate,
+        yCoordinate: pub.yCoordinate,
+        keyId: 'ec-key',
+        algorithm: 'ES256',
+      );
+      expect(jwk.keyType, 'EC');
+      expect(jwk.keyId, 'ec-key');
+      expect(jwk.algorithm, 'ES256');
+    });
+
+    test('symmetric builds an oct key with a keyId', () {
+      final jwk = JsonWebKey.symmetric(
+        key: BigInt.parse('123456789abcdef0', radix: 16),
+        keyId: 'sym-key',
+      );
+      expect(jwk.keyType, 'oct');
+      expect(jwk.keyId, 'sym-key');
+    });
+  });
+
+  group('JsonWebKey X.509 accessors', () {
+    test('exposes x5u, x5t and x5t#S256 parameters', () {
+      final jwk = JsonWebKey.fromJson({
+        'kty': 'oct',
+        'k': 'GawgguFyGrWKav7AX4VKUg',
+        'x5u': 'https://example.com/cert',
+        'x5t': 'thumb-1',
+        'x5t#S256': 'thumb-256',
+      })!;
+      expect(jwk.x509Url, Uri.parse('https://example.com/cert'));
+      expect(jwk.x509CertificateThumbprint, 'thumb-1');
+      expect(jwk.x509CertificateSha256Thumbprint, 'thumb-256');
+    });
+
+    test('throws a FormatException when x5c is not a valid certificate', () {
+      // base64 of DER [0x02, 0x01, 0x05] — an ASN.1 INTEGER, not a SEQUENCE.
+      final badCert = base64.encode([2, 1, 5]);
+      expect(
+        () => JsonWebKey.fromJson({
+          'kty': 'oct',
+          'k': 'GawgguFyGrWKav7AX4VKUg',
+          'x5c': [badCert],
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('JsonWebKey cryptographic operation guards', () {
+    test('sign throws StateError when the key cannot sign', () {
+      final publicOnly = JsonWebKey.fromJson({
+        'kty': 'RSA',
+        'n': 'sXchDaQebHnPiGvyDOAT4saGEUetSyo9MKLOoWFsueri23bOdgWp4Dy1Wl'
+            'UzewbgBHod5pcM9H95GQRV3JDXboIRROSBigeC5yjU1hGzHHyXss8UDpre'
+            'cbAYxknTcQkhslANGRUZmdTOQ5qTRsLAt6BTYuyvVRdhS8exSZEy_c4gs_'
+            '7svlJJQ4H9_NxsiIoLwAEk7-Q3UXERGYw_75IDrGA84-lA_-Ct4eTlXHBI'
+            'Y2EaV7t7LjJaynVJCpkv4LKjTTAumiGUIuQhrNhZLuF_RJLqHpM2kgWFLU'
+            '7-VTdL1VbC2tejvcI2BlMkEpk1BzBZI0KQB0GaDWFLN-aEAw3vRw',
+        'e': 'AQAB',
+      })!;
+      expect(
+        () => publicOnly.sign([1, 2, 3], algorithm: 'RS256'),
+        throwsStateError,
+      );
+    });
+
+    test('sign throws ArgumentError when algorithm differs from key algorithm',
+        () {
+      final key = JsonWebKey.fromJson({
+        'kty': 'oct',
+        'k': 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75'
+            'aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow',
+        'alg': 'HS256',
+      })!;
+      expect(
+        () => key.sign([1, 2, 3], algorithm: 'HS384'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('sign throws ArgumentError when no algorithm can be determined', () {
+      final key = JsonWebKey.fromJson({
+        'kty': 'oct',
+        'k': 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75'
+            'aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow',
+      })!;
+      expect(() => key.sign([1, 2, 3]), throwsA(isA<ArgumentError>()));
+    });
+
+    test('wrapKey throws UnsupportedError when wrapping a non-oct key', () {
+      final wrappingKey = JsonWebKey.generate('RSA-OAEP');
+      final ecKey = JsonWebKey.generate('ES256');
+      expect(
+        () => wrappingKey.wrapKey(ecKey),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('wrapKey/unwrapKey round-trips a symmetric content key', () {
+      final wrappingKey = JsonWebKey.generate('RSA-OAEP');
+      final cek = JsonWebKey.generate('A128GCM');
+      final wrapped = wrappingKey.wrapKey(cek);
+      final unwrapped = wrappingKey.unwrapKey(wrapped);
+      expect(unwrapped.keyType, 'oct');
+      expect(unwrapped['k'], cek['k']);
+    });
+  });
+
+  group('JsonWebKey.usableForOperation and algorithmForOperation', () {
+    test('a private RSA signing key can sign but a public one cannot', () {
+      final pub =
+          JsonWebKey.generate('RS256').cryptoKeyPair.publicKey as RsaPublicKey;
+      final publicJwk = JsonWebKey.fromCryptoKeys(publicKey: pub);
+      expect(publicJwk.usableForOperation('sign'), isFalse);
+      expect(publicJwk.usableForOperation('verify'), isTrue);
+      expect(publicJwk.algorithmForOperation('sign'), isNull);
+    });
+  });
+
+  group('JsonWebKeySetLoader', () {
+    test('global getter and setter can be swapped and restored', () async {
+      final original = JsonWebKeySetLoader.current;
+      final custom = DefaultJsonWebKeySetLoader();
+      try {
+        JsonWebKeySetLoader.global = custom;
+        expect(JsonWebKeySetLoader.current, same(custom));
+      } finally {
+        JsonWebKeySetLoader.global = original;
+      }
+    });
+  });
+
+  group('DefaultJsonWebKeySetLoader.readAsString', () {
+    test('reads a JWK set from a data: URI', () async {
+      final setJson = json.encode({
+        'keys': [
+          {'kty': 'oct', 'alg': 'A128KW', 'k': 'GawgguFyGrWKav7AX4VKUg'}
+        ]
+      });
+      final uri = Uri.parse(
+          'data:application/json;charset=utf-8,${Uri.encodeComponent(setJson)}');
+      final loader = DefaultJsonWebKeySetLoader();
+      final set = await loader.read(uri);
+      expect(set.keys, hasLength(1));
+      expect(set.keys.single.algorithm, 'A128KW');
+    });
+
+    test('throws UnsupportedError for an unsupported URI scheme', () {
+      final loader = DefaultJsonWebKeySetLoader();
+      expect(
+        () => loader.readAsString(Uri.parse('ftp://example.com/keys')),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('honours date/expires headers to compute cache expiry', () async {
+      final setJson = json.encode({'keys': []});
+      final now = DateTime.utc(2022, 1, 1, 12);
+      var callCount = 0;
+      final client = MockClient((request) async {
+        callCount++;
+        return Response(setJson, 200, headers: {
+          'date': formatHttpDate(now),
+          'expires': formatHttpDate(now.add(const Duration(hours: 1))),
+        });
+      });
+      final loader = DefaultJsonWebKeySetLoader(httpClient: client);
+      final uri = Uri.parse('https://example.com/keys.json');
+      await loader.readAsString(uri);
+      // Second read within the cache window should not hit the network again.
+      await loader.readAsString(uri);
+      expect(callCount, 1);
+    });
+
+    test('falls back to the default cache expiry when date header is invalid',
+        () async {
+      final setJson = json.encode({'keys': []});
+      final client = MockClient((request) async {
+        return Response(setJson, 200, headers: {'date': 'not-a-real-date'});
+      });
+      final loader = DefaultJsonWebKeySetLoader(httpClient: client);
+      final body =
+          await loader.readAsString(Uri.parse('https://example.com/k.json'));
+      expect(body, setJson);
+    });
+  });
+}

--- a/packages/jose_plus/test/jws_error_test.dart
+++ b/packages/jose_plus/test/jws_error_test.dart
@@ -1,0 +1,98 @@
+import 'package:jose_plus/jose.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final octKey = JsonWebKey.fromJson({
+    'kty': 'oct',
+    'k':
+        'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow',
+  })!;
+
+  group('JsonWebSignature.fromCompactSerialization', () {
+    test('throws when the serialization does not have three parts', () {
+      expect(
+        () => JsonWebSignature.fromCompactSerialization('only.two'),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => JsonWebSignature.fromCompactSerialization('a.b.c.d'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('JsonWebSignature.toCompactSerialization', () {
+    test('throws for a JWS with multiple signatures', () {
+      final jws = JsonWebSignature.fromJson({
+        'payload': 'eyJpc3MiOiJqb2UifQ',
+        'signatures': [
+          {'protected': 'eyJhbGciOiJSUzI1NiJ9', 'signature': 'AAAA'},
+          {'protected': 'eyJhbGciOiJFUzI1NiJ9', 'signature': 'BBBB'},
+        ],
+      });
+      expect(() => jws.toCompactSerialization(), throwsStateError);
+    });
+
+    test('throws when a recipient has an unprotected header', () {
+      final jws = JsonWebSignature.fromJson({
+        'payload': 'eyJpc3MiOiJqb2UifQ',
+        'protected': 'eyJhbGciOiJFUzI1NiJ9',
+        'header': {'kid': 'key-1'},
+        'signature': 'AAAA',
+      });
+      expect(() => jws.toCompactSerialization(), throwsStateError);
+    });
+  });
+
+  group('JsonWebSignatureBuilder.build', () {
+    test('throws when there are no recipients', () {
+      final builder = JsonWebSignatureBuilder()..content = 'hello';
+      expect(() => builder.build(), throwsStateError);
+    });
+
+    test('throws when no payload has been set', () {
+      final builder = JsonWebSignatureBuilder()
+        ..addRecipient(null, algorithm: 'none');
+      expect(() => builder.build(), throwsStateError);
+    });
+
+    test(
+        'throws when a protected header alg conflicts with the recipient '
+        'algorithm', () {
+      final builder = JsonWebSignatureBuilder()
+        ..content = 'hello'
+        ..setProtectedHeader('alg', 'HS512')
+        ..addRecipient(octKey, algorithm: 'HS256');
+      expect(() => builder.build(), throwsA(isA<ArgumentError>()));
+    });
+
+    test(
+        'succeeds and produces a verifiable JWS when protected header alg '
+        'matches the recipient algorithm', () async {
+      final builder = JsonWebSignatureBuilder()
+        ..content = 'hello'
+        ..setProtectedHeader('alg', 'HS256')
+        ..addRecipient(octKey, algorithm: 'HS256');
+      final jws = builder.build();
+
+      final keyStore = JsonWebKeyStore()..addKey(octKey);
+      final payload = await jws.getPayload(keyStore);
+      expect(payload.stringContent, 'hello');
+    });
+  });
+
+  group('JsonWebSignature.getPayloadFor with alg none', () {
+    test('returns the payload only when no key and empty signature', () async {
+      final builder = JsonWebSignatureBuilder()
+        ..content = 'unsecured'
+        ..addRecipient(null, algorithm: 'none');
+      final jws = JsonWebSignature.fromCompactSerialization(
+          builder.build().toCompactSerialization());
+
+      final keyStore = JsonWebKeyStore();
+      final payload =
+          await jws.getPayload(keyStore, allowedAlgorithms: ['none']);
+      expect(payload.stringContent, 'unsecured');
+    });
+  });
+}

--- a/packages/jose_plus/test/jwt_claims_test.dart
+++ b/packages/jose_plus/test/jwt_claims_test.dart
@@ -1,0 +1,199 @@
+import 'package:clock/clock.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonWebTokenClaims getters', () {
+    test('exposes all registered claim getters', () {
+      final claims = JsonWebTokenClaims.fromJson({
+        'iss': 'https://issuer.example.com',
+        'sid': 'session-123',
+        'sub': 'subject-42',
+        'aud': ['client-a', 'client-b'],
+        'exp': 1300819380,
+        'nbf': 1300819000,
+        'iat': 1300818900,
+        'jti': 'unique-id',
+      });
+
+      expect(claims.issuer, Uri.parse('https://issuer.example.com'));
+      expect(claims.sid, 'session-123');
+      expect(claims.subject, 'subject-42');
+      expect(claims.audience, ['client-a', 'client-b']);
+      expect(claims.expiry,
+          DateTime.fromMillisecondsSinceEpoch(1300819380 * 1000));
+      expect(claims.notBefore,
+          DateTime.fromMillisecondsSinceEpoch(1300819000 * 1000));
+      expect(claims.issuedAt,
+          DateTime.fromMillisecondsSinceEpoch(1300818900 * 1000));
+      expect(claims.jwtId, 'unique-id');
+    });
+
+    test('audience accepts a single string value', () {
+      final claims = JsonWebTokenClaims.fromJson({'aud': 'only-client'});
+      expect(claims.audience, ['only-client']);
+    });
+  });
+
+  group('JsonWebTokenClaims.validate', () {
+    // A fixed clock so expiry math is deterministic.
+    final now = DateTime.utc(2022, 1, 1, 12, 0, 0);
+    final nowSeconds = now.millisecondsSinceEpoch ~/ 1000;
+
+    Iterable<JoseException> validateAt(
+      DateTime at,
+      JsonWebTokenClaims claims, {
+      Duration expiryTolerance = Duration.zero,
+      Uri? issuer,
+      String? clientId,
+    }) {
+      return withClock(Clock.fixed(at), () {
+        return claims
+            .validate(
+              expiryTolerance: expiryTolerance,
+              issuer: issuer,
+              clientId: clientId,
+            )
+            .toList();
+      });
+    }
+
+    test('a valid, unexpired token yields no exceptions', () {
+      final claims = JsonWebTokenClaims.fromJson({
+        'iss': 'https://issuer.example.com',
+        'aud': ['my-client'],
+        'exp': nowSeconds + 3600,
+      });
+
+      final errors = validateAt(
+        now,
+        claims,
+        issuer: Uri.parse('https://issuer.example.com'),
+        clientId: 'my-client',
+      );
+      expect(errors, isEmpty);
+    });
+
+    test('reports an expired token', () {
+      final claims = JsonWebTokenClaims.fromJson({
+        'exp': nowSeconds - 3600,
+      });
+
+      final errors = validateAt(now, claims);
+      expect(errors, hasLength(1));
+      expect(errors.single.message, contains('expired'));
+    });
+
+    test('respects the expiry tolerance', () {
+      final claims = JsonWebTokenClaims.fromJson({
+        'exp': nowSeconds - 30,
+      });
+
+      // Within tolerance -> accepted.
+      expect(
+        validateAt(now, claims, expiryTolerance: const Duration(minutes: 1)),
+        isEmpty,
+      );
+      // Beyond tolerance -> rejected.
+      expect(
+        validateAt(now, claims, expiryTolerance: const Duration(seconds: 5)),
+        hasLength(1),
+      );
+    });
+
+    test('reports an issuer mismatch', () {
+      final claims = JsonWebTokenClaims.fromJson({
+        'iss': 'https://evil.example.com',
+        'exp': nowSeconds + 3600,
+      });
+
+      final errors = validateAt(
+        now,
+        claims,
+        issuer: Uri.parse('https://issuer.example.com'),
+      );
+      expect(errors, hasLength(1));
+      expect(errors.single.message, contains('Issuer does not match'));
+    });
+
+    test('reports a clientId not present in the audience', () {
+      final claims = JsonWebTokenClaims.fromJson({
+        'aud': ['someone-else'],
+        'exp': nowSeconds + 3600,
+      });
+
+      final errors = validateAt(now, claims, clientId: 'my-client');
+      expect(errors, hasLength(1));
+      expect(errors.single.message, contains('clientId'));
+    });
+
+    test('reports a missing audience when clientId is required', () {
+      final claims = JsonWebTokenClaims.fromJson({
+        'exp': nowSeconds + 3600,
+      });
+
+      final errors = validateAt(now, claims, clientId: 'my-client');
+      expect(errors, hasLength(1));
+      expect(errors.single.message, contains('clientId'));
+    });
+
+    test('accumulates multiple validation errors', () {
+      final claims = JsonWebTokenClaims.fromJson({
+        'iss': 'https://evil.example.com',
+        'aud': ['someone-else'],
+        'exp': nowSeconds - 3600,
+      });
+
+      final errors = validateAt(
+        now,
+        claims,
+        issuer: Uri.parse('https://issuer.example.com'),
+        clientId: 'my-client',
+      );
+      expect(errors, hasLength(3));
+    });
+  });
+
+  group('JsonWebToken verification state', () {
+    final key = JsonWebKey.fromJson({
+      'kty': 'oct',
+      'k':
+          'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow',
+    })!;
+
+    String signedJwt() {
+      return (JsonWebSignatureBuilder()
+            ..jsonContent = {'sub': 'user', 'exp': 9999999999}
+            ..setProtectedHeader('typ', 'JWT')
+            ..addRecipient(key, algorithm: 'HS256'))
+          .build()
+          .toCompactSerialization();
+    }
+
+    test('unverified() leaves isVerified null until a verify attempt', () {
+      final jwt = JsonWebToken.unverified(signedJwt());
+      expect(jwt.isVerified, isNull);
+      expect(jwt.claims.subject, 'user');
+    });
+
+    test('verify() returns true and sets isVerified for the correct key',
+        () async {
+      final jwt = JsonWebToken.unverified(signedJwt());
+      final ok = await jwt.verify(JsonWebKeyStore()..addKey(key));
+      expect(ok, isTrue);
+      expect(jwt.isVerified, isTrue);
+    });
+
+    test('verify() returns false and sets isVerified for a wrong key',
+        () async {
+      final jwt = JsonWebToken.unverified(signedJwt());
+      final wrongKey = JsonWebKey.fromJson({
+        'kty': 'oct',
+        'k': 'AAECAwQFBgcICQoLDA0ODw',
+      })!;
+      final ok = await jwt.verify(JsonWebKeyStore()..addKey(wrongKey));
+      expect(ok, isFalse);
+      expect(jwt.isVerified, isFalse);
+    });
+  });
+}

--- a/packages/jose_plus/test/util_test.dart
+++ b/packages/jose_plus/test/util_test.dart
@@ -1,0 +1,160 @@
+import 'package:jose_plus/src/util.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonObject', () {
+    test('equality and hashCode are based on encoded content', () {
+      final a = JsonObject.from({'a': 1, 'b': 'two'});
+      final b = JsonObject.from({'a': 1, 'b': 'two'});
+      final c = JsonObject.from({'a': 2, 'b': 'two'});
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+      // Comparing against a non-JsonObject value returns false.
+      final Object other = 'not a json object';
+      expect(a == other, isFalse);
+    });
+
+    test('toString reflects the underlying map', () {
+      final o = JsonObject.from({'x': 1});
+      expect(o.toString(), '{x: 1}');
+    });
+
+    test('toBytes round-trips through the base64 encoding', () {
+      final o = JsonObject.from({'hello': 'world'});
+      final decoded = JsonObject.fromBytes(o.toBytes());
+      expect(decoded, equals(o));
+      expect(decoded['hello'], 'world');
+    });
+
+    test('from() rejects values that are not valid JSON', () {
+      expect(
+        () => JsonObject.from({'bad': DateTime.now()}),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('getTyped converts Uri values', () {
+      final o = JsonObject.from({'u': 'https://example.com/path'});
+      expect(o.getTyped<Uri>('u'), Uri.parse('https://example.com/path'));
+    });
+
+    test('getTyped converts Duration values from seconds', () {
+      final o = JsonObject.from({'d': 90});
+      expect(o.getTyped<Duration>('d'), const Duration(seconds: 90));
+    });
+
+    test('getTyped converts DateTime values from unix seconds', () {
+      final o = JsonObject.from({'t': 1300819380});
+      expect(
+        o.getTyped<DateTime>('t'),
+        DateTime.fromMillisecondsSinceEpoch(1300819380000),
+      );
+    });
+
+    test('getTyped returns null for absent keys', () {
+      final o = JsonObject.from({'a': 1});
+      expect(o.getTyped<Uri>('missing'), isNull);
+    });
+
+    test('getTypedList wraps a single scalar value into a list', () {
+      final o = JsonObject.from({'aud': 'only-one'});
+      expect(o.getTypedList<String>('aud'), ['only-one']);
+    });
+
+    test('getTypedList returns each element of a list', () {
+      final o = JsonObject.from({
+        'aud': ['a', 'b', 'c']
+      });
+      expect(o.getTypedList<String>('aud'), ['a', 'b', 'c']);
+    });
+
+    test('getTypedList returns null for absent keys', () {
+      final o = JsonObject.from({'a': 1});
+      expect(o.getTypedList<String>('missing'), isNull);
+    });
+  });
+
+  group('safeUnion', () {
+    test('merges disjoint maps', () {
+      expect(
+        safeUnion([
+          {'a': 1},
+          {'b': 2},
+          null,
+        ]),
+        {'a': 1, 'b': 2},
+      );
+    });
+
+    test('allows duplicate keys with equal values', () {
+      expect(
+        safeUnion([
+          {'a': 1},
+          {'a': 1, 'b': 2},
+        ]),
+        {'a': 1, 'b': 2},
+      );
+    });
+
+    test('throws on conflicting duplicate keys', () {
+      expect(
+        () => safeUnion([
+          {'a': 1},
+          {'a': 2},
+        ]),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('commonUnion', () {
+    test('returns empty for an empty iterable', () {
+      expect(commonUnion([]), isEmpty);
+    });
+
+    test('keeps only the parameters common (and equal) to all maps', () {
+      expect(
+        commonUnion([
+          {'a': 1, 'b': 2, 'c': 3},
+          {'a': 1, 'b': 9, 'c': 3},
+          {'a': 1, 'c': 3},
+        ]),
+        {'a': 1, 'c': 3},
+      );
+    });
+
+    test('returns empty when nothing is shared', () {
+      expect(
+        commonUnion([
+          {'a': 1},
+          {'b': 2},
+        ]),
+        isEmpty,
+      );
+    });
+  });
+
+  group('encodeBigInt', () {
+    test('encodes a positive BigInt to unpadded base64url', () {
+      // 0x010203 -> bytes [1,2,3]
+      final encoded = encodeBigInt(BigInt.parse('010203', radix: 16));
+      final decoded = decodeBase64EncodedBytes(encoded);
+      expect(decoded, [1, 2, 3]);
+    });
+
+    test('encodes zero to an empty byte sequence', () {
+      expect(encodeBigInt(BigInt.zero), isEmpty);
+    });
+  });
+
+  group('base64 helpers', () {
+    test('encode/decode round-trips arbitrary bytes without padding', () {
+      final data = [0, 1, 2, 250, 255];
+      final encoded = encodeBase64EncodedBytes(data);
+      expect(encoded, isNot(contains('=')));
+      expect(decodeBase64EncodedBytes(encoded), data);
+    });
+  });
+}

--- a/packages/oidc/test/facade_and_manager_test.dart
+++ b/packages/oidc/test/facade_and_manager_test.dart
@@ -1,0 +1,397 @@
+// ignore_for_file: prefer_single_quotes
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oidc/oidc.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import 'mock_client.dart';
+
+class MockOidcPlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements OidcPlatform {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockOidcPlatform oidcPlatform;
+
+  const clientCredentials = OidcClientAuthentication.none(
+    clientId: 'my_client_id',
+  );
+  final settings = OidcUserManagerSettings(
+    redirectUri: Uri.parse('http://example.com/redirect.html'),
+  );
+  final managerKeyStore = JsonWebKeyStore()..addKey(mockSigningKey);
+  final doc = OidcProviderMetadata.fromJson(mockProviderMetadata);
+
+  final authorizeRequest = OidcAuthorizeRequest(
+    clientId: 'my_client_id',
+    redirectUri: Uri.parse('http://example.com/redirect.html'),
+    scope: [OidcConstants_Scopes.openid],
+    responseType: [OidcConstants_AuthorizationEndpoint_ResponseType.code],
+  );
+  final endSessionRequest = OidcEndSessionRequest(
+    clientId: 'my_client_id',
+    postLogoutRedirectUri: Uri.parse('http://example.com/redirect.html'),
+  );
+  const platformOptions = OidcPlatformSpecificOptions();
+
+  setUp(() {
+    oidcPlatform = MockOidcPlatform();
+    when(
+      oidcPlatform.nativeBrowserEvents,
+    ).thenAnswer((_) => const Stream.empty());
+    OidcPlatform.instance = oidcPlatform;
+  });
+
+  group('OidcFlutter facade', () {
+    test('prepareForRedirectFlow returns whatever the platform returns', () {
+      when(
+        () => oidcPlatform.prepareForRedirectFlow(platformOptions),
+      ).thenReturn({'prepared': true});
+
+      final result = OidcFlutter.prepareForRedirectFlow(platformOptions);
+
+      expect(result, {'prepared': true});
+      verify(
+        () => oidcPlatform.prepareForRedirectFlow(platformOptions),
+      ).called(1);
+    });
+
+    test(
+      'getPlatformAuthorizationResponse returns the platform response',
+      () async {
+        final response = OidcAuthorizeResponse(
+          src: const {'code': 'abc'},
+          code: 'abc',
+        );
+        when(
+          () => oidcPlatform.getAuthorizationResponse(
+            doc,
+            authorizeRequest,
+            platformOptions,
+            const {},
+          ),
+        ).thenAnswer((_) async => response);
+
+        final result = await OidcFlutter.getPlatformAuthorizationResponse(
+          metadata: doc,
+          request: authorizeRequest,
+        );
+
+        expect(result, same(response));
+      },
+    );
+
+    test(
+      'getPlatformAuthorizationResponse rethrows OidcException unchanged',
+      () async {
+        const original = OidcException('native failure');
+        when(
+          () => oidcPlatform.getAuthorizationResponse(
+            doc,
+            authorizeRequest,
+            platformOptions,
+            const {},
+          ),
+        ).thenThrow(original);
+
+        await expectLater(
+          () => OidcFlutter.getPlatformAuthorizationResponse(
+            metadata: doc,
+            request: authorizeRequest,
+          ),
+          throwsA(same(original)),
+        );
+      },
+    );
+
+    test(
+      'getPlatformAuthorizationResponse wraps a non-OidcException failure',
+      () async {
+        final original = StateError('boom');
+        when(
+          () => oidcPlatform.getAuthorizationResponse(
+            doc,
+            authorizeRequest,
+            platformOptions,
+            const {},
+          ),
+        ).thenThrow(original);
+
+        await expectLater(
+          () => OidcFlutter.getPlatformAuthorizationResponse(
+            metadata: doc,
+            request: authorizeRequest,
+          ),
+          throwsA(
+            isA<OidcException>()
+                .having((e) => e.message, 'message', 'Failed to authorize user')
+                .having(
+                  (e) => e.internalException,
+                  'internalException',
+                  same(original),
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'getPlatformEndSessionResponse returns the platform response',
+      () async {
+        final response = OidcEndSessionResponse.fromJson({'state': 's1'});
+        when(
+          () => oidcPlatform.getEndSessionResponse(
+            doc,
+            endSessionRequest,
+            platformOptions,
+            const {},
+          ),
+        ).thenAnswer((_) async => response);
+
+        final result = await OidcFlutter.getPlatformEndSessionResponse(
+          metadata: doc,
+          request: endSessionRequest,
+          preparationResult: const {},
+        );
+
+        expect(result, same(response));
+      },
+    );
+
+    test(
+      'getPlatformEndSessionResponse wraps any failure into an OidcException',
+      () async {
+        final original = StateError('logout boom');
+        when(
+          () => oidcPlatform.getEndSessionResponse(
+            doc,
+            endSessionRequest,
+            platformOptions,
+            const {},
+          ),
+        ).thenThrow(original);
+
+        await expectLater(
+          () => OidcFlutter.getPlatformEndSessionResponse(
+            metadata: doc,
+            request: endSessionRequest,
+            preparationResult: const {},
+          ),
+          throwsA(
+            isA<OidcException>()
+                .having(
+                  (e) => e.message,
+                  'message',
+                  'Failed to end user session',
+                )
+                .having(
+                  (e) => e.internalException,
+                  'internalException',
+                  same(original),
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'listenToFrontChannelLogoutRequests streams events from the platform',
+      () async {
+        final incoming = OidcFrontChannelLogoutIncomingRequest.fromJson({
+          'iss': 'http://server.example.com',
+          'sid': 'session-1',
+        });
+        final listenTo = Uri.parse('http://example.com/front-channel');
+        const options = OidcFrontChannelRequestListeningOptions();
+        when(
+          () => oidcPlatform.listenToFrontChannelLogoutRequests(
+            listenTo,
+            options,
+          ),
+        ).thenAnswer((_) => Stream.value(incoming));
+
+        final stream = OidcFlutter.listenToFrontChannelLogoutRequests(
+          listenTo: listenTo,
+        );
+
+        await expectLater(stream, emits(same(incoming)));
+      },
+    );
+
+    test('monitorSessionStatus streams events from the platform', () async {
+      const result = OidcValidMonitorSessionResult(changed: true);
+      final checkSessionIframe = Uri.parse(
+        'http://server.example.com/check-session',
+      );
+      const request = OidcMonitorSessionStatusRequest(
+        clientId: 'my_client_id',
+        sessionState: 'session-state',
+        interval: Duration(seconds: 5),
+      );
+      when(
+        () => oidcPlatform.monitorSessionStatus(
+          checkSessionIframe: checkSessionIframe,
+          request: request,
+        ),
+      ).thenAnswer((_) => Stream.value(result));
+
+      final stream = OidcFlutter.monitorSessionStatus(
+        checkSessionIframe: checkSessionIframe,
+        request: request,
+      );
+
+      await expectLater(stream, emits(same(result)));
+    });
+
+    test('nativeBrowserEvents streams events from the platform', () async {
+      final event = OidcBrowserOpeningEvent(at: DateTime.now());
+      when(
+        oidcPlatform.nativeBrowserEvents,
+      ).thenAnswer((_) => Stream.value(event));
+
+      await expectLater(OidcFlutter.nativeBrowserEvents(), emits(same(event)));
+    });
+  });
+
+  group('OidcUserManager platform delegation', () {
+    late OidcUserManager manager;
+
+    setUp(() {
+      manager = OidcUserManager(
+        discoveryDocument: doc,
+        clientCredentials: clientCredentials,
+        store: OidcMemoryStore(),
+        settings: settings,
+        httpClient: createMockOidcClient(),
+        keyStore: managerKeyStore,
+      );
+    });
+
+    test('isWeb reflects the current platform (false under flutter test)', () {
+      expect(manager.isWeb, isFalse);
+    });
+
+    test('getAuthorizationResponse delegates to the platform', () async {
+      final response = OidcAuthorizeResponse(
+        src: const {'code': 'xyz'},
+        code: 'xyz',
+      );
+      when(
+        () => oidcPlatform.getAuthorizationResponse(
+          doc,
+          authorizeRequest,
+          platformOptions,
+          const {},
+        ),
+      ).thenAnswer((_) async => response);
+
+      final result = await manager.getAuthorizationResponse(
+        doc,
+        authorizeRequest,
+        platformOptions,
+        const {},
+      );
+
+      expect(result, same(response));
+    });
+
+    test('getEndSessionResponse delegates to the platform', () async {
+      final response = OidcEndSessionResponse.fromJson({'state': 's2'});
+      when(
+        () => oidcPlatform.getEndSessionResponse(
+          doc,
+          endSessionRequest,
+          platformOptions,
+          const {},
+        ),
+      ).thenAnswer((_) async => response);
+
+      final result = await manager.getEndSessionResponse(
+        doc,
+        endSessionRequest,
+        platformOptions,
+        const {},
+      );
+
+      expect(result, same(response));
+    });
+
+    test(
+      'listenToFrontChannelLogoutRequests delegates to the platform',
+      () async {
+        final incoming = OidcFrontChannelLogoutIncomingRequest.fromJson({
+          'iss': 'http://server.example.com',
+          'sid': 'session-2',
+        });
+        final listenTo = Uri.parse('http://example.com/front-channel-2');
+        const options = OidcFrontChannelRequestListeningOptions();
+        when(
+          () => oidcPlatform.listenToFrontChannelLogoutRequests(
+            listenTo,
+            options,
+          ),
+        ).thenAnswer((_) => Stream.value(incoming));
+
+        final stream = manager.listenToFrontChannelLogoutRequests(
+          listenTo,
+          options,
+        );
+
+        await expectLater(stream, emits(same(incoming)));
+      },
+    );
+
+    test('monitorSessionStatus delegates to the platform', () async {
+      const result = OidcValidMonitorSessionResult(changed: false);
+      final checkSessionIframe = Uri.parse(
+        'http://server.example.com/check-session-2',
+      );
+      const request = OidcMonitorSessionStatusRequest(
+        clientId: 'my_client_id',
+        sessionState: 'session-state-2',
+        interval: Duration(seconds: 10),
+      );
+      when(
+        () => oidcPlatform.monitorSessionStatus(
+          checkSessionIframe: checkSessionIframe,
+          request: request,
+        ),
+      ).thenAnswer((_) => Stream.value(result));
+
+      final stream = manager.monitorSessionStatus(
+        checkSessionIframe: checkSessionIframe,
+        request: request,
+      );
+
+      await expectLater(stream, emits(same(result)));
+    });
+
+    test('prepareForRedirectFlow delegates to the platform', () {
+      when(
+        () => oidcPlatform.prepareForRedirectFlow(platformOptions),
+      ).thenReturn({'ready': true});
+
+      final result = manager.prepareForRedirectFlow(platformOptions);
+
+      expect(result, {'ready': true});
+    });
+
+    test(
+      'listenToNativeBrowserEvents delegates to the platform stream',
+      () async {
+        final event = OidcBrowserFlowCancelledEvent(at: DateTime.now());
+        when(
+          oidcPlatform.nativeBrowserEvents,
+        ).thenAnswer((_) => Stream.value(event));
+
+        await expectLater(
+          manager.listenToNativeBrowserEvents(),
+          emits(same(event)),
+        );
+      },
+    );
+  });
+}

--- a/packages/oidc_cli/test/src/commands/discovery_command_test.dart
+++ b/packages/oidc_cli/test/src/commands/discovery_command_test.dart
@@ -1,0 +1,172 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oidc_cli/src/command_runner.dart';
+import 'package:oidc_cli/src/file_oidc_store.dart';
+import 'package:pub_updater/pub_updater.dart';
+import 'package:test/test.dart';
+
+import '../support/oidc_test_server.dart';
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockPubUpdater extends Mock implements PubUpdater {}
+
+void main() {
+  group('oidc discovery', () {
+    late Logger logger;
+    late List<String> infoMessages;
+    late List<String> errMessages;
+    late PubUpdater pubUpdater;
+    late OidcCliCommandRunner runner;
+    late Directory tempDir;
+    late String storePath;
+
+    setUp(() {
+      infoMessages = [];
+      errMessages = [];
+      logger = _MockLogger();
+      when(() => logger.info(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) infoMessages.add(message);
+      });
+      when(() => logger.err(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) errMessages.add(message);
+      });
+      pubUpdater = _MockPubUpdater();
+      runner = OidcCliCommandRunner(
+        logger: logger,
+        pubUpdater: pubUpdater,
+        hasTerminal: () => false,
+      );
+      tempDir = Directory.systemTemp.createTempSync(
+        'oidc_cli_discovery_command_test_',
+      );
+      storePath = File('${tempDir.path}/store.json').path;
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test(
+      'requires --issuer/--well-known when neither is given and no config '
+      'is saved',
+      () async {
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'discovery',
+        ]);
+
+        expect(result, ExitCode.usage.code);
+        expect(
+          errMessages,
+          contains('Error: --issuer (or --well-known) is required.'),
+        );
+      },
+    );
+
+    test('fetches and prints the discovery document for --issuer', () async {
+      late final TestOidcServer server;
+      server = await TestOidcServer.start(
+        onToken: (form, callCount) => server.tokenResponseJson(sub: 'u1'),
+      );
+      addTearDown(server.close);
+
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'discovery',
+        '--issuer',
+        server.issuer.toString(),
+      ]);
+
+      expect(result, ExitCode.success.code);
+      expect(infoMessages, hasLength(1));
+      expect(infoMessages.single, contains(server.issuer.toString()));
+      expect(infoMessages.single, contains('"token_endpoint"'));
+    });
+
+    test(
+      'falls back to the issuer saved in config when --issuer is omitted',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) => server.tokenResponseJson(sub: 'u1'),
+        );
+        addTearDown(server.close);
+
+        final store = FileOidcStore.fromPath(storePath, logger: logger);
+        await store.setConfig({
+          'issuer': server.issuer.toString(),
+          'clientId': 'my-client',
+          'clientSecret': null,
+          'scopes': ['openid'],
+          'port': 3000,
+        });
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'discovery',
+        ]);
+
+        expect(result, ExitCode.success.code);
+        expect(infoMessages.single, contains(server.issuer.toString()));
+      },
+    );
+
+    test('--well-known takes precedence over --issuer', () async {
+      late final TestOidcServer server;
+      server = await TestOidcServer.start(
+        onToken: (form, callCount) => server.tokenResponseJson(sub: 'u1'),
+      );
+      addTearDown(server.close);
+
+      final wellKnown = server.issuer.replace(
+        path: '/.well-known/openid-configuration',
+      );
+
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'discovery',
+        '--issuer',
+        'https://ignored.example.com',
+        '--well-known',
+        wellKnown.toString(),
+      ]);
+
+      expect(result, ExitCode.success.code);
+      expect(infoMessages.single, contains(server.issuer.toString()));
+      expect(infoMessages.single, isNot(contains('ignored.example.com')));
+    });
+
+    test('reports an error when the discovery fetch fails', () async {
+      final probe = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final deadPort = probe.port;
+      await probe.close(force: true);
+
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'discovery',
+        '--issuer',
+        'http://127.0.0.1:$deadPort',
+      ]);
+
+      expect(result, ExitCode.software.code);
+      expect(
+        errMessages.any(
+          (m) => m.startsWith('Error fetching discovery document: '),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/packages/oidc_cli/test/src/commands/login/login_interactive_command_test.dart
+++ b/packages/oidc_cli/test/src/commands/login/login_interactive_command_test.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oidc_cli/src/command_runner.dart';
+import 'package:pub_updater/pub_updater.dart';
+import 'package:test/test.dart';
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockPubUpdater extends Mock implements PubUpdater {}
+
+void main() {
+  // NOTE: the happy path of `login interactive` opens a real browser window
+  // (via `rundll32`/`open`/`xdg-open`) and starts a real loopback HTTP
+  // listener via `CliUserManager`, so it is intentionally not exercised
+  // here; only the argument-validation paths (which run before any of that)
+  // are covered.
+  group('oidc login interactive', () {
+    late Logger logger;
+    late List<String> errMessages;
+    late PubUpdater pubUpdater;
+    late OidcCliCommandRunner runner;
+    late Directory tempDir;
+    late String storePath;
+
+    setUp(() {
+      errMessages = [];
+      logger = _MockLogger();
+      when(() => logger.info(any())).thenReturn(null);
+      when(() => logger.err(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) errMessages.add(message);
+      });
+      pubUpdater = _MockPubUpdater();
+      runner = OidcCliCommandRunner(
+        logger: logger,
+        pubUpdater: pubUpdater,
+        hasTerminal: () => false,
+      );
+      tempDir = Directory.systemTemp.createTempSync(
+        'oidc_cli_login_interactive_test_',
+      );
+      storePath = File('${tempDir.path}/store.json').path;
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('requires --issuer and --client-id when both are missing', () async {
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'login',
+        'interactive',
+      ]);
+
+      expect(result, ExitCode.usage.code);
+      expect(
+        errMessages,
+        contains('Error: --issuer and --client-id are required.'),
+      );
+    });
+
+    test('requires --client-id when only --issuer is given', () async {
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'login',
+        'interactive',
+        '--issuer',
+        'https://example.com',
+      ]);
+
+      expect(result, ExitCode.usage.code);
+      expect(
+        errMessages,
+        contains('Error: --issuer and --client-id are required.'),
+      );
+    });
+
+    test('requires --issuer when only --client-id is given', () async {
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'login',
+        'interactive',
+        '--client-id',
+        'my-client',
+      ]);
+
+      expect(result, ExitCode.usage.code);
+      expect(
+        errMessages,
+        contains('Error: --issuer and --client-id are required.'),
+      );
+    });
+  });
+}

--- a/packages/oidc_cli/test/src/commands/login/login_password_command_test.dart
+++ b/packages/oidc_cli/test/src/commands/login/login_password_command_test.dart
@@ -1,0 +1,304 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oidc_cli/src/command_runner.dart';
+import 'package:oidc_cli/src/file_oidc_store.dart';
+import 'package:pub_updater/pub_updater.dart';
+import 'package:test/test.dart';
+
+import '../../support/oidc_test_server.dart';
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockPubUpdater extends Mock implements PubUpdater {}
+
+void main() {
+  group('oidc login password', () {
+    late Logger logger;
+    late List<String> infoMessages;
+    late List<String> errMessages;
+    late PubUpdater pubUpdater;
+    late OidcCliCommandRunner runner;
+    late Directory tempDir;
+    late String storePath;
+
+    setUp(() {
+      infoMessages = [];
+      errMessages = [];
+      logger = _MockLogger();
+      when(() => logger.info(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) infoMessages.add(message);
+      });
+      when(() => logger.err(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) errMessages.add(message);
+      });
+      when(() => logger.success(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) infoMessages.add(message);
+      });
+      pubUpdater = _MockPubUpdater();
+      runner = OidcCliCommandRunner(
+        logger: logger,
+        pubUpdater: pubUpdater,
+        hasTerminal: () => false,
+      );
+      tempDir = Directory.systemTemp.createTempSync(
+        'oidc_cli_login_password_test_',
+      );
+      storePath = File('${tempDir.path}/store.json').path;
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('requires --username', () async {
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'login',
+        'password',
+        '--password',
+        'secret',
+        '--issuer',
+        'https://example.com',
+        '--client-id',
+        'my-client',
+      ]);
+
+      expect(result, ExitCode.usage.code);
+      expect(errMessages, contains('Error: --username is required.'));
+    });
+
+    test('rejects a blank --username', () async {
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'login',
+        'password',
+        '--username',
+        '   ',
+        '--password',
+        'secret',
+      ]);
+
+      expect(result, ExitCode.usage.code);
+      expect(errMessages, contains('Error: --username is required.'));
+    });
+
+    test('requires --password', () async {
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'login',
+        'password',
+        '--username',
+        'alice',
+        '--issuer',
+        'https://example.com',
+        '--client-id',
+        'my-client',
+      ]);
+
+      expect(result, ExitCode.usage.code);
+      expect(errMessages, contains('Error: --password is required.'));
+    });
+
+    test(
+      'requires --issuer/--client-id when no config is saved',
+      () async {
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'login',
+          'password',
+          '--username',
+          'alice',
+          '--password',
+          'secret',
+        ]);
+
+        expect(result, ExitCode.usage.code);
+        expect(
+          errMessages,
+          contains(
+            'Error: --issuer and --client-id are required '
+            '(or must exist in the saved config).',
+          ),
+        );
+      },
+    );
+
+    test('logs in successfully and persists config + token', () async {
+      late final TestOidcServer server;
+      server = await TestOidcServer.start(
+        onToken: (form, callCount) {
+          expect(form['grant_type'], 'password');
+          expect(form['username'], 'alice');
+          expect(form['password'], 'secret');
+          return server.tokenResponseJson(sub: 'user-1', expiresIn: 3600);
+        },
+      );
+      addTearDown(server.close);
+
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'login',
+        'password',
+        '--username',
+        'alice',
+        '--password',
+        'secret',
+        '--issuer',
+        server.issuer.toString(),
+        '--client-id',
+        'my-client',
+        '--scopes',
+        'openid profile',
+      ]);
+
+      expect(result, ExitCode.success.code);
+      expect(infoMessages, contains('Authentication successful!'));
+      expect(
+        infoMessages,
+        contains('Access Token: access-token-abc'),
+      );
+
+      final store = FileOidcStore.fromPath(storePath, logger: logger);
+      final config = await store.getConfig();
+      expect(config['issuer'], server.issuer.toString());
+      expect(config['clientId'], 'my-client');
+      expect(config['scopes'], ['openid', 'profile']);
+      expect(config['port'], 3000);
+    });
+
+    test(
+      'reuses --issuer/--client-id from previously saved config',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) =>
+              server.tokenResponseJson(sub: 'user-1', expiresIn: 3600),
+        );
+        addTearDown(server.close);
+
+        final store = FileOidcStore.fromPath(storePath, logger: logger);
+        await store.setConfig({
+          'issuer': server.issuer.toString(),
+          'clientId': 'my-client',
+          'clientSecret': null,
+          'scopes': ['openid'],
+          'port': 3000,
+        });
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'login',
+          'password',
+          '--username',
+          'alice',
+          '--password',
+          'secret',
+        ]);
+
+        expect(result, ExitCode.success.code);
+        expect(infoMessages, contains('Authentication successful!'));
+      },
+    );
+
+    test(
+      'auto-refreshes when the returned token is expiring soon',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) {
+            if (callCount == 1) {
+              expect(form['grant_type'], 'password');
+              // Expires in 10s: below the 1-minute auto-refresh threshold.
+              return server.tokenResponseJson(sub: 'user-1', expiresIn: 10);
+            }
+            expect(form['grant_type'], 'refresh_token');
+            expect(form['refresh_token'], 'refresh-token-1');
+            return server.tokenResponseJson(
+              sub: 'user-1',
+              expiresIn: 3600,
+              accessToken: 'refreshed-access-token',
+            );
+          },
+        );
+        addTearDown(server.close);
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'login',
+          'password',
+          '--username',
+          'alice',
+          '--password',
+          'secret',
+          '--issuer',
+          server.issuer.toString(),
+          '--client-id',
+          'my-client',
+        ]);
+
+        expect(result, ExitCode.success.code);
+        expect(
+          infoMessages,
+          contains('Token expired or expiring soon. Refreshing...'),
+        );
+        expect(
+          infoMessages,
+          contains('Access Token: refreshed-access-token'),
+        );
+      },
+    );
+
+    test(
+      '--no-auto-refresh keeps the near-expiry token as-is',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) {
+            expect(callCount, 1, reason: 'refresh must not be attempted');
+            return server.tokenResponseJson(sub: 'user-1', expiresIn: 10);
+          },
+        );
+        addTearDown(server.close);
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'login',
+          'password',
+          '--username',
+          'alice',
+          '--password',
+          'secret',
+          '--issuer',
+          server.issuer.toString(),
+          '--client-id',
+          'my-client',
+          '--no-auto-refresh',
+        ]);
+
+        expect(result, ExitCode.success.code);
+        expect(infoMessages, contains('Access Token: access-token-abc'));
+        expect(
+          infoMessages,
+          isNot(
+            contains('Token expired or expiring soon. Refreshing...'),
+          ),
+        );
+      },
+    );
+  });
+}

--- a/packages/oidc_cli/test/src/commands/logout_command_test.dart
+++ b/packages/oidc_cli/test/src/commands/logout_command_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oidc_cli/src/command_runner.dart';
+import 'package:oidc_cli/src/file_oidc_store.dart';
+import 'package:pub_updater/pub_updater.dart';
+import 'package:test/test.dart';
+
+import '../support/oidc_test_server.dart';
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockPubUpdater extends Mock implements PubUpdater {}
+
+void main() {
+  group('oidc logout', () {
+    late Logger logger;
+    late List<String> infoMessages;
+    late PubUpdater pubUpdater;
+    late OidcCliCommandRunner runner;
+    late Directory tempDir;
+    late String storePath;
+
+    setUp(() {
+      infoMessages = [];
+      logger = _MockLogger();
+      when(() => logger.info(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) infoMessages.add(message);
+      });
+      when(() => logger.err(any())).thenReturn(null);
+      when(() => logger.warn(any())).thenReturn(null);
+      when(() => logger.success(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) infoMessages.add(message);
+      });
+      pubUpdater = _MockPubUpdater();
+      runner = OidcCliCommandRunner(
+        logger: logger,
+        pubUpdater: pubUpdater,
+        hasTerminal: () => false,
+      );
+      tempDir = Directory.systemTemp.createTempSync(
+        'oidc_cli_logout_command_test_',
+      );
+      storePath = File('${tempDir.path}/store.json').path;
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('succeeds trivially when there is no saved config', () async {
+      final result = await runner.run(['--store', storePath, 'logout']);
+
+      expect(result, ExitCode.success.code);
+      expect(infoMessages, contains('Logged out successfully.'));
+    });
+
+    test(
+      'clears the session and reports success for an active login',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) =>
+              server.tokenResponseJson(sub: 'user-1', expiresIn: 3600),
+        );
+        addTearDown(server.close);
+
+        final loginResult = await runner.run([
+          '--store',
+          storePath,
+          'login',
+          'password',
+          '--username',
+          'alice',
+          '--password',
+          'secret',
+          '--issuer',
+          server.issuer.toString(),
+          '--client-id',
+          'my-client',
+        ]);
+        expect(loginResult, ExitCode.success.code);
+        infoMessages.clear();
+
+        final result = await runner.run(['--store', storePath, 'logout']);
+
+        expect(result, ExitCode.success.code);
+        expect(infoMessages, contains('Revoking refresh token...'));
+        expect(infoMessages, contains('Revoking access token...'));
+        expect(infoMessages, contains('Logged out successfully.'));
+
+        // The user was forgotten: the manager should no longer report a
+        // `currentUser` on the next command that loads the same store.
+        final statusResult = await runner.run([
+          '--store',
+          storePath,
+          'status',
+        ]);
+        expect(statusResult, ExitCode.success.code);
+        expect(infoMessages, contains('Not logged in.'));
+      },
+    );
+
+    test(
+      'reports config present but no active session as a trivial success',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) => server.tokenResponseJson(sub: 'user-1'),
+        );
+        addTearDown(server.close);
+
+        final store = FileOidcStore.fromPath(storePath, logger: logger);
+        await store.setConfig({
+          'issuer': server.issuer.toString(),
+          'clientId': 'my-client',
+          'clientSecret': null,
+          'scopes': ['openid'],
+          'port': 3000,
+        });
+
+        final result = await runner.run(['--store', storePath, 'logout']);
+
+        // The manager is created (config is non-empty), so it still logs
+        // its revoke-attempt messages; `revokeRefreshToken`/
+        // `revokeAccessToken` themselves are no-ops when there is no
+        // `currentUser`.
+        expect(result, ExitCode.success.code);
+        expect(infoMessages, contains('Logged out successfully.'));
+      },
+    );
+  });
+}

--- a/packages/oidc_cli/test/src/commands/proxy/pub_proxy_command_test.dart
+++ b/packages/oidc_cli/test/src/commands/proxy/pub_proxy_command_test.dart
@@ -1,0 +1,158 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oidc_cli/src/command_runner.dart';
+import 'package:oidc_cli/src/file_oidc_store.dart';
+import 'package:pub_updater/pub_updater.dart';
+import 'package:test/test.dart';
+
+import '../../support/oidc_test_server.dart';
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockPubUpdater extends Mock implements PubUpdater {}
+
+void main() {
+  // NOTE: none of these tests result in a stored access token being found,
+  // so the command never reaches `addToDartPub` (which shells out to the
+  // real `dart pub token add` and would mutate the machine's actual pub
+  // credentials). `cache list` forwarded to the real `dart` binary below is
+  // read-only (deliberately NOT `--version`: that string collides with the
+  // CLI's own global `-v, --version` flag, which short-circuits the whole
+  // command runner before the subcommand even runs). The issuer always
+  // points at a local fake OIDC server rather than a real host, so
+  // discovery resolution is deterministic and offline-safe.
+  group('oidc dart pub (proxy)', () {
+    late Logger logger;
+    late List<String> errMessages;
+    late PubUpdater pubUpdater;
+    late OidcCliCommandRunner runner;
+    late Directory tempDir;
+    late String storePath;
+
+    setUp(() {
+      errMessages = [];
+      logger = _MockLogger();
+      when(() => logger.info(any())).thenReturn(null);
+      when(() => logger.err(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) errMessages.add(message);
+      });
+      pubUpdater = _MockPubUpdater();
+      runner = OidcCliCommandRunner(
+        logger: logger,
+        pubUpdater: pubUpdater,
+        hasTerminal: () => false,
+      );
+      tempDir = Directory.systemTemp.createTempSync(
+        'oidc_cli_pub_proxy_command_test_',
+      );
+      storePath = File('${tempDir.path}/store.json').path;
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test(
+      'forwards to `dart pub` and returns its exit code when no '
+      'hostedUrl is configured',
+      () async {
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'dart',
+          'pub',
+          'cache',
+          'list',
+        ]);
+
+        expect(result, ExitCode.success.code);
+      },
+    );
+
+    test(
+      'errors when a hostedUrl is configured but there is no active '
+      'session',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) => server.tokenResponseJson(sub: 'user-1'),
+        );
+        addTearDown(server.close);
+
+        final store = FileOidcStore.fromPath(storePath, logger: logger);
+        await store.setConfig({
+          'issuer': server.issuer.toString(),
+          'clientId': 'my-client',
+          'clientSecret': null,
+          'scopes': ['openid'],
+          'port': 3000,
+          'hostedUrl': 'https://pub.example.com',
+        });
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'dart',
+          'pub',
+          'cache',
+          'list',
+        ]);
+
+        expect(result, ExitCode.software.code);
+        expect(
+          errMessages,
+          contains(
+            'No active session/token found for pub. '
+            'Run `oidc login --add-to-dart-pub <hostedUrl>` first.',
+          ),
+        );
+      },
+    );
+
+    test(
+      '--hosted-url overrides the saved config (missing) hostedUrl for '
+      'the check',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) => server.tokenResponseJson(sub: 'user-1'),
+        );
+        addTearDown(server.close);
+
+        final store = FileOidcStore.fromPath(storePath, logger: logger);
+        await store.setConfig({
+          'issuer': server.issuer.toString(),
+          'clientId': 'my-client',
+          'clientSecret': null,
+          'scopes': ['openid'],
+          'port': 3000,
+        });
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'dart',
+          'pub',
+          '--hosted-url',
+          'https://override.example.com',
+          'cache',
+          'list',
+        ]);
+
+        expect(result, ExitCode.software.code);
+        expect(
+          errMessages,
+          contains(
+            'No active session/token found for pub. '
+            'Run `oidc login --add-to-dart-pub <hostedUrl>` first.',
+          ),
+        );
+      },
+    );
+  });
+}

--- a/packages/oidc_cli/test/src/commands/status_command_test.dart
+++ b/packages/oidc_cli/test/src/commands/status_command_test.dart
@@ -1,0 +1,206 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oidc_cli/src/command_runner.dart';
+import 'package:oidc_cli/src/file_oidc_store.dart';
+import 'package:pub_updater/pub_updater.dart';
+import 'package:test/test.dart';
+
+import '../support/oidc_test_server.dart';
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockPubUpdater extends Mock implements PubUpdater {}
+
+void main() {
+  group('oidc status', () {
+    late Logger logger;
+    late List<String> infoMessages;
+    late List<String> warnMessages;
+    late PubUpdater pubUpdater;
+    late OidcCliCommandRunner runner;
+    late Directory tempDir;
+    late String storePath;
+
+    setUp(() {
+      infoMessages = [];
+      warnMessages = [];
+      logger = _MockLogger();
+      when(() => logger.info(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) infoMessages.add(message);
+      });
+      when(() => logger.err(any())).thenReturn(null);
+      when(() => logger.success(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) infoMessages.add(message);
+      });
+      when(() => logger.warn(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) warnMessages.add(message);
+      });
+      pubUpdater = _MockPubUpdater();
+      runner = OidcCliCommandRunner(
+        logger: logger,
+        pubUpdater: pubUpdater,
+        hasTerminal: () => false,
+      );
+      tempDir = Directory.systemTemp.createTempSync(
+        'oidc_cli_status_command_test_',
+      );
+      storePath = File('${tempDir.path}/store.json').path;
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('reports no configuration found when store is empty', () async {
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'status',
+      ]);
+
+      expect(result, ExitCode.success.code);
+      expect(
+        infoMessages,
+        contains('Not logged in (no configuration found).'),
+      );
+    });
+
+    test(
+      'reports not logged in when config exists but no session',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) => server.tokenResponseJson(sub: 'user-1'),
+        );
+        addTearDown(server.close);
+
+        final store = FileOidcStore.fromPath(storePath, logger: logger);
+        await store.setConfig({
+          'issuer': server.issuer.toString(),
+          'clientId': 'my-client',
+          'clientSecret': null,
+          'scopes': ['openid'],
+          'port': 3000,
+        });
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'status',
+        ]);
+
+        expect(result, ExitCode.success.code);
+        expect(infoMessages, contains('Not logged in.'));
+      },
+    );
+
+    test(
+      'reports logged in with email claim and expiry for an active session',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) {
+            final nowSeconds =
+                DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+            final idToken = server.signIdToken({
+              'iss': server.issuer.toString(),
+              'aud': 'my-client',
+              'sub': 'user-1',
+              'email': 'alice@example.com',
+              'iat': nowSeconds,
+              'exp': nowSeconds + 300,
+            });
+            return {
+              'access_token': 'access-token-abc',
+              'id_token': idToken,
+              'token_type': 'Bearer',
+              'expires_in': 3600,
+              'refresh_token': 'refresh-token-1',
+            };
+          },
+        );
+        addTearDown(server.close);
+
+        final loginResult = await runner.run([
+          '--store',
+          storePath,
+          'login',
+          'password',
+          '--username',
+          'alice',
+          '--password',
+          'secret',
+          '--issuer',
+          server.issuer.toString(),
+          '--client-id',
+          'my-client',
+        ]);
+        expect(loginResult, ExitCode.success.code);
+        infoMessages.clear();
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'status',
+        ]);
+
+        expect(result, ExitCode.success.code);
+        expect(infoMessages, contains('Logged in.'));
+        expect(infoMessages, contains('User: alice@example.com'));
+        expect(
+          infoMessages.any((m) => m.startsWith('Token expires at: ')),
+          isTrue,
+        );
+        expect(warnMessages, isNot(contains('(Expired)')));
+      },
+    );
+
+    test(
+      'warns when the session token is already expired',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) =>
+              server.tokenResponseJson(sub: 'user-1', expiresIn: -3600),
+        );
+        addTearDown(server.close);
+
+        final loginResult = await runner.run([
+          '--store',
+          storePath,
+          'login',
+          'password',
+          '--username',
+          'alice',
+          '--password',
+          'secret',
+          '--issuer',
+          server.issuer.toString(),
+          '--client-id',
+          'my-client',
+          '--no-auto-refresh',
+        ]);
+        expect(loginResult, ExitCode.success.code);
+        infoMessages.clear();
+        warnMessages.clear();
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'status',
+        ]);
+
+        expect(result, ExitCode.success.code);
+        expect(infoMessages, contains('Logged in.'));
+        expect(warnMessages, contains('(Expired)'));
+      },
+    );
+  });
+}

--- a/packages/oidc_cli/test/src/commands/store_path_command_test.dart
+++ b/packages/oidc_cli/test/src/commands/store_path_command_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oidc_cli/src/command_runner.dart';
+import 'package:pub_updater/pub_updater.dart';
+import 'package:test/test.dart';
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockPubUpdater extends Mock implements PubUpdater {}
+
+void main() {
+  group('oidc store-path', () {
+    late Logger logger;
+    late List<String> infoMessages;
+    late PubUpdater pubUpdater;
+    late OidcCliCommandRunner runner;
+    late Directory tempDir;
+
+    setUp(() {
+      infoMessages = [];
+      logger = _MockLogger();
+      when(() => logger.info(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) infoMessages.add(message);
+      });
+      pubUpdater = _MockPubUpdater();
+      runner = OidcCliCommandRunner(
+        logger: logger,
+        pubUpdater: pubUpdater,
+        hasTerminal: () => false,
+      );
+      tempDir = Directory.systemTemp.createTempSync(
+        'oidc_cli_store_path_command_test_',
+      );
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('prints the absolute path of the --store override', () async {
+      final storePath = File('${tempDir.path}/nested/store.json').path;
+
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'store-path',
+      ]);
+
+      expect(result, ExitCode.success.code);
+      expect(infoMessages, hasLength(1));
+      expect(infoMessages.single, File(storePath).absolute.path);
+    });
+
+    test('is stable when given an already-absolute path', () async {
+      final storePath = File('${tempDir.path}/store.json').absolute.path;
+
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'store-path',
+      ]);
+
+      expect(result, ExitCode.success.code);
+      expect(infoMessages.single, storePath);
+    });
+  });
+}

--- a/packages/oidc_cli/test/src/commands/token/token_commands_test.dart
+++ b/packages/oidc_cli/test/src/commands/token/token_commands_test.dart
@@ -1,0 +1,274 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oidc_cli/src/command_runner.dart';
+import 'package:oidc_cli/src/file_oidc_store.dart';
+import 'package:pub_updater/pub_updater.dart';
+import 'package:test/test.dart';
+
+import '../../support/oidc_test_server.dart';
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockPubUpdater extends Mock implements PubUpdater {}
+
+void main() {
+  group('oidc token get / oidc token refresh', () {
+    late Logger logger;
+    late List<String> infoMessages;
+    late List<String> errMessages;
+    late PubUpdater pubUpdater;
+    late OidcCliCommandRunner runner;
+    late Directory tempDir;
+    late String storePath;
+
+    setUp(() {
+      infoMessages = [];
+      errMessages = [];
+      logger = _MockLogger();
+      when(() => logger.info(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) infoMessages.add(message);
+      });
+      when(() => logger.err(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) errMessages.add(message);
+      });
+      when(() => logger.success(any())).thenAnswer((invocation) {
+        final message = invocation.positionalArguments.first;
+        if (message is String) infoMessages.add(message);
+      });
+      pubUpdater = _MockPubUpdater();
+      runner = OidcCliCommandRunner(
+        logger: logger,
+        pubUpdater: pubUpdater,
+        hasTerminal: () => false,
+      );
+      tempDir = Directory.systemTemp.createTempSync(
+        'oidc_cli_token_command_test_',
+      );
+      storePath = File('${tempDir.path}/store.json').path;
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('get: no config at all -> no active session', () async {
+      final result = await runner.run(['--store', storePath, 'token', 'get']);
+
+      expect(result, ExitCode.software.code);
+      expect(
+        errMessages,
+        contains('No active session. Please login first.'),
+      );
+    });
+
+    test('refresh: no config at all -> no active session', () async {
+      final result = await runner.run([
+        '--store',
+        storePath,
+        'token',
+        'refresh',
+      ]);
+
+      expect(result, ExitCode.software.code);
+      expect(
+        errMessages,
+        contains('No active session. Please login first.'),
+      );
+    });
+
+    test(
+      'get: config present but never logged in -> no active session',
+      () async {
+        late final TestOidcServer server;
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) => server.tokenResponseJson(sub: 'user-1'),
+        );
+        addTearDown(server.close);
+
+        final store = FileOidcStore.fromPath(storePath, logger: logger);
+        await store.setConfig({
+          'issuer': server.issuer.toString(),
+          'clientId': 'my-client',
+          'clientSecret': null,
+          'scopes': ['openid'],
+          'port': 3000,
+        });
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'token',
+          'get',
+        ]);
+
+        expect(result, ExitCode.software.code);
+        expect(
+          errMessages,
+          contains('No active session. Please login first.'),
+        );
+      },
+    );
+
+    test(
+      'get: network failure resolving discovery is reported as an error',
+      () async {
+        // Bind then immediately close a loopback port, guaranteeing that
+        // subsequent connections to it are refused.
+        final probe = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        final deadPort = probe.port;
+        await probe.close(force: true);
+
+        final store = FileOidcStore.fromPath(storePath, logger: logger);
+        await store.setConfig({
+          'issuer': 'http://127.0.0.1:$deadPort',
+          'clientId': 'my-client',
+          'clientSecret': null,
+          'scopes': ['openid'],
+          'port': 3000,
+        });
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'token',
+          'get',
+        ]);
+
+        expect(result, ExitCode.software.code);
+        expect(
+          errMessages.any((m) => m.startsWith('Error retrieving token: ')),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'refresh: network failure resolving discovery is reported as an error',
+      () async {
+        final probe = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        final deadPort = probe.port;
+        await probe.close(force: true);
+
+        final store = FileOidcStore.fromPath(storePath, logger: logger);
+        await store.setConfig({
+          'issuer': 'http://127.0.0.1:$deadPort',
+          'clientId': 'my-client',
+          'clientSecret': null,
+          'scopes': ['openid'],
+          'port': 3000,
+        });
+
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'token',
+          'refresh',
+        ]);
+
+        expect(result, ExitCode.software.code);
+        expect(
+          errMessages.any((m) => m.startsWith('Error refreshing token: ')),
+          isTrue,
+        );
+      },
+    );
+
+    group('with an existing session', () {
+      late TestOidcServer server;
+
+      setUp(() async {
+        server = await TestOidcServer.start(
+          onToken: (form, callCount) {
+            if (form['grant_type'] == 'refresh_token') {
+              return server.tokenResponseJson(
+                sub: 'user-1',
+                expiresIn: 3600,
+                accessToken: 'refreshed-access-token',
+              );
+            }
+            // Login always issues a near-expiry token; individual tests
+            // control whether auto-refresh kicks in on top of it.
+            return server.tokenResponseJson(sub: 'user-1', expiresIn: 10);
+          },
+        );
+
+        final loginResult = await runner.run([
+          '--store',
+          storePath,
+          'login',
+          'password',
+          '--username',
+          'alice',
+          '--password',
+          'secret',
+          '--issuer',
+          server.issuer.toString(),
+          '--client-id',
+          'my-client',
+          '--no-auto-refresh',
+        ]);
+        expect(loginResult, ExitCode.success.code);
+        infoMessages.clear();
+      });
+
+      tearDown(() => server.close());
+
+      test('get: auto-refreshes an expiring token by default', () async {
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'token',
+          'get',
+        ]);
+
+        expect(result, ExitCode.success.code);
+        expect(
+          infoMessages,
+          contains('Token expired or expiring soon. Refreshing...'),
+        );
+        expect(infoMessages, contains('refreshed-access-token'));
+      });
+
+      test(
+        'get --no-auto-refresh prints the stored token unchanged',
+        () async {
+          final result = await runner.run([
+            '--store',
+            storePath,
+            'token',
+            'get',
+            '--no-auto-refresh',
+          ]);
+
+          expect(result, ExitCode.success.code);
+          expect(infoMessages, contains('access-token-abc'));
+          expect(
+            infoMessages,
+            isNot(
+              contains('Token expired or expiring soon. Refreshing...'),
+            ),
+          );
+        },
+      );
+
+      test('refresh: unconditionally refreshes and prints new token', () async {
+        final result = await runner.run([
+          '--store',
+          storePath,
+          'token',
+          'refresh',
+        ]);
+
+        expect(result, ExitCode.success.code);
+        expect(infoMessages, contains('Refreshing token...'));
+        expect(infoMessages, contains('refreshed-access-token'));
+      });
+    });
+  });
+}

--- a/packages/oidc_cli/test/src/support/oidc_test_server.dart
+++ b/packages/oidc_cli/test/src/support/oidc_test_server.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:jose_plus/jose.dart';
+
+/// A minimal local OIDC provider used to exercise the CLI's real HTTP flows
+/// (discovery document + token endpoint + JWKS) without mocking any of the
+/// SDK's HTTP layer, so id_token signature verification runs for real.
+class TestOidcServer {
+  TestOidcServer._(this.server, this._signingKey);
+
+  /// The bound loopback server.
+  final HttpServer server;
+  final JsonWebKey _signingKey;
+
+  /// The issuer URI (also the base URI) for this server.
+  Uri get issuer => Uri.parse('http://127.0.0.1:${server.port}');
+
+  /// Signs [payload] as a compact RS256 JWS, so tests exercise the
+  /// production (fail-closed) id_token verification path.
+  String signIdToken(Map<String, dynamic> payload) =>
+      (JsonWebSignatureBuilder()
+            ..jsonContent = payload
+            ..addRecipient(_signingKey, algorithm: 'RS256'))
+          .build()
+          .toCompactSerialization();
+
+  Map<String, dynamic> _publicJwk() => {
+    'kty': _signingKey['kty'],
+    'n': _signingKey['n'],
+    'e': _signingKey['e'],
+    'alg': 'RS256',
+    'use': 'sig',
+  };
+
+  /// Builds a standard successful token-endpoint JSON response, complete
+  /// with a validly-signed id_token for [sub] (audience = [clientId]).
+  Map<String, dynamic> tokenResponseJson({
+    required String sub,
+    String clientId = 'my-client',
+    int expiresIn = 300,
+    String accessToken = 'access-token-abc',
+    String refreshToken = 'refresh-token-1',
+  }) {
+    final nowSeconds = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+    final idToken = signIdToken({
+      'iss': issuer.toString(),
+      'aud': clientId,
+      'sub': sub,
+      'iat': nowSeconds,
+      'exp': nowSeconds + 300,
+    });
+    return {
+      'access_token': accessToken,
+      'id_token': idToken,
+      'token_type': 'Bearer',
+      'expires_in': expiresIn,
+      'refresh_token': refreshToken,
+    };
+  }
+
+  /// Starts a server that serves discovery + jwks, and delegates token
+  /// requests to [onToken]. [onToken] receives the parsed
+  /// `application/x-www-form-urlencoded` fields of the token request (e.g.
+  /// `grant_type`, `username`, `refresh_token`) plus a 1-based call counter,
+  /// and must return the JSON map to serve as the response.
+  static Future<TestOidcServer> start({
+    required FutureOr<Map<String, dynamic>> Function(
+      Map<String, String> form,
+      int callCount,
+    )
+    onToken,
+  }) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final signingKey = JsonWebKey.generate('RS256');
+    final testServer = TestOidcServer._(server, signingKey);
+    var tokenCallCount = 0;
+
+    server.listen((request) async {
+      try {
+        final path = request.uri.path;
+        if (request.method == 'GET' &&
+            path == '/.well-known/openid-configuration') {
+          await _writeJson(request.response, {
+            'issuer': testServer.issuer.toString(),
+            'token_endpoint': testServer.issuer
+                .replace(path: '/token')
+                .toString(),
+            'jwks_uri': testServer.issuer.replace(path: '/jwks').toString(),
+            'id_token_signing_alg_values_supported': ['RS256'],
+          });
+          return;
+        }
+        if (request.method == 'GET' && path == '/jwks') {
+          await _writeJson(request.response, {
+            'keys': [testServer._publicJwk()],
+          });
+          return;
+        }
+        if (request.method == 'POST' && path == '/token') {
+          tokenCallCount += 1;
+          final bodyStr = await utf8.decoder.bind(request).join();
+          final form = Uri.splitQueryString(bodyStr);
+          final json = await onToken(form, tokenCallCount);
+          await _writeJson(request.response, json);
+          return;
+        }
+        request.response.statusCode = HttpStatus.notFound;
+        await request.response.close();
+      } on Object {
+        request.response.statusCode = HttpStatus.internalServerError;
+        await request.response.close();
+      }
+    });
+
+    return testServer;
+  }
+
+  /// Force-closes the server.
+  Future<void> close() => server.close(force: true);
+
+  static Future<void> _writeJson(HttpResponse response, Object json) async {
+    response.headers.contentType = ContentType.json;
+    response.write(jsonEncode(json));
+    await response.close();
+  }
+}

--- a/packages/oidc_core/test/claim_source_test.dart
+++ b/packages/oidc_core/test/claim_source_test.dart
@@ -1,0 +1,66 @@
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OidcClaimSource.fromJson dispatch', () {
+    test('a JWT member produces an aggregated claim source', () {
+      final source = OidcClaimSource.fromJson({
+        'JWT': 'eyJ.header.sig',
+      });
+      expect(source, isA<OidcAggregatedClaimSource>());
+      expect((source as OidcAggregatedClaimSource).jwt, 'eyJ.header.sig');
+      expect(source.src, {'JWT': 'eyJ.header.sig'});
+    });
+
+    test('an endpoint member produces a distributed claim source', () {
+      final source = OidcClaimSource.fromJson({
+        'endpoint': 'https://claims.example.com/source',
+        'access_token': 'at-123',
+      });
+      expect(source, isA<OidcDistributedClaimSource>());
+      final distributed = source as OidcDistributedClaimSource;
+      expect(
+        distributed.endpoint,
+        Uri.parse('https://claims.example.com/source'),
+      );
+      expect(distributed.accessToken, 'at-123');
+    });
+
+    test('a distributed source without an access token parses', () {
+      final source = OidcClaimSource.fromJson({
+        'endpoint': 'https://claims.example.com/source',
+      });
+      expect(source, isA<OidcDistributedClaimSource>());
+      expect((source as OidcDistributedClaimSource).accessToken, isNull);
+    });
+
+    test('a JWT source is preferred when both members are present', () {
+      final source = OidcClaimSource.fromJson({
+        'JWT': 'the-jwt',
+        'endpoint': 'https://claims.example.com/source',
+      });
+      expect(source, isA<OidcAggregatedClaimSource>());
+    });
+
+    test('a source with neither member throws ArgumentError', () {
+      expect(
+        () => OidcClaimSource.fromJson({'foo': 'bar'}),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('OidcAggregatedClaimSource.fromJson decodes directly', () {
+      final agg = OidcAggregatedClaimSource.fromJson({'JWT': 'abc'});
+      expect(agg.jwt, 'abc');
+    });
+
+    test('OidcDistributedClaimSource.fromJson decodes directly', () {
+      final dist = OidcDistributedClaimSource.fromJson({
+        'endpoint': 'https://e.example.com',
+        'access_token': 'tok',
+      });
+      expect(dist.endpoint, Uri.parse('https://e.example.com'));
+      expect(dist.accessToken, 'tok');
+    });
+  });
+}

--- a/packages/oidc_core/test/client_registration_response_accessors_test.dart
+++ b/packages/oidc_core/test/client_registration_response_accessors_test.dart
@@ -1,0 +1,117 @@
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OidcClientRegistrationResponse typed accessors', () {
+    test('reads every registered member from a full RFC 7591 response', () {
+      final resp = OidcClientRegistrationResponse.fromJson({
+        'client_id': 'abc123',
+        'client_secret': 's3cr3t',
+        'registration_access_token': 'reg-token',
+        'registration_client_uri': 'https://op.example.com/register/abc123',
+        // 2023-01-01T00:00:00Z in seconds since epoch.
+        'client_id_issued_at': 1672531200,
+        'client_secret_expires_at': 1704067200,
+        'redirect_uris': [
+          'https://app.example.com/cb',
+          'com.example.app:/cb',
+        ],
+        'grant_types': ['authorization_code', 'refresh_token'],
+        'response_types': ['code'],
+        'token_endpoint_auth_method': 'client_secret_basic',
+        'scope': 'openid profile',
+        'client_name': 'My App',
+      });
+
+      expect(resp.clientId, 'abc123');
+      expect(resp.clientSecret, 's3cr3t');
+      expect(resp.registrationAccessToken, 'reg-token');
+      expect(
+        resp.registrationClientUri,
+        Uri.parse('https://op.example.com/register/abc123'),
+      );
+      expect(
+        resp.clientIdIssuedAt,
+        DateTime.utc(2023),
+      );
+      expect(
+        resp.clientSecretExpiresAt,
+        DateTime.utc(2024),
+      );
+      expect(resp.clientSecretNeverExpires, isFalse);
+      expect(resp.redirectUris, [
+        Uri.parse('https://app.example.com/cb'),
+        Uri.parse('com.example.app:/cb'),
+      ]);
+      expect(resp.grantTypes, ['authorization_code', 'refresh_token']);
+      expect(resp.responseTypes, ['code']);
+      expect(resp.tokenEndpointAuthMethod, 'client_secret_basic');
+      expect(resp.scope, 'openid profile');
+      expect(resp.clientName, 'My App');
+    });
+
+    test('absent optional members surface as null', () {
+      final resp = OidcClientRegistrationResponse.fromJson({
+        'client_id': 'only-id',
+      });
+      expect(resp.clientId, 'only-id');
+      expect(resp.clientSecret, isNull);
+      expect(resp.registrationAccessToken, isNull);
+      expect(resp.registrationClientUri, isNull);
+      expect(resp.clientIdIssuedAt, isNull);
+      expect(resp.clientSecretExpiresAt, isNull);
+      expect(resp.clientSecretNeverExpires, isFalse);
+      expect(resp.redirectUris, isNull);
+      expect(resp.grantTypes, isNull);
+      expect(resp.responseTypes, isNull);
+      expect(resp.tokenEndpointAuthMethod, isNull);
+      expect(resp.scope, isNull);
+      expect(resp.clientName, isNull);
+    });
+
+    test(
+      'client_secret_expires_at == 0 means the secret never expires '
+      '(RFC 7591 §3.2.1)',
+      () {
+        final resp = OidcClientRegistrationResponse.fromJson({
+          'client_id': 'abc',
+          'client_secret': 'shh',
+          'client_secret_expires_at': 0,
+        });
+        expect(resp.clientSecretNeverExpires, isTrue);
+        // 0 is still a valid numeric date (the epoch).
+        expect(
+          resp.clientSecretExpiresAt,
+          DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+        );
+      },
+    );
+
+    test('registration_client_uri that is non-string is ignored', () {
+      final resp = OidcClientRegistrationResponse.fromJson({
+        'client_id': 'abc',
+        'registration_client_uri': 12345,
+      });
+      expect(resp.registrationClientUri, isNull);
+    });
+
+    test('redirect_uris that is not a list surfaces as null', () {
+      final resp = OidcClientRegistrationResponse.fromJson({
+        'client_id': 'abc',
+        'redirect_uris': 'not-a-list',
+      });
+      expect(resp.redirectUris, isNull);
+    });
+
+    test('numeric dates accept fractional seconds', () {
+      final resp = OidcClientRegistrationResponse.fromJson({
+        'client_id': 'abc',
+        'client_id_issued_at': 1.5,
+      });
+      expect(
+        resp.clientIdIssuedAt,
+        DateTime.fromMillisecondsSinceEpoch(1500, isUtc: true),
+      );
+    });
+  });
+}

--- a/packages/oidc_core/test/internal_utils_test.dart
+++ b/packages/oidc_core/test/internal_utils_test.dart
@@ -1,0 +1,243 @@
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OidcInternalUtilities.joinSpaceDelimitedList', () {
+    test('joins a non-empty list with spaces', () {
+      expect(
+        OidcInternalUtilities.joinSpaceDelimitedList(['a', 'b', 'c']),
+        'a b c',
+      );
+    });
+
+    test('null and empty list both yield null', () {
+      expect(OidcInternalUtilities.joinSpaceDelimitedList(null), isNull);
+      expect(OidcInternalUtilities.joinSpaceDelimitedList([]), isNull);
+    });
+  });
+
+  group('OidcInternalUtilities.splitSpaceDelimitedString', () {
+    test('splits a space-delimited string', () {
+      expect(
+        OidcInternalUtilities.splitSpaceDelimitedString('openid profile email'),
+        ['openid', 'profile', 'email'],
+      );
+    });
+
+    test('an empty string yields an empty list', () {
+      expect(OidcInternalUtilities.splitSpaceDelimitedString(''), isEmpty);
+    });
+
+    test('null yields an empty list', () {
+      expect(OidcInternalUtilities.splitSpaceDelimitedString(null), isEmpty);
+    });
+
+    test('a List filters to its String elements', () {
+      expect(
+        OidcInternalUtilities.splitSpaceDelimitedString(['a', 1, 'b', null]),
+        ['a', 'b'],
+      );
+    });
+
+    test('an unsupported type throws ArgumentError', () {
+      expect(
+        () => OidcInternalUtilities.splitSpaceDelimitedString(42),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('OidcInternalUtilities.splitSpaceDelimitedStringNullable', () {
+    test('null input stays null (not an empty list)', () {
+      expect(
+        OidcInternalUtilities.splitSpaceDelimitedStringNullable(null),
+        isNull,
+      );
+    });
+
+    test('a value is delegated to the non-nullable splitter', () {
+      expect(
+        OidcInternalUtilities.splitSpaceDelimitedStringNullable('a b'),
+        ['a', 'b'],
+      );
+    });
+  });
+
+  group('OidcInternalUtilities.readDurationSeconds', () {
+    test('returns null for an absent key', () {
+      expect(OidcInternalUtilities.readDurationSeconds({}, 'x'), isNull);
+    });
+
+    test('returns an int value verbatim', () {
+      expect(OidcInternalUtilities.readDurationSeconds({'x': 30}, 'x'), 30);
+    });
+
+    test('parses a numeric string', () {
+      expect(OidcInternalUtilities.readDurationSeconds({'x': '45'}, 'x'), 45);
+    });
+
+    test('a non-numeric string parses to null', () {
+      expect(
+        OidcInternalUtilities.readDurationSeconds({'x': 'abc'}, 'x'),
+        isNull,
+      );
+    });
+  });
+
+  group('OidcInternalUtilities.durationFromJson / durationToJson', () {
+    test('null decodes to null', () {
+      expect(OidcInternalUtilities.durationFromJson(null), isNull);
+    });
+
+    test('an int is interpreted as seconds', () {
+      expect(
+        OidcInternalUtilities.durationFromJson(60),
+        const Duration(minutes: 1),
+      );
+    });
+
+    test('a numeric string is interpreted as seconds', () {
+      expect(
+        OidcInternalUtilities.durationFromJson('90'),
+        const Duration(seconds: 90),
+      );
+    });
+
+    test('a non-numeric string decodes to null', () {
+      expect(OidcInternalUtilities.durationFromJson('nope'), isNull);
+    });
+
+    test('durationToJson emits whole seconds; null stays null', () {
+      expect(
+        OidcInternalUtilities.durationToJson(const Duration(minutes: 2)),
+        120,
+      );
+      expect(OidcInternalUtilities.durationToJson(null), isNull);
+    });
+  });
+
+  group('OidcInternalUtilities date helpers', () {
+    test('dateTimeToJson emits ISO-8601; null stays null', () {
+      final dt = DateTime.utc(2023, 1, 1, 12);
+      expect(
+        OidcInternalUtilities.dateTimeToJson(dt),
+        dt.toIso8601String(),
+      );
+      expect(OidcInternalUtilities.dateTimeToJson(null), isNull);
+    });
+
+    test('dateTimeFromJsonRequired parses an ISO string', () {
+      expect(
+        OidcInternalUtilities.dateTimeFromJsonRequired('2023-01-01T12:00:00Z'),
+        DateTime.utc(2023, 1, 1, 12),
+      );
+    });
+
+    test('dateTimeFromJsonRequired reads epoch millis for an int', () {
+      expect(
+        OidcInternalUtilities.dateTimeFromJsonRequired(1000),
+        DateTime.fromMillisecondsSinceEpoch(1000, isUtc: true),
+      );
+    });
+
+    test('dateTimeFromJsonRequired passes a DateTime through', () {
+      final dt = DateTime.utc(2020);
+      expect(OidcInternalUtilities.dateTimeFromJsonRequired(dt), dt);
+    });
+
+    test('dateTimeFromJsonRequired throws on an unsupported type', () {
+      expect(
+        () => OidcInternalUtilities.dateTimeFromJsonRequired(1.5),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('dateTimeFromJson tolerates null', () {
+      expect(OidcInternalUtilities.dateTimeFromJson(null), isNull);
+      expect(
+        OidcInternalUtilities.dateTimeFromJson('2023-01-01T00:00:00Z'),
+        DateTime.utc(2023),
+      );
+    });
+  });
+
+  group('OidcInternalUtilities.tryParseUri', () {
+    test('a valid string becomes a Uri', () {
+      expect(
+        OidcInternalUtilities.tryParseUri('https://a.example.com/x'),
+        Uri.parse('https://a.example.com/x'),
+      );
+    });
+
+    test('null and non-string values become null', () {
+      expect(OidcInternalUtilities.tryParseUri(null), isNull);
+      expect(OidcInternalUtilities.tryParseUri(42), isNull);
+      expect(OidcInternalUtilities.tryParseUri({'a': 'b'}), isNull);
+    });
+  });
+
+  group('OidcInternalUtilities.serializeQueryParameters', () {
+    test('drops nulls, stringifies scalars, and maps iterables', () {
+      final result = OidcInternalUtilities.serializeQueryParameters({
+        'scope': 'openid',
+        'count': 3,
+        'skip': null,
+        'ids': [1, 2, 3],
+      });
+      expect(result, {
+        'scope': 'openid',
+        'count': '3',
+        'ids': ['1', '2', '3'],
+      });
+      expect(result.containsKey('skip'), isFalse);
+    });
+  });
+
+  group('OidcDateTime extension', () {
+    test('secondsSinceEpoch truncates millis', () {
+      final dt = DateTime.fromMillisecondsSinceEpoch(1500, isUtc: true);
+      expect(dt.secondsSinceEpoch, 1);
+    });
+
+    test('fromSecondsSinceEpoch is the inverse for whole seconds', () {
+      final dt = OidcDateTime.fromSecondsSinceEpoch(120);
+      expect(dt.millisecondsSinceEpoch, 120000);
+    });
+  });
+
+  group('OidcUtils.getIssuerFromOpenIdConfigWellKnownUri (inverse of §4.1)', () {
+    test('recovers the issuer from a standard well-known URL', () {
+      final issuer = OidcUtils.getIssuerFromOpenIdConfigWellKnownUri(
+        Uri.parse(
+          'https://op.example.com/realm/.well-known/openid-configuration',
+        ),
+      );
+      expect(issuer, Uri.parse('https://op.example.com/realm'));
+    });
+
+    test('recovers a root issuer', () {
+      final issuer = OidcUtils.getIssuerFromOpenIdConfigWellKnownUri(
+        Uri.parse('https://op.example.com/.well-known/openid-configuration'),
+      );
+      expect(issuer, Uri.parse('https://op.example.com'));
+    });
+
+    test('returns null when the URL does not end with the two segments', () {
+      // RFC 8414 insert-layout URL cannot be inverted.
+      expect(
+        OidcUtils.getIssuerFromOpenIdConfigWellKnownUri(
+          Uri.parse(
+            'https://op.example.com/.well-known/oauth-authorization-server/realm',
+          ),
+        ),
+        isNull,
+      );
+      expect(
+        OidcUtils.getIssuerFromOpenIdConfigWellKnownUri(
+          Uri.parse('https://op.example.com/foo'),
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/packages/oidc_core/test/oidc_user_test.dart
+++ b/packages/oidc_core/test/oidc_user_test.dart
@@ -1,0 +1,227 @@
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+String _unsignedIdToken(Map<String, dynamic> claims) =>
+    (JsonWebSignatureBuilder()
+          ..jsonContent = claims
+          ..addRecipient(
+            JsonWebKey.fromJson({
+              'kty': 'oct',
+              'k': base64Url.encode(utf8.encode('x' * 32)).replaceAll('=', ''),
+              'alg': 'HS256',
+            }),
+            algorithm: 'HS256',
+          ))
+        .build()
+        .toCompactSerialization();
+
+Map<String, dynamic> _claims({
+  String sub = 'user-1',
+  String iss = 'https://op.example.com',
+}) => {
+  'iss': iss,
+  'sub': sub,
+  'aud': 'client-1',
+  'exp':
+      clock.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000,
+  'iat': clock.now().millisecondsSinceEpoch ~/ 1000,
+};
+
+OidcToken _token(String idToken) => OidcToken(
+  idToken: idToken,
+  accessToken: 'at',
+  tokenType: 'Bearer',
+  expiresIn: const Duration(hours: 1),
+  creationTime: clock.now(),
+);
+
+void main() {
+  group('OidcUser.fromIdToken (unverified path)', () {
+    test('parses claims and exposes uid/uidRequired', () async {
+      final user = await OidcUser.fromIdToken(
+        token: _token(_unsignedIdToken(_claims(sub: 'abc'))),
+      );
+      expect(user.uid, 'abc');
+      expect(user.uidRequired, 'abc');
+      expect(user.claims.subject, 'abc');
+      expect(user.parsedIdToken.isVerified, isNot(isTrue));
+    });
+
+    test('throws OidcException when there is no id_token', () async {
+      final token = OidcToken(
+        accessToken: 'at',
+        tokenType: 'Bearer',
+        creationTime: clock.now(),
+      );
+      await expectLater(
+        OidcUser.fromIdToken(token: token),
+        throwsA(isA<OidcException>()),
+      );
+    });
+
+    test('idTokenOverride takes precedence over token.idToken', () async {
+      final overrideIdToken = _unsignedIdToken(_claims(sub: 'override-sub'));
+      final user = await OidcUser.fromIdToken(
+        token: _token(_unsignedIdToken(_claims(sub: 'original-sub'))),
+        idTokenOverride: overrideIdToken,
+      );
+      expect(user.uid, 'override-sub');
+      expect(user.idToken, overrideIdToken);
+    });
+
+    test('uidRequired throws when sub is absent', () async {
+      final claims = _claims()..remove('sub');
+      final user = await OidcUser.fromIdToken(
+        token: _token(_unsignedIdToken(claims)),
+      );
+      expect(user.uid, isNull);
+      expect(() => user.uidRequired, throwsA(isA<TypeError>()));
+    });
+  });
+
+  group('OidcUser attributes + userInfo aggregation', () {
+    late OidcUser user;
+
+    setUp(() async {
+      user = await OidcUser.fromIdToken(
+        token: _token(_unsignedIdToken(_claims(sub: 'u1'))),
+        attributes: const {'a': 1},
+        userInfo: const {'email': 'u1@example.com'},
+      );
+    });
+
+    test('aggregatedClaims merges id_token claims and userInfo', () {
+      expect(user.aggregatedClaims['sub'], 'u1');
+      expect(user.aggregatedClaims['email'], 'u1@example.com');
+    });
+
+    test('attributes are exposed', () {
+      expect(user.attributes, const {'a': 1});
+      expect(user.userInfo, const {'email': 'u1@example.com'});
+    });
+
+    test('withUserInfo replaces userInfo and re-aggregates', () {
+      final updated = user.withUserInfo(const {'name': 'New Name'});
+      expect(updated.userInfo, const {'name': 'New Name'});
+      expect(updated.aggregatedClaims['name'], 'New Name');
+      // old userInfo key is gone from the aggregate
+      expect(updated.aggregatedClaims.containsKey('email'), isFalse);
+      // id_token claim survives
+      expect(updated.aggregatedClaims['sub'], 'u1');
+      // attributes preserved
+      expect(updated.attributes, const {'a': 1});
+    });
+
+    test('setAttributes merges into existing attributes', () {
+      final updated = user.setAttributes(const {'b': 2});
+      expect(updated.attributes, const {'a': 1, 'b': 2});
+      // original is unchanged (immutability)
+      expect(user.attributes, const {'a': 1});
+    });
+
+    test('setAttributes overrides an existing key', () {
+      final updated = user.setAttributes(const {'a': 99});
+      expect(updated.attributes, const {'a': 99});
+    });
+
+    test('clearAttributes empties the attributes map', () {
+      final cleared = user.clearAttributes();
+      expect(cleared.attributes, isEmpty);
+      // other state preserved
+      expect(cleared.userInfo, const {'email': 'u1@example.com'});
+      expect(cleared.uid, 'u1');
+    });
+  });
+
+  group('OidcUser.replaceToken', () {
+    test('keeps the parsed id_token when the id_token is unchanged', () async {
+      final idToken = _unsignedIdToken(_claims(sub: 'same'));
+      final user = await OidcUser.fromIdToken(token: _token(idToken));
+      final newToken = OidcToken(
+        idToken: idToken,
+        accessToken: 'new-at',
+        tokenType: 'Bearer',
+        creationTime: clock.now(),
+      );
+
+      final replaced = await user.replaceToken(newToken);
+      expect(replaced.idToken, idToken);
+      expect(replaced.token.accessToken, 'new-at');
+      // same parsed token instance is reused (not re-verified)
+      expect(replaced.parsedIdToken, same(user.parsedIdToken));
+    });
+
+    test('re-parses when the id_token changes', () async {
+      final user = await OidcUser.fromIdToken(
+        token: _token(_unsignedIdToken(_claims(sub: 'old'))),
+      );
+      final newIdToken = _unsignedIdToken(_claims(sub: 'new'));
+      final replaced = await user.replaceToken(
+        OidcToken(
+          idToken: newIdToken,
+          accessToken: 'at',
+          tokenType: 'Bearer',
+          creationTime: clock.now(),
+        ),
+      );
+      expect(replaced.uid, 'new');
+      expect(replaced.parsedIdToken, isNot(same(user.parsedIdToken)));
+    });
+
+    test('merges token json, preferring new values over old', () async {
+      final idToken = _unsignedIdToken(_claims());
+      final user = await OidcUser.fromIdToken(token: _token(idToken));
+      final replaced = await user.replaceToken(
+        OidcToken(
+          idToken: idToken,
+          accessToken: 'newer-at',
+          tokenType: 'Bearer',
+          creationTime: clock.now(),
+        ),
+      );
+      // new access token wins; refresh-less new token doesn't wipe old fields
+      expect(replaced.token.accessToken, 'newer-at');
+    });
+
+    test('allowExpiredIdToken=true is recorded on the merged token', () async {
+      final idToken = _unsignedIdToken(_claims());
+      final user = await OidcUser.fromIdToken(token: _token(idToken));
+      final replaced = await user.replaceToken(
+        _token(idToken),
+        allowExpiredIdToken: true,
+      );
+      expect(replaced.token.allowExpiredIdToken, isTrue);
+    });
+
+    test('allowExpiredIdToken defaults to clearing the flag', () async {
+      final idToken = _unsignedIdToken(_claims());
+      final user = await OidcUser.fromIdToken(token: _token(idToken));
+      final replaced = await user.replaceToken(_token(idToken));
+      expect(replaced.token.allowExpiredIdToken, isNot(isTrue));
+    });
+
+    test(
+      'falls back to the existing id_token when the new token has none',
+      () async {
+        final idToken = _unsignedIdToken(_claims(sub: 'keep-me'));
+        final user = await OidcUser.fromIdToken(token: _token(idToken));
+        final replaced = await user.replaceToken(
+          OidcToken(
+            accessToken: 'at2',
+            tokenType: 'Bearer',
+            creationTime: clock.now(),
+          ),
+        );
+        expect(replaced.idToken, idToken);
+        expect(replaced.uid, 'keep-me');
+      },
+    );
+  });
+}

--- a/packages/oidc_core/test/platform_options_serialization_test.dart
+++ b/packages/oidc_core/test/platform_options_serialization_test.dart
@@ -1,0 +1,466 @@
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OidcColorSchemeParams', () {
+    test('fromJson reads all ARGB fields', () {
+      final parsed = OidcColorSchemeParams.fromJson(const {
+        'toolbarColor': 0xFF2196F3,
+        'secondaryToolbarColor': 0xFF000000,
+        'navigationBarColor': 0xFFFFFFFF,
+        'navigationBarDividerColor': 0xFF808080,
+      });
+      expect(parsed.toolbarColor, 0xFF2196F3);
+      expect(parsed.secondaryToolbarColor, 0xFF000000);
+      expect(parsed.navigationBarColor, 0xFFFFFFFF);
+      expect(parsed.navigationBarDividerColor, 0xFF808080);
+    });
+
+    test('toJson round-trips', () {
+      const obj = OidcColorSchemeParams(
+        toolbarColor: 1,
+        secondaryToolbarColor: 2,
+        navigationBarColor: 3,
+        navigationBarDividerColor: 4,
+      );
+      final json = obj.toJson();
+      expect(json, {
+        'toolbarColor': 1,
+        'secondaryToolbarColor': 2,
+        'navigationBarColor': 3,
+        'navigationBarDividerColor': 4,
+      });
+      final reparsed = OidcColorSchemeParams.fromJson(json);
+      expect(reparsed.toolbarColor, 1);
+      expect(reparsed.navigationBarDividerColor, 4);
+    });
+
+    test('absent fields decode to null', () {
+      final parsed = OidcColorSchemeParams.fromJson(const {});
+      expect(parsed.toolbarColor, isNull);
+      expect(parsed.secondaryToolbarColor, isNull);
+      expect(parsed.navigationBarColor, isNull);
+      expect(parsed.navigationBarDividerColor, isNull);
+    });
+  });
+
+  group('OidcCustomTabsColorSchemes', () {
+    test('full round-trip preserves colorScheme + nested params', () {
+      const obj = OidcCustomTabsColorSchemes(
+        colorScheme: OidcColorScheme.dark,
+        lightParams: OidcColorSchemeParams(toolbarColor: 10),
+        darkParams: OidcColorSchemeParams(toolbarColor: 20),
+        defaultParams: OidcColorSchemeParams(toolbarColor: 30),
+      );
+      final json = obj.toJson();
+      expect(json['colorScheme'], 'dark');
+      final reparsed = OidcCustomTabsColorSchemes.fromJson(json);
+      expect(reparsed.colorScheme, OidcColorScheme.dark);
+      expect(reparsed.lightParams?.toolbarColor, 10);
+      expect(reparsed.darkParams?.toolbarColor, 20);
+      expect(reparsed.defaultParams?.toolbarColor, 30);
+    });
+
+    test('defaults: system scheme, null params', () {
+      final parsed = OidcCustomTabsColorSchemes.fromJson(const {});
+      expect(parsed.colorScheme, OidcColorScheme.system);
+      expect(parsed.lightParams, isNull);
+      expect(parsed.darkParams, isNull);
+      expect(parsed.defaultParams, isNull);
+    });
+
+    test('each OidcColorScheme value encodes to its wire name', () {
+      for (final entry in {
+        OidcColorScheme.system: 'system',
+        OidcColorScheme.light: 'light',
+        OidcColorScheme.dark: 'dark',
+      }.entries) {
+        final json = OidcCustomTabsColorSchemes(
+          colorScheme: entry.key,
+        ).toJson();
+        expect(json['colorScheme'], entry.value);
+        expect(
+          OidcCustomTabsColorSchemes.fromJson(json).colorScheme,
+          entry.key,
+        );
+      }
+    });
+  });
+
+  group('OidcPartialCustomTabs', () {
+    test('full round-trip', () {
+      const obj = OidcPartialCustomTabs(
+        initialHeightPx: 400,
+        resizeBehavior: OidcPartialTabResizeBehavior.fixed,
+        toolbarCornerRadiusDp: 16,
+        backgroundInteractionEnabled: false,
+      );
+      final json = obj.toJson();
+      expect(json['initialHeightPx'], 400);
+      expect(json['resizeBehavior'], 'fixed');
+      expect(json['toolbarCornerRadiusDp'], 16);
+      expect(json['backgroundInteractionEnabled'], false);
+
+      final reparsed = OidcPartialCustomTabs.fromJson(json);
+      expect(reparsed.initialHeightPx, 400);
+      expect(reparsed.resizeBehavior, OidcPartialTabResizeBehavior.fixed);
+      expect(reparsed.toolbarCornerRadiusDp, 16);
+      expect(reparsed.backgroundInteractionEnabled, isFalse);
+    });
+
+    test('defaults', () {
+      final parsed = OidcPartialCustomTabs.fromJson(const {});
+      expect(parsed.initialHeightPx, isNull);
+      expect(
+        parsed.resizeBehavior,
+        OidcPartialTabResizeBehavior.defaultBehavior,
+      );
+      expect(parsed.toolbarCornerRadiusDp, isNull);
+      expect(parsed.backgroundInteractionEnabled, isTrue);
+    });
+
+    test('all resize behaviors round-trip', () {
+      for (final entry in {
+        OidcPartialTabResizeBehavior.defaultBehavior: 'defaultBehavior',
+        OidcPartialTabResizeBehavior.adjustable: 'adjustable',
+        OidcPartialTabResizeBehavior.fixed: 'fixed',
+      }.entries) {
+        final json = OidcPartialCustomTabs(resizeBehavior: entry.key).toJson();
+        expect(json['resizeBehavior'], entry.value);
+        expect(
+          OidcPartialCustomTabs.fromJson(json).resizeBehavior,
+          entry.key,
+        );
+      }
+    });
+  });
+
+  group('OidcNativeOptionsAndroid', () {
+    test('fully-populated round-trip', () {
+      const obj = OidcNativeOptionsAndroid(
+        colorSchemes: OidcCustomTabsColorSchemes(
+          colorScheme: OidcColorScheme.light,
+        ),
+        shareState: OidcCustomTabsShareState.on,
+        showTitle: false,
+        urlBarHidingEnabled: true,
+        ephemeralBrowsing: true,
+        closeButtonPosition: OidcCustomTabsCloseButtonPosition.end,
+        preferredBrowserPackages: ['com.android.chrome'],
+        useAuthTab: OidcAuthTabMode.force,
+        partialCustomTabs: OidcPartialCustomTabs(initialHeightPx: 500),
+        warmup: OidcCustomTabsWarmup.mayLaunch,
+        rawIntentExtras: {'x': 1},
+        allowInsecureConnections: true,
+        flowTimeoutSeconds: 30,
+      );
+      final json = obj.toJson();
+      expect(json['shareState'], 'on');
+      expect(json['showTitle'], false);
+      expect(json['urlBarHidingEnabled'], true);
+      expect(json['ephemeralBrowsing'], true);
+      expect(json['closeButtonPosition'], 'end');
+      expect(json['preferredBrowserPackages'], ['com.android.chrome']);
+      expect(json['useAuthTab'], 'force');
+      expect(json['warmup'], 'mayLaunch');
+      expect(json['rawIntentExtras'], {'x': 1});
+      expect(json['allowInsecureConnections'], true);
+      expect(json['flowTimeoutSeconds'], 30);
+
+      final reparsed = OidcNativeOptionsAndroid.fromJson(json);
+      expect(reparsed.colorSchemes?.colorScheme, OidcColorScheme.light);
+      expect(reparsed.shareState, OidcCustomTabsShareState.on);
+      expect(reparsed.showTitle, isFalse);
+      expect(reparsed.urlBarHidingEnabled, isTrue);
+      expect(reparsed.ephemeralBrowsing, isTrue);
+      expect(
+        reparsed.closeButtonPosition,
+        OidcCustomTabsCloseButtonPosition.end,
+      );
+      expect(reparsed.preferredBrowserPackages, ['com.android.chrome']);
+      expect(reparsed.useAuthTab, OidcAuthTabMode.force);
+      expect(reparsed.partialCustomTabs?.initialHeightPx, 500);
+      expect(reparsed.warmup, OidcCustomTabsWarmup.mayLaunch);
+      expect(reparsed.rawIntentExtras, {'x': 1});
+      expect(reparsed.allowInsecureConnections, isTrue);
+      expect(reparsed.flowTimeoutSeconds, 30);
+    });
+
+    test('defaults from empty json', () {
+      final parsed = OidcNativeOptionsAndroid.fromJson(const {});
+      expect(parsed.colorSchemes, isNull);
+      expect(parsed.shareState, OidcCustomTabsShareState.browserDefault);
+      expect(parsed.showTitle, isTrue);
+      expect(parsed.urlBarHidingEnabled, isFalse);
+      expect(parsed.ephemeralBrowsing, isFalse);
+      expect(parsed.closeButtonPosition, isNull);
+      expect(parsed.preferredBrowserPackages, isEmpty);
+      expect(parsed.useAuthTab, OidcAuthTabMode.auto);
+      expect(parsed.partialCustomTabs, isNull);
+      expect(parsed.warmup, OidcCustomTabsWarmup.none);
+      expect(parsed.rawIntentExtras, isEmpty);
+      expect(parsed.allowInsecureConnections, isFalse);
+      expect(parsed.flowTimeoutSeconds, isNull);
+    });
+
+    test('implements the platform-options marker interface', () {
+      expect(
+        const OidcNativeOptionsAndroid(),
+        isA<OidcPlatformOptionsMarker>(),
+      );
+    });
+
+    test('every share state + close-button position + warmup encodes', () {
+      for (final entry in {
+        OidcCustomTabsShareState.browserDefault: 'browserDefault',
+        OidcCustomTabsShareState.on: 'on',
+        OidcCustomTabsShareState.off: 'off',
+      }.entries) {
+        expect(
+          OidcNativeOptionsAndroid(
+            shareState: entry.key,
+          ).toJson()['shareState'],
+          entry.value,
+        );
+      }
+      for (final entry in {
+        OidcCustomTabsCloseButtonPosition.defaultPosition: 'defaultPosition',
+        OidcCustomTabsCloseButtonPosition.start: 'start',
+        OidcCustomTabsCloseButtonPosition.end: 'end',
+      }.entries) {
+        expect(
+          OidcNativeOptionsAndroid(
+            closeButtonPosition: entry.key,
+          ).toJson()['closeButtonPosition'],
+          entry.value,
+        );
+      }
+      for (final entry in {
+        OidcAuthTabMode.auto: 'auto',
+        OidcAuthTabMode.force: 'force',
+        OidcAuthTabMode.never: 'never',
+      }.entries) {
+        expect(
+          OidcNativeOptionsAndroid(
+            useAuthTab: entry.key,
+          ).toJson()['useAuthTab'],
+          entry.value,
+        );
+      }
+      for (final entry in {
+        OidcCustomTabsWarmup.none: 'none',
+        OidcCustomTabsWarmup.warmup: 'warmup',
+        OidcCustomTabsWarmup.mayLaunch: 'mayLaunch',
+      }.entries) {
+        expect(
+          OidcNativeOptionsAndroid(warmup: entry.key).toJson()['warmup'],
+          entry.value,
+        );
+      }
+    });
+  });
+
+  group('OidcNativeOptionsApple', () {
+    test('fully-populated round-trip', () {
+      const obj = OidcNativeOptionsApple(
+        prefersEphemeralWebBrowserSession: true,
+        additionalHeaderFields: {'X-A': 'b'},
+        callbackMode: OidcAppleCallbackMode.https,
+        rawSessionOptions: {'k': 'v'},
+        flowTimeoutSeconds: 42,
+      );
+      final json = obj.toJson();
+      expect(json['prefersEphemeralWebBrowserSession'], true);
+      expect(json['additionalHeaderFields'], {'X-A': 'b'});
+      expect(json['callbackMode'], 'https');
+      expect(json['rawSessionOptions'], {'k': 'v'});
+      expect(json['flowTimeoutSeconds'], 42);
+
+      final reparsed = OidcNativeOptionsApple.fromJson(json);
+      expect(reparsed.prefersEphemeralWebBrowserSession, isTrue);
+      expect(reparsed.additionalHeaderFields, {'X-A': 'b'});
+      expect(reparsed.callbackMode, OidcAppleCallbackMode.https);
+      expect(reparsed.rawSessionOptions, {'k': 'v'});
+      expect(reparsed.flowTimeoutSeconds, 42);
+    });
+
+    test('defaults from empty json + marker interface', () {
+      final parsed = OidcNativeOptionsApple.fromJson(const {});
+      expect(parsed.prefersEphemeralWebBrowserSession, isFalse);
+      expect(parsed.additionalHeaderFields, isNull);
+      expect(parsed.callbackMode, OidcAppleCallbackMode.auto);
+      expect(parsed.rawSessionOptions, isEmpty);
+      expect(parsed.flowTimeoutSeconds, isNull);
+      expect(parsed, isA<OidcPlatformOptionsMarker>());
+    });
+
+    test('all callback modes round-trip', () {
+      for (final entry in {
+        OidcAppleCallbackMode.auto: 'auto',
+        OidcAppleCallbackMode.customScheme: 'customScheme',
+        OidcAppleCallbackMode.https: 'https',
+      }.entries) {
+        final json = OidcNativeOptionsApple(callbackMode: entry.key).toJson();
+        expect(json['callbackMode'], entry.value);
+        expect(
+          OidcNativeOptionsApple.fromJson(json).callbackMode,
+          entry.key,
+        );
+      }
+    });
+  });
+
+  group('OidcPlatformSpecificOptions_Native', () {
+    test('full round-trip (launchUrl excluded from json)', () {
+      const obj = OidcPlatformSpecificOptions_Native(
+        successfulPageResponse: 'ok',
+        methodMismatchResponse: 'nope',
+        notFoundResponse: '404',
+        flowTimeoutSeconds: 12,
+      );
+      final json = obj.toJson();
+      expect(json['successfulPageResponse'], 'ok');
+      expect(json['methodMismatchResponse'], 'nope');
+      expect(json['notFoundResponse'], '404');
+      expect(json['flowTimeoutSeconds'], 12);
+      expect(json.containsKey('launchUrl'), isFalse);
+
+      final reparsed = OidcPlatformSpecificOptions_Native.fromJson(json);
+      expect(reparsed.successfulPageResponse, 'ok');
+      expect(reparsed.methodMismatchResponse, 'nope');
+      expect(reparsed.notFoundResponse, '404');
+      expect(reparsed.flowTimeoutSeconds, 12);
+      expect(reparsed.launchUrl, isNull);
+    });
+
+    test('defaults', () {
+      final parsed = OidcPlatformSpecificOptions_Native.fromJson(const {});
+      expect(parsed.successfulPageResponse, isNull);
+      expect(parsed.methodMismatchResponse, isNull);
+      expect(parsed.notFoundResponse, isNull);
+      expect(parsed.flowTimeoutSeconds, isNull);
+    });
+  });
+
+  group('OidcPlatformSpecificOptions_Web', () {
+    test('fully-populated round-trip', () {
+      const obj = OidcPlatformSpecificOptions_Web(
+        navigationMode: OidcPlatformSpecificOptions_Web_NavigationMode.popup,
+        popupWidth: 800,
+        popupHeight: 600,
+        broadcastChannel: 'custom/channel',
+        hiddenIframeTimeout: Duration(seconds: 5),
+      );
+      final json = obj.toJson();
+      expect(json['navigationMode'], 'popup');
+      expect(json['popupWidth'], 800);
+      expect(json['popupHeight'], 600);
+      expect(json['broadcastChannel'], 'custom/channel');
+      expect(
+        json['hiddenIframeTimeout'],
+        const Duration(seconds: 5).inMicroseconds,
+      );
+
+      final reparsed = OidcPlatformSpecificOptions_Web.fromJson(json);
+      expect(
+        reparsed.navigationMode,
+        OidcPlatformSpecificOptions_Web_NavigationMode.popup,
+      );
+      expect(reparsed.popupWidth, 800);
+      expect(reparsed.popupHeight, 600);
+      expect(reparsed.broadcastChannel, 'custom/channel');
+      expect(reparsed.hiddenIframeTimeout, const Duration(seconds: 5));
+    });
+
+    test('defaults', () {
+      final parsed = OidcPlatformSpecificOptions_Web.fromJson(const {});
+      expect(
+        parsed.navigationMode,
+        OidcPlatformSpecificOptions_Web_NavigationMode.newPage,
+      );
+      expect(parsed.popupWidth, 700);
+      expect(parsed.popupHeight, 750);
+      expect(
+        parsed.broadcastChannel,
+        OidcPlatformSpecificOptions_Web.defaultBroadcastChannel,
+      );
+      expect(parsed.hiddenIframeTimeout, const Duration(seconds: 10));
+    });
+
+    test('all navigation modes round-trip', () {
+      for (final entry in {
+        OidcPlatformSpecificOptions_Web_NavigationMode.samePage: 'samePage',
+        OidcPlatformSpecificOptions_Web_NavigationMode.newPage: 'newPage',
+        OidcPlatformSpecificOptions_Web_NavigationMode.popup: 'popup',
+        OidcPlatformSpecificOptions_Web_NavigationMode.hiddenIFrame:
+            'hiddenIFrame',
+      }.entries) {
+        final json = OidcPlatformSpecificOptions_Web(
+          navigationMode: entry.key,
+        ).toJson();
+        expect(json['navigationMode'], entry.value);
+        expect(
+          OidcPlatformSpecificOptions_Web.fromJson(json).navigationMode,
+          entry.key,
+        );
+      }
+    });
+  });
+
+  group('OidcPlatformSpecificOptions (top-level)', () {
+    test('defaults populate every platform with its default object', () {
+      const obj = OidcPlatformSpecificOptions();
+      final json = obj.toJson();
+      expect(
+        json.keys,
+        containsAll(<String>[
+          'android',
+          'ios',
+          'macos',
+          'web',
+          'linux',
+          'windows',
+        ]),
+      );
+
+      final reparsed = OidcPlatformSpecificOptions.fromJson(json);
+      expect(reparsed.android.showTitle, isTrue);
+      expect(reparsed.ios.callbackMode, OidcAppleCallbackMode.auto);
+      expect(reparsed.macos.callbackMode, OidcAppleCallbackMode.auto);
+      expect(
+        reparsed.web.navigationMode,
+        OidcPlatformSpecificOptions_Web_NavigationMode.newPage,
+      );
+      expect(reparsed.linux.flowTimeoutSeconds, isNull);
+      expect(reparsed.windows.flowTimeoutSeconds, isNull);
+    });
+
+    test('empty json falls back to defaults for every platform', () {
+      final parsed = OidcPlatformSpecificOptions.fromJson(const {});
+      expect(parsed.android, isA<OidcNativeOptionsAndroid>());
+      expect(parsed.ios, isA<OidcNativeOptionsApple>());
+      expect(parsed.macos, isA<OidcNativeOptionsApple>());
+      expect(parsed.web, isA<OidcPlatformSpecificOptions_Web>());
+      expect(parsed.linux, isA<OidcPlatformSpecificOptions_Native>());
+      expect(parsed.windows, isA<OidcPlatformSpecificOptions_Native>());
+    });
+
+    test('nested custom values survive a full round-trip', () {
+      const obj = OidcPlatformSpecificOptions(
+        android: OidcNativeOptionsAndroid(flowTimeoutSeconds: 11),
+        ios: OidcNativeOptionsApple(flowTimeoutSeconds: 22),
+        macos: OidcNativeOptionsApple(flowTimeoutSeconds: 33),
+        web: OidcPlatformSpecificOptions_Web(popupWidth: 1234),
+        linux: OidcPlatformSpecificOptions_Native(flowTimeoutSeconds: 44),
+        windows: OidcPlatformSpecificOptions_Native(flowTimeoutSeconds: 55),
+      );
+      final reparsed = OidcPlatformSpecificOptions.fromJson(obj.toJson());
+      expect(reparsed.android.flowTimeoutSeconds, 11);
+      expect(reparsed.ios.flowTimeoutSeconds, 22);
+      expect(reparsed.macos.flowTimeoutSeconds, 33);
+      expect(reparsed.web.popupWidth, 1234);
+      expect(reparsed.linux.flowTimeoutSeconds, 44);
+      expect(reparsed.windows.flowTimeoutSeconds, 55);
+    });
+  });
+}

--- a/packages/oidc_core/test/provider_metadata_full_test.dart
+++ b/packages/oidc_core/test/provider_metadata_full_test.dart
@@ -1,0 +1,365 @@
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+/// A discovery document that populates EVERY typed field, so the generated
+/// `fromJson` exercises every "present" branch (the common case is a sparse
+/// document that only hits the `== null` side).
+Map<String, dynamic> _fullDiscovery() => {
+  'issuer': 'https://op.example.com',
+  'authorization_endpoint': 'https://op.example.com/authorize',
+  'token_endpoint': 'https://op.example.com/token',
+  'userinfo_endpoint': 'https://op.example.com/userinfo',
+  'jwks_uri': 'https://op.example.com/jwks',
+  'registration_endpoint': 'https://op.example.com/register',
+  'scopes_supported': ['openid', 'profile', 'email'],
+  'response_types_supported': ['code', 'id_token'],
+  'response_modes_supported': ['query', 'fragment'],
+  'grant_types_supported': ['authorization_code', 'refresh_token'],
+  'acr_values_supported': ['urn:mace:incommon:iap:silver'],
+  'subject_types_supported': ['public', 'pairwise'],
+  'id_token_signing_alg_values_supported': ['RS256', 'ES256'],
+  'id_token_encryption_alg_values_supported': ['RSA-OAEP'],
+  'id_token_encryption_enc_values_supported': ['A128GCM'],
+  'userinfo_signing_alg_values_supported': ['RS256'],
+  'userinfo_encryption_alg_values_supported': ['RSA-OAEP'],
+  'userinfo_encryption_enc_values_supported': ['A128GCM'],
+  'request_object_signing_alg_values_supported': ['RS256'],
+  'request_object_encryption_alg_values_supported': ['RSA-OAEP'],
+  'request_object_encryption_enc_values_supported': ['A128GCM'],
+  'token_endpoint_auth_methods_supported': ['client_secret_basic'],
+  'token_endpoint_auth_signing_alg_values_supported': ['RS256'],
+  'display_values_supported': ['page', 'popup'],
+  'claim_types_supported': ['normal'],
+  'claims_supported': ['sub', 'iss', 'email'],
+  'service_documentation': 'https://op.example.com/docs',
+  'claims_locales_supported': ['en-US'],
+  'ui_locales_supported': ['en-US', 'fr-FR'],
+  'pushed_authorization_request_endpoint': 'https://op.example.com/par',
+  'claims_parameter_supported': true,
+  'authorization_response_iss_parameter_supported': true,
+  'request_parameter_supported': true,
+  'require_request_uri_registration': true,
+  'request_uri_parameter_supported': false,
+  'require_pushed_authorization_requests': true,
+  'op_policy_uri': 'https://op.example.com/policy',
+  'op_tos_uri': 'https://op.example.com/tos',
+  'check_session_iframe': 'https://op.example.com/checksession',
+  'end_session_endpoint': 'https://op.example.com/logout',
+  'frontchannel_logout_supported': true,
+  'frontchannel_logout_session_supported': true,
+  'backchannel_logout_supported': true,
+  'backchannel_logout_session_supported': true,
+  'revocation_endpoint': 'https://op.example.com/revoke',
+  'revocation_endpoint_auth_methods_supported': ['client_secret_basic'],
+  'revocation_endpoint_auth_signing_alg_values_supported': ['RS256'],
+  'introspection_endpoint': 'https://op.example.com/introspect',
+  'introspection_endpoint_auth_methods_supported': ['client_secret_basic'],
+  'introspection_endpoint_auth_signing_alg_values_supported': ['RS256'],
+  'code_challenge_methods_supported': ['S256', 'plain'],
+};
+
+void main() {
+  group('OidcProviderMetadata full fromJson', () {
+    final parsed = OidcProviderMetadata.fromJson(_fullDiscovery());
+
+    test('all Uri fields parse', () {
+      expect(parsed.issuer, Uri.parse('https://op.example.com'));
+      expect(
+        parsed.authorizationEndpoint,
+        Uri.parse('https://op.example.com/authorize'),
+      );
+      expect(parsed.tokenEndpoint, Uri.parse('https://op.example.com/token'));
+      expect(
+        parsed.userinfoEndpoint,
+        Uri.parse('https://op.example.com/userinfo'),
+      );
+      expect(parsed.jwksUri, Uri.parse('https://op.example.com/jwks'));
+      expect(
+        parsed.registrationEndpoint,
+        Uri.parse('https://op.example.com/register'),
+      );
+      expect(
+        parsed.serviceDocumentation,
+        Uri.parse('https://op.example.com/docs'),
+      );
+      expect(
+        parsed.pushedAuthorizationRequestEndpoint,
+        Uri.parse('https://op.example.com/par'),
+      );
+      expect(parsed.opPolicyUri, Uri.parse('https://op.example.com/policy'));
+      expect(parsed.opTosUri, Uri.parse('https://op.example.com/tos'));
+      expect(
+        parsed.checkSessionIframe,
+        Uri.parse('https://op.example.com/checksession'),
+      );
+      expect(
+        parsed.endSessionEndpoint,
+        Uri.parse('https://op.example.com/logout'),
+      );
+      expect(
+        parsed.revocationEndpoint,
+        Uri.parse('https://op.example.com/revoke'),
+      );
+      expect(
+        parsed.introspectionEndpoint,
+        Uri.parse('https://op.example.com/introspect'),
+      );
+    });
+
+    test('all String-list fields parse', () {
+      expect(parsed.scopesSupported, ['openid', 'profile', 'email']);
+      expect(parsed.responseTypesSupported, ['code', 'id_token']);
+      expect(parsed.responseModesSupported, ['query', 'fragment']);
+      expect(parsed.grantTypesSupported, [
+        'authorization_code',
+        'refresh_token',
+      ]);
+      expect(parsed.acrValuesSupported, ['urn:mace:incommon:iap:silver']);
+      expect(parsed.subjectTypesSupported, ['public', 'pairwise']);
+      expect(parsed.idTokenSigningAlgValuesSupported, ['RS256', 'ES256']);
+      expect(parsed.idTokenEncryptionAlgValuesSupported, ['RSA-OAEP']);
+      expect(parsed.idTokenEncryptionEncValuesSupported, ['A128GCM']);
+      expect(parsed.userinfoSigningAlgValuesSupported, ['RS256']);
+      expect(parsed.userinfoEncryptionAlgValuesSupported, ['RSA-OAEP']);
+      expect(parsed.userinfoEncryptionEncValuesSupported, ['A128GCM']);
+      expect(parsed.requestObjectSigningAlgValuesSupported, ['RS256']);
+      expect(parsed.requestObjectEncryptionAlgValuesSupported, ['RSA-OAEP']);
+      expect(parsed.requestObjectEncryptionEncValuesSupported, ['A128GCM']);
+      expect(parsed.tokenEndpointAuthMethodsSupported, ['client_secret_basic']);
+      expect(parsed.tokenEndpointAuthSigningAlgValuesSupported, ['RS256']);
+      expect(parsed.displayValuesSupported, ['page', 'popup']);
+      expect(parsed.claimTypesSupported, ['normal']);
+      expect(parsed.claimsSupported, ['sub', 'iss', 'email']);
+      expect(parsed.claimsLocalesSupported, ['en-US']);
+      expect(parsed.uiLocalesSupported, ['en-US', 'fr-FR']);
+      expect(
+        parsed.revocationEndpointAuthMethodsSupported,
+        ['client_secret_basic'],
+      );
+      expect(
+        parsed.revocationEndpointAuthSigningAlgValuesSupported,
+        ['RS256'],
+      );
+      expect(
+        parsed.introspectionEndpointAuthMethodsSupported,
+        ['client_secret_basic'],
+      );
+      expect(
+        parsed.introspectionEndpointAuthSigningAlgValuesSupported,
+        ['RS256'],
+      );
+      expect(parsed.codeChallengeMethodsSupported, ['S256', 'plain']);
+    });
+
+    test('all bool fields parse (with their OrDefault getters)', () {
+      expect(parsed.claimsParameterSupported, isTrue);
+      expect(parsed.claimsParameterSupportedOrDefault, isTrue);
+      expect(parsed.authorizationResponseIssParameterSupported, isTrue);
+      expect(
+        parsed.authorizationResponseIssParameterSupportedOrDefault,
+        isTrue,
+      );
+      expect(parsed.requestParameterSupported, isTrue);
+      expect(parsed.requireRequestUriRegistration, isTrue);
+      expect(parsed.requestUriParameterSupported, isFalse);
+      expect(parsed.requestUriParameterSupportedOrDefault, isFalse);
+      expect(parsed.requirePushedAuthorizationRequests, isTrue);
+      expect(parsed.requirePushedAuthorizationRequestsOrDefault, isTrue);
+      expect(parsed.frontchannelLogoutSupportedOrDefault, isTrue);
+      expect(parsed.frontchannelLogoutSessionSupportedOrDefault, isTrue);
+      expect(parsed.backchannelLogoutSupportedOrDefault, isTrue);
+      expect(parsed.backchannelLogoutSessionSupportedOrDefault, isTrue);
+    });
+
+    test('src preserves the raw json', () {
+      expect(parsed.src['issuer'], 'https://op.example.com');
+      expect(parsed.src['code_challenge_methods_supported'], ['S256', 'plain']);
+    });
+  });
+
+  group('OidcProviderMetadata OrDefault getters when absent', () {
+    final sparse = OidcProviderMetadata.fromJson({
+      'issuer': 'https://op.example.com',
+      'jwks_uri': 'https://op.example.com/jwks',
+      'token_endpoint': 'https://op.example.com/token',
+    });
+
+    test('grantTypesSupportedOrDefault falls back to code+implicit', () {
+      expect(sparse.grantTypesSupported, isNull);
+      expect(sparse.grantTypesSupportedOrDefault, const [
+        'authorization_code',
+        'implicit',
+      ]);
+    });
+
+    test('requestUriParameterSupportedOrDefault defaults to true', () {
+      expect(sparse.requestUriParameterSupported, isNull);
+      expect(sparse.requestUriParameterSupportedOrDefault, isTrue);
+    });
+
+    test('requirePushedAuthorizationRequestsOrDefault defaults to false', () {
+      expect(sparse.requirePushedAuthorizationRequestsOrDefault, isFalse);
+    });
+
+    test('claims/iss parameter OrDefault getters default to false', () {
+      expect(sparse.claimsParameterSupportedOrDefault, isFalse);
+      expect(
+        sparse.authorizationResponseIssParameterSupportedOrDefault,
+        isFalse,
+      );
+    });
+  });
+
+  group('OidcProviderMetadata copyWith', () {
+    final base = OidcProviderMetadata.fromJson(_fullDiscovery());
+
+    test('bulk copyWith replaces every field', () {
+      final updated = base.copyWith(
+        issuer: Uri.parse('https://new.example.com'),
+        authorizationEndpoint: Uri.parse('https://new.example.com/a'),
+        jwksUri: Uri.parse('https://new.example.com/jwks'),
+        responseTypesSupported: const ['code'],
+        subjectTypesSupported: const ['public'],
+        idTokenSigningAlgValuesSupported: const ['ES256'],
+        tokenEndpoint: Uri.parse('https://new.example.com/t'),
+        userinfoEndpoint: Uri.parse('https://new.example.com/u'),
+        registrationEndpoint: Uri.parse('https://new.example.com/r'),
+        scopesSupported: const ['openid'],
+        responseModesSupported: const ['query'],
+        grantTypesSupported: const ['authorization_code'],
+        acrValuesSupported: const ['acr'],
+        idTokenEncryptionAlgValuesSupported: const ['A'],
+        requestObjectSigningAlgValuesSupported: const ['B'],
+        requestObjectEncryptionAlgValuesSupported: const ['C'],
+        requestObjectEncryptionEncValuesSupported: const ['D'],
+        tokenEndpointAuthSigningAlgValuesSupported: const ['E'],
+        tokenEndpointAuthMethodsSupported: const ['F'],
+        displayValuesSupported: const ['page'],
+        claimTypesSupported: const ['normal'],
+        claimsSupported: const ['sub'],
+        serviceDocumentation: Uri.parse('https://new.example.com/docs'),
+        claimsLocalesSupported: const ['en'],
+        uiLocalesSupported: const ['en'],
+        pushedAuthorizationRequestEndpoint: Uri.parse(
+          'https://new.example.com/par',
+        ),
+        claimsParameterSupported: false,
+        authorizationResponseIssParameterSupported: false,
+        requestParameterSupported: false,
+        requireRequestUriRegistration: false,
+        requestUriParameterSupported: true,
+        requirePushedAuthorizationRequests: false,
+        opPolicyUri: Uri.parse('https://new.example.com/policy'),
+        opTosUri: Uri.parse('https://new.example.com/tos'),
+        checkSessionIframe: Uri.parse('https://new.example.com/cs'),
+        endSessionEndpoint: Uri.parse('https://new.example.com/logout'),
+        frontchannelLogoutSupported: false,
+        frontchannelLogoutSessionSupported: false,
+        backchannelLogoutSupported: false,
+        backchannelLogoutSessionSupported: false,
+        revocationEndpoint: Uri.parse('https://new.example.com/rev'),
+        revocationEndpointAuthMethodsSupported: const ['G'],
+        revocationEndpointAuthSigningAlgValuesSupported: const ['H'],
+        introspectionEndpoint: Uri.parse('https://new.example.com/int'),
+        introspectionEndpointAuthMethodsSupported: const ['I'],
+        introspectionEndpointAuthSigningAlgValuesSupported: const ['J'],
+        codeChallengeMethodsSupported: const ['S256'],
+        idTokenEncryptionEncValuesSupported: const ['K'],
+        userinfoSigningAlgValuesSupported: const ['L'],
+        userinfoEncryptionAlgValuesSupported: const ['M'],
+        userinfoEncryptionEncValuesSupported: const ['N'],
+        src: const {'issuer': 'https://new.example.com'},
+      );
+
+      expect(updated.issuer, Uri.parse('https://new.example.com'));
+      expect(updated.responseTypesSupported, const ['code']);
+      expect(updated.idTokenSigningAlgValuesSupported, const ['ES256']);
+      expect(updated.claimsParameterSupported, isFalse);
+      expect(updated.requestUriParameterSupported, isTrue);
+      expect(updated.codeChallengeMethodsSupported, const ['S256']);
+      expect(updated.userinfoEncryptionEncValuesSupported, const ['N']);
+      expect(updated.src, const {'issuer': 'https://new.example.com'});
+    });
+
+    test('single-field copyWith proxies leave other fields intact', () {
+      final onlyIssuer = base.copyWith.issuer(Uri.parse('https://x.example'));
+      expect(onlyIssuer.issuer, Uri.parse('https://x.example'));
+      // untouched
+      expect(onlyIssuer.tokenEndpoint, base.tokenEndpoint);
+      expect(onlyIssuer.scopesSupported, base.scopesSupported);
+
+      expect(
+        base.copyWith.tokenEndpoint(Uri.parse('https://x/t')).tokenEndpoint,
+        Uri.parse('https://x/t'),
+      );
+      expect(
+        base.copyWith.jwksUri(Uri.parse('https://x/j')).jwksUri,
+        Uri.parse('https://x/j'),
+      );
+      expect(
+        base.copyWith.grantTypesSupported(const [
+          'refresh_token',
+        ]).grantTypesSupported,
+        const ['refresh_token'],
+      );
+      expect(
+        base.copyWith.scopesSupported(const ['openid']).scopesSupported,
+        const ['openid'],
+      );
+      expect(
+        base.copyWith.responseTypesSupported(const [
+          'code',
+        ]).responseTypesSupported,
+        const ['code'],
+      );
+      expect(
+        base.copyWith.subjectTypesSupported(const [
+          'public',
+        ]).subjectTypesSupported,
+        const ['public'],
+      );
+      expect(
+        base.copyWith
+            .frontchannelLogoutSupported(false)
+            .frontchannelLogoutSupported,
+        isFalse,
+      );
+      expect(
+        base.copyWith
+            .backchannelLogoutSupported(false)
+            .backchannelLogoutSupported,
+        isFalse,
+      );
+      expect(
+        base.copyWith.codeChallengeMethodsSupported(const [
+          'plain',
+        ]).codeChallengeMethodsSupported,
+        const ['plain'],
+      );
+      expect(
+        base.copyWith
+            .endSessionEndpoint(Uri.parse('https://x/end'))
+            .endSessionEndpoint,
+        Uri.parse('https://x/end'),
+      );
+      expect(
+        base.copyWith
+            .revocationEndpoint(Uri.parse('https://x/rev'))
+            .revocationEndpoint,
+        Uri.parse('https://x/rev'),
+      );
+      expect(
+        base.copyWith
+            .introspectionEndpoint(Uri.parse('https://x/int'))
+            .introspectionEndpoint,
+        Uri.parse('https://x/int'),
+      );
+    });
+
+    test('copyWith.src replaces only the raw src map', () {
+      final updated = base.copyWith.src(const {'a': 'b'});
+      expect(updated.src, const {'a': 'b'});
+      expect(updated.issuer, base.issuer);
+    });
+  });
+}

--- a/packages/oidc_core/test/store_extensions_test.dart
+++ b/packages/oidc_core/test/store_extensions_test.dart
@@ -1,0 +1,110 @@
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late OidcMemoryStore store;
+
+  setUp(() async {
+    store = OidcMemoryStore();
+    await store.init();
+  });
+
+  group('nonce helpers (secureTokens namespace)', () {
+    test('setCurrentNonce then getCurrentNonce round-trips', () async {
+      await store.setCurrentNonce('the-nonce');
+      expect(await store.getCurrentNonce(), 'the-nonce');
+    });
+
+    test('setCurrentNonce(null) removes the stored nonce', () async {
+      await store.setCurrentNonce('the-nonce');
+      await store.setCurrentNonce(null);
+      expect(await store.getCurrentNonce(), isNull);
+    });
+
+    test('an absent nonce reads as null', () async {
+      expect(await store.getCurrentNonce(), isNull);
+    });
+  });
+
+  group('front-channel logout request helpers (request namespace)', () {
+    test('set then get round-trips the request', () async {
+      await store.setCurrentFrontChannelLogoutRequest('sid=abc');
+      expect(
+        await store.getCurrentFrontChannelLogoutRequest(),
+        'sid=abc',
+      );
+    });
+
+    test('setting null removes the request', () async {
+      await store.setCurrentFrontChannelLogoutRequest('sid=abc');
+      await store.setCurrentFrontChannelLogoutRequest(null);
+      expect(await store.getCurrentFrontChannelLogoutRequest(), isNull);
+    });
+  });
+
+  group('single-key set/get/remove extension helpers', () {
+    test('set then get on a namespace', () async {
+      await store.set(
+        OidcStoreNamespace.discoveryDocument,
+        key: 'k',
+        value: 'v',
+      );
+      expect(
+        await store.get(OidcStoreNamespace.discoveryDocument, key: 'k'),
+        'v',
+      );
+    });
+
+    test('remove deletes a single key', () async {
+      await store.set(
+        OidcStoreNamespace.discoveryDocument,
+        key: 'k',
+        value: 'v',
+      );
+      await store.remove(OidcStoreNamespace.discoveryDocument, key: 'k');
+      expect(
+        await store.get(OidcStoreNamespace.discoveryDocument, key: 'k'),
+        isNull,
+      );
+    });
+  });
+
+  group('getStatesWithResponses', () {
+    test('returns empty when no responses are stored', () async {
+      expect(await store.getStatesWithResponses(), isEmpty);
+    });
+
+    test(
+      'pairs each stored state with its response, dropping responses that '
+      'have no matching state data',
+      () async {
+        // s1 has both state data + a response.
+        await store.setStateData(state: 's1', stateData: 'data1');
+        await store.setStateResponseData(state: 's1', stateData: 'resp1');
+        // s2 has a response but NO state data → must be dropped.
+        await store.setStateResponseData(state: 's2', stateData: 'resp2');
+
+        final result = await store.getStatesWithResponses();
+        expect(result.keys, ['s1']);
+        expect(result['s1']!.stateData, 'data1');
+        expect(result['s1']!.stateResponse, 'resp1');
+      },
+    );
+
+    test('returns empty when only state data (no responses) exists', () async {
+      await store.setStateData(state: 's1', stateData: 'data1');
+      expect(await store.getStatesWithResponses(), isEmpty);
+    });
+  });
+
+  group('OidcStoreNamespace values', () {
+    test('each namespace carries its wire value', () {
+      expect(OidcStoreNamespace.session.value, 'session');
+      expect(OidcStoreNamespace.state.value, 'state');
+      expect(OidcStoreNamespace.stateResponse.value, 'response.state');
+      expect(OidcStoreNamespace.request.value, 'request');
+      expect(OidcStoreNamespace.discoveryDocument.value, 'discoveryDocument');
+      expect(OidcStoreNamespace.secureTokens.value, 'secureTokens');
+    });
+  });
+}

--- a/packages/oidc_core/test/userinfo_distributed_claims_test.dart
+++ b/packages/oidc_core/test/userinfo_distributed_claims_test.dart
@@ -1,0 +1,218 @@
+@TestOn('vm')
+library;
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+String _unsignedJwt(Map<String, dynamic> claims) =>
+    (JsonWebSignatureBuilder()
+          ..jsonContent = claims
+          ..addRecipient(
+            JsonWebKey.generate('HS256'),
+            algorithm: 'HS256',
+          ))
+        .build()
+        .toCompactSerialization();
+
+void main() {
+  group('OidcEndpoints.userInfoFollowDistributedClaims', () {
+    test(
+      'returns the response untouched when there are no claim names',
+      () async {
+        final response = OidcUserInfoResponse.fromJson({'sub': 'u1'});
+        final result = await OidcEndpoints.userInfoFollowDistributedClaims(
+          response: response,
+        );
+        expect(identical(result, response), isTrue);
+      },
+    );
+
+    test(
+      'returns untouched when claim names reference missing sources',
+      () async {
+        final response = OidcUserInfoResponse.fromJson({
+          'sub': 'u1',
+          '_claim_names': {'address': 'src-1'},
+          // no src-1 in _claim_sources
+          '_claim_sources': <String, dynamic>{},
+        });
+        final result = await OidcEndpoints.userInfoFollowDistributedClaims(
+          response: response,
+        );
+        expect(identical(result, response), isTrue);
+      },
+    );
+
+    test('resolves an aggregated claim source (embedded JWT)', () async {
+      final aggregatedJwt = _unsignedJwt({
+        'address': {'country': 'DE'},
+        'unrelated': 'ignored',
+      });
+      final response = OidcUserInfoResponse.fromJson({
+        'sub': 'u1',
+        '_claim_names': {'address': 'src-1'},
+        '_claim_sources': {
+          'src-1': {'JWT': aggregatedJwt},
+        },
+      });
+
+      final result = await OidcEndpoints.userInfoFollowDistributedClaims(
+        response: response,
+      );
+      expect(result.src['address'], {'country': 'DE'});
+      // only the referenced claim is merged, not the aggregate's other claims
+      expect(result.src.containsKey('unrelated'), isFalse);
+      // base claims are preserved
+      expect(result.sub, 'u1');
+    });
+
+    test(
+      'resolves a distributed claim source over http (Bearer token)',
+      () async {
+        final distributedJwt = _unsignedJwt({
+          'payment_info': 'gold',
+          'ignored': true,
+        });
+        late http.Request captured;
+        final client = MockClient((request) async {
+          captured = request;
+          return http.Response(distributedJwt, 200);
+        });
+
+        final response = OidcUserInfoResponse.fromJson({
+          'sub': 'u1',
+          '_claim_names': {'payment_info': 'src-2'},
+          '_claim_sources': {
+            'src-2': {
+              'endpoint': 'https://claims.example.com/payment',
+              'access_token': 'dist-token',
+            },
+          },
+        });
+
+        final result = await OidcEndpoints.userInfoFollowDistributedClaims(
+          response: response,
+          client: client,
+        );
+        expect(result.src['payment_info'], 'gold');
+        expect(result.src.containsKey('ignored'), isFalse);
+        expect(captured.url, Uri.parse('https://claims.example.com/payment'));
+        expect(captured.headers['Authorization'], 'Bearer dist-token');
+      },
+    );
+
+    test(
+      'uses getAccessTokenFor when the distributed source has no token',
+      () async {
+        final distributedJwt = _unsignedJwt({'payment_info': 'silver'});
+        late http.Request captured;
+        final client = MockClient((request) async {
+          captured = request;
+          return http.Response(distributedJwt, 200);
+        });
+
+        String? requestedSource;
+        Uri? requestedEndpoint;
+
+        final response = OidcUserInfoResponse.fromJson({
+          'sub': 'u1',
+          '_claim_names': {'payment_info': 'src-3'},
+          '_claim_sources': {
+            'src-3': {'endpoint': 'https://claims.example.com/p'},
+          },
+        });
+
+        final result = await OidcEndpoints.userInfoFollowDistributedClaims(
+          response: response,
+          client: client,
+          getAccessTokenFor: (source, endpoint) async {
+            requestedSource = source;
+            requestedEndpoint = endpoint;
+            return 'fetched-token';
+          },
+        );
+
+        expect(result.src['payment_info'], 'silver');
+        expect(requestedSource, 'src-3');
+        expect(requestedEndpoint, Uri.parse('https://claims.example.com/p'));
+        expect(captured.headers['Authorization'], 'Bearer fetched-token');
+      },
+    );
+
+    test(
+      'a distributed endpoint returning a non-2xx status is skipped',
+      () async {
+        final client = MockClient((request) async {
+          return http.Response('nope', 403);
+        });
+        final response = OidcUserInfoResponse.fromJson({
+          'sub': 'u1',
+          '_claim_names': {'payment_info': 'src-4'},
+          '_claim_sources': {
+            'src-4': {'endpoint': 'https://claims.example.com/p'},
+          },
+        });
+
+        final result = await OidcEndpoints.userInfoFollowDistributedClaims(
+          response: response,
+          client: client,
+        );
+        // The claim could not be resolved, so it is not added.
+        expect(result.src.containsKey('payment_info'), isFalse);
+        expect(result.sub, 'u1');
+      },
+    );
+
+    test(
+      'a distributed endpoint returning a non-JWT body resolves no claim',
+      () async {
+        final client = MockClient((request) async {
+          return http.Response('not-a-jwt', 200);
+        });
+        final response = OidcUserInfoResponse.fromJson({
+          'sub': 'u1',
+          '_claim_names': {'payment_info': 'src-5'},
+          '_claim_sources': {
+            'src-5': {'endpoint': 'https://claims.example.com/p'},
+          },
+        });
+
+        final result = await OidcEndpoints.userInfoFollowDistributedClaims(
+          response: response,
+          client: client,
+        );
+        expect(result.src.containsKey('payment_info'), isFalse);
+      },
+    );
+
+    test('merges claims from multiple sources at once', () async {
+      final aggregatedJwt = _unsignedJwt({'address': 'Berlin'});
+      final distributedJwt = _unsignedJwt({'balance': 100});
+      final client = MockClient((request) async {
+        return http.Response(distributedJwt, 200);
+      });
+
+      final response = OidcUserInfoResponse.fromJson({
+        'sub': 'u1',
+        '_claim_names': {'address': 'agg', 'balance': 'dist'},
+        '_claim_sources': {
+          'agg': {'JWT': aggregatedJwt},
+          'dist': {
+            'endpoint': 'https://claims.example.com/b',
+            'access_token': 't',
+          },
+        },
+      });
+
+      final result = await OidcEndpoints.userInfoFollowDistributedClaims(
+        response: response,
+        client: client,
+      );
+      expect(result.src['address'], 'Berlin');
+      expect(result.src['balance'], 100);
+    });
+  });
+}

--- a/packages/oidc_default_store/test/oidc_default_store_web_and_secure_test.dart
+++ b/packages/oidc_default_store/test/oidc_default_store_web_and_secure_test.dart
@@ -1,0 +1,300 @@
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:oidc_default_store/oidc_default_store.dart';
+import 'package:oidc_default_store/src/html_stub.dart' as html_stub;
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('OidcDefaultStore web branches (testIsWeb = true)', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    for (final webSessionManagementLocation
+        in OidcDefaultStoreWebSessionManagementLocation.values) {
+      testWidgets(
+          'exercises the html.window based storage paths for '
+          '$webSessionManagementLocation', (tester) async {
+        final store = OidcDefaultStore(
+          webSessionManagementLocation: webSessionManagementLocation,
+        )..testIsWeb = true;
+        await store.init();
+
+        const goldenValues = {'k1': 'v1', 'k2': 'v2'};
+
+        for (final namespace in OidcStoreNamespace.values) {
+          var allKeys = await store.getAllKeys(namespace);
+          expect(allKeys, isEmpty);
+
+          await store.setMany(namespace, values: goldenValues);
+          allKeys = await store.getAllKeys(namespace);
+          expect(allKeys, goldenValues.keys);
+
+          final allValues =
+              await store.getMany(namespace, keys: {...allKeys, 'missing'});
+          expect(allValues, allOf(hasLength(2), equals(goldenValues)));
+
+          await expectLater(
+            store.set(namespace, key: 'k1', value: 'nnv1'),
+            completes,
+          );
+          await expectLater(
+            store.get(namespace, key: 'k1'),
+            completion('nnv1'),
+          );
+          await expectLater(store.remove(namespace, key: 'k1'), completes);
+          await expectLater(store.get(namespace, key: 'k1'), completion(null));
+
+          await store.removeMany(namespace, keys: allKeys);
+          final afterRemove = await store.getMany(namespace, keys: allKeys);
+          expect(afterRemove, isEmpty);
+        }
+      });
+    }
+
+    testWidgets(
+        'session namespace on web with sessionStorage location does not leak '
+        'into localStorage', (tester) async {
+      final store = OidcDefaultStore()..testIsWeb = true;
+      await store.init();
+
+      await store.set(
+        OidcStoreNamespace.session,
+        key: 'sessionKey',
+        value: 'sessionValue',
+      );
+
+      // it must be readable back through the store.
+      expect(
+        await store.get(OidcStoreNamespace.session, key: 'sessionKey'),
+        'sessionValue',
+      );
+    });
+  });
+
+  group('OidcDefaultStore secureTokens namespace with a real secure storage',
+      () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      FlutterSecureStorage.setMockInitialValues({});
+    });
+
+    testWidgets(
+        'routes secureTokens through FlutterSecureStorage, not through '
+        'SharedPreferences', (tester) async {
+      const secureStorage = FlutterSecureStorage();
+      final store = OidcDefaultStore(secureStorageInstance: secureStorage);
+      await store.init();
+
+      await store.setMany(
+        OidcStoreNamespace.secureTokens,
+        values: {'access_token': 'secret-value'},
+      );
+
+      // readable through the secure storage instance directly.
+      expect(
+        await secureStorage.read(key: 'oidc.secureTokens.access_token'),
+        'secret-value',
+      );
+
+      // readable through the store's getMany/get.
+      expect(
+        await store.get(
+          OidcStoreNamespace.secureTokens,
+          key: 'access_token',
+        ),
+        'secret-value',
+      );
+
+      // must NOT have leaked into SharedPreferences in plaintext.
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('oidc.secureTokens.access_token'), isNull);
+
+      // removeMany must delete it from the secure storage backend.
+      await store.removeMany(
+        OidcStoreNamespace.secureTokens,
+        keys: {'access_token'},
+      );
+      expect(
+        await secureStorage.read(key: 'oidc.secureTokens.access_token'),
+        isNull,
+      );
+      expect(
+        await store.get(OidcStoreNamespace.secureTokens, key: 'access_token'),
+        isNull,
+      );
+    });
+
+    testWidgets(
+        'secureTokens keys are still tracked in the namespace key index',
+        (tester) async {
+      const secureStorage = FlutterSecureStorage();
+      final store = OidcDefaultStore(secureStorageInstance: secureStorage);
+      await store.init();
+
+      await store.setMany(
+        OidcStoreNamespace.secureTokens,
+        values: {'id_token': 'idval', 'refresh_token': 'refval'},
+      );
+
+      final keys = await store.getAllKeys(OidcStoreNamespace.secureTokens);
+      expect(keys, containsAll(<String>['id_token', 'refresh_token']));
+
+      await store.removeMany(
+        OidcStoreNamespace.secureTokens,
+        keys: {'id_token'},
+      );
+      final keysAfter = await store.getAllKeys(OidcStoreNamespace.secureTokens);
+      expect(keysAfter, {'refresh_token'});
+    });
+  });
+
+  group('OidcDefaultStore namespace/managerId isolation', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    testWidgets(
+        'the same key in different namespaces does not clash, and clearing '
+        'one namespace does not affect another', (tester) async {
+      final store = OidcDefaultStore();
+      await store.init();
+
+      await store.set(
+        OidcStoreNamespace.state,
+        key: 'shared',
+        value: 'state-value',
+      );
+      await store.set(
+        OidcStoreNamespace.request,
+        key: 'shared',
+        value: 'request-value',
+      );
+
+      expect(
+        await store.get(OidcStoreNamespace.state, key: 'shared'),
+        'state-value',
+      );
+      expect(
+        await store.get(OidcStoreNamespace.request, key: 'shared'),
+        'request-value',
+      );
+
+      // removing from `state` must not affect `request`.
+      await store.remove(OidcStoreNamespace.state, key: 'shared');
+      expect(
+        await store.get(OidcStoreNamespace.state, key: 'shared'),
+        isNull,
+      );
+      expect(
+        await store.get(OidcStoreNamespace.request, key: 'shared'),
+        'request-value',
+      );
+    });
+
+    testWidgets('different managerIds keep fully isolated data and key indexes',
+        (tester) async {
+      final store = OidcDefaultStore();
+      await store.init();
+      const ns = OidcStoreNamespace.discoveryDocument;
+
+      await store.setMany(
+        ns,
+        values: {'doc': 'manager-A-doc'},
+        managerId: 'managerA',
+      );
+      await store.setMany(
+        ns,
+        values: {'doc': 'manager-B-doc'},
+        managerId: 'managerB',
+      );
+
+      expect(
+        await store.get(ns, key: 'doc', managerId: 'managerA'),
+        'manager-A-doc',
+      );
+      expect(
+        await store.get(ns, key: 'doc', managerId: 'managerB'),
+        'manager-B-doc',
+      );
+
+      final keysA = await store.getAllKeys(ns, managerId: 'managerA');
+      final keysB = await store.getAllKeys(ns, managerId: 'managerB');
+      expect(keysA, {'doc'});
+      expect(keysB, {'doc'});
+
+      // removing managerA's key must not touch managerB's data or index.
+      await store.removeMany(ns, keys: {'doc'}, managerId: 'managerA');
+      expect(await store.getAllKeys(ns, managerId: 'managerA'), isEmpty);
+      expect(await store.getAllKeys(ns, managerId: 'managerB'), {'doc'});
+      expect(
+        await store.get(ns, key: 'doc', managerId: 'managerB'),
+        'manager-B-doc',
+      );
+    });
+
+    testWidgets(
+        'removeMany only removes the requested keys from the index, leaving '
+        'the rest intact', (tester) async {
+      final store = OidcDefaultStore();
+      await store.init();
+      const ns = OidcStoreNamespace.stateResponse;
+
+      await store.setMany(
+        ns,
+        values: {'a': '1', 'b': '2', 'c': '3'},
+      );
+      await store.removeMany(ns, keys: {'b'});
+
+      final remainingKeys = await store.getAllKeys(ns);
+      expect(remainingKeys, {'a', 'c'});
+
+      final remainingValues = await store.getMany(ns, keys: remainingKeys);
+      expect(remainingValues, {'a': '1', 'c': '3'});
+    });
+  });
+
+  group('html_stub.dart (non-web conditional-import shim)', () {
+    test('initWeb is a no-op that does not throw', () {
+      expect(html_stub.initWeb, returnsNormally);
+    });
+
+    test('Storage get/set/remove round-trips values in memory', () {
+      final storage = html_stub.Storage();
+      expect(storage.getItem('missing'), isNull);
+
+      storage.setItem('key1', 'value1');
+      expect(storage.getItem('key1'), 'value1');
+
+      // overwriting an existing key updates the value.
+      storage.setItem('key1', 'value2');
+      expect(storage.getItem('key1'), 'value2');
+
+      storage.removeItem('key1');
+      expect(storage.getItem('key1'), isNull);
+
+      // removing a non-existent key must not throw.
+      expect(() => storage.removeItem('never-set'), returnsNormally);
+    });
+
+    test('Window exposes independent localStorage and sessionStorage', () {
+      final window = html_stub.Window();
+      window.localStorage.setItem('a', '1');
+      window.sessionStorage.setItem('a', '2');
+
+      // local and session storage must be independent instances.
+      expect(window.localStorage.getItem('a'), '1');
+      expect(window.sessionStorage.getItem('a'), '2');
+    });
+
+    test('module-level window instance persists across accesses', () {
+      html_stub.window.localStorage.setItem('persisted', 'yes');
+      expect(html_stub.window.localStorage.getItem('persisted'), 'yes');
+    });
+  });
+}

--- a/packages/oidc_desktop/test/oidc_desktop_test.dart
+++ b/packages/oidc_desktop/test/oidc_desktop_test.dart
@@ -1,5 +1,8 @@
 // ignore_for_file: prefer_const_constructors
 
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logging/src/logger.dart';
 import 'package:oidc_core/oidc_core.dart';
@@ -107,6 +110,265 @@ void main() {
             ),
           ),
         );
+      },
+    );
+
+    test(
+      'getAuthorizationResponse completes successfully when the loopback '
+      'listener receives a matching GET redirect, and returns the '
+      'configured successful page body to the caller',
+      () async {
+        String? receivedBody;
+        int? receivedStatusCode;
+
+        final oidc = MockDesktopImpl(
+          successfulPageResponse: '<html>done</html>',
+          launchUrl: (uri) async {
+            final redirectUriString = uri.queryParameters['redirect_uri'];
+            expect(redirectUriString, isNotNull);
+            final redirectUri = Uri.parse(redirectUriString!);
+
+            final client = HttpClient();
+            try {
+              final callbackUri = redirectUri.replace(
+                queryParameters: {
+                  ...redirectUri.queryParameters,
+                  'code': 'auth-code-123',
+                  'state': uri.queryParameters['state'] ?? '',
+                },
+              );
+              final request = await client.getUrl(callbackUri);
+              final response = await request.close();
+              receivedStatusCode = response.statusCode;
+              receivedBody = await response.transform(utf8.decoder).join();
+            } finally {
+              client.close(force: true);
+            }
+            return true;
+          },
+        );
+
+        final metadata = OidcProviderMetadata.fromJson({
+          'issuer': 'https://op.example.com',
+          'authorization_endpoint': 'https://op.example.com/authorize',
+        });
+        final request = OidcAuthorizeRequest(
+          responseType: const ['code'],
+          clientId: 'client-1',
+          redirectUri: Uri(
+            scheme: 'http',
+            host: '127.0.0.1',
+            port: 0,
+            path: '/callback',
+          ),
+          scope: const ['openid'],
+        );
+
+        final response = await oidc.getAuthorizationResponse(
+          metadata,
+          request,
+          const OidcPlatformSpecificOptions(),
+          const {},
+        );
+
+        expect(receivedStatusCode, HttpStatus.ok);
+        expect(receivedBody, '<html>done</html>');
+        expect(response, isNotNull);
+        expect(response!.code, 'auth-code-123');
+      },
+    );
+
+    test(
+      'the loopback listener responds 405 with the configured mismatch '
+      'body to a non-GET request, then still completes the flow on a '
+      'subsequent matching GET',
+      () async {
+        int? mismatchStatusCode;
+        String? mismatchBody;
+
+        final oidc = MockDesktopImpl(
+          methodMismatchResponse: 'method-not-allowed-body',
+          launchUrl: (uri) async {
+            final redirectUri = Uri.parse(uri.queryParameters['redirect_uri']!);
+            final client = HttpClient();
+            try {
+              // First: send a POST, which the listener should reject.
+              final postRequest = await client.postUrl(redirectUri);
+              final postResponse = await postRequest.close();
+              mismatchStatusCode = postResponse.statusCode;
+              mismatchBody = await postResponse.transform(utf8.decoder).join();
+
+              // Then: send the matching GET so the flow can complete.
+              final callbackUri = redirectUri.replace(
+                queryParameters: {
+                  ...redirectUri.queryParameters,
+                  'code': 'auth-code-456',
+                  'state': '',
+                },
+              );
+              final getRequest = await client.getUrl(callbackUri);
+              await (await getRequest.close()).drain<void>();
+            } finally {
+              client.close(force: true);
+            }
+            return true;
+          },
+        );
+
+        final metadata = OidcProviderMetadata.fromJson({
+          'issuer': 'https://op.example.com',
+          'authorization_endpoint': 'https://op.example.com/authorize',
+        });
+        final request = OidcAuthorizeRequest(
+          responseType: const ['code'],
+          clientId: 'client-1',
+          redirectUri: Uri(
+            scheme: 'http',
+            host: '127.0.0.1',
+            port: 0,
+            path: '/callback',
+          ),
+          scope: const ['openid'],
+        );
+
+        final response = await oidc.getAuthorizationResponse(
+          metadata,
+          request,
+          const OidcPlatformSpecificOptions(),
+          const {},
+        );
+
+        expect(mismatchStatusCode, HttpStatus.methodNotAllowed);
+        expect(mismatchBody, 'method-not-allowed-body');
+        expect(response, isNotNull);
+        expect(response!.code, 'auth-code-456');
+      },
+    );
+
+    test(
+      'the loopback listener responds 404 with the configured not-found '
+      'body when the request path does not match the redirect path, then '
+      'still completes the flow on a subsequent matching GET',
+      () async {
+        int? notFoundStatusCode;
+        String? notFoundBody;
+
+        final oidc = MockDesktopImpl(
+          notFoundResponse: 'not-found-body',
+          launchUrl: (uri) async {
+            final redirectUri = Uri.parse(uri.queryParameters['redirect_uri']!);
+            final client = HttpClient();
+            try {
+              // First: hit a path that does not match the configured one.
+              final wrongPathUri = redirectUri.replace(path: '/wrong-path');
+              final wrongRequest = await client.getUrl(wrongPathUri);
+              final wrongResponse = await wrongRequest.close();
+              notFoundStatusCode = wrongResponse.statusCode;
+              notFoundBody = await wrongResponse.transform(utf8.decoder).join();
+
+              // Then: send the matching GET so the flow can complete.
+              final callbackUri = redirectUri.replace(
+                queryParameters: {
+                  ...redirectUri.queryParameters,
+                  'code': 'auth-code-789',
+                  'state': '',
+                },
+              );
+              final getRequest = await client.getUrl(callbackUri);
+              await (await getRequest.close()).drain<void>();
+            } finally {
+              client.close(force: true);
+            }
+            return true;
+          },
+        );
+
+        final metadata = OidcProviderMetadata.fromJson({
+          'issuer': 'https://op.example.com',
+          'authorization_endpoint': 'https://op.example.com/authorize',
+        });
+        final request = OidcAuthorizeRequest(
+          responseType: const ['code'],
+          clientId: 'client-1',
+          redirectUri: Uri(
+            scheme: 'http',
+            host: '127.0.0.1',
+            port: 0,
+            path: '/callback',
+          ),
+          scope: const ['openid'],
+        );
+
+        final response = await oidc.getAuthorizationResponse(
+          metadata,
+          request,
+          const OidcPlatformSpecificOptions(),
+          const {},
+        );
+
+        expect(notFoundStatusCode, HttpStatus.notFound);
+        expect(notFoundBody, 'not-found-body');
+        expect(response, isNotNull);
+        expect(response!.code, 'auth-code-789');
+      },
+    );
+
+    test(
+      'getAuthorizationResponse still completes the flow (and logs a '
+      'warning) when the custom launchUrl callback reports a failed '
+      'launch',
+      () async {
+        var launchAttempted = false;
+
+        final oidc = MockDesktopImpl(
+          launchUrl: (uri) async {
+            launchAttempted = true;
+            final redirectUri = Uri.parse(uri.queryParameters['redirect_uri']!);
+            final client = HttpClient();
+            try {
+              final callbackUri = redirectUri.replace(
+                queryParameters: {
+                  ...redirectUri.queryParameters,
+                  'code': 'auth-code-fallback',
+                  'state': '',
+                },
+              );
+              final getRequest = await client.getUrl(callbackUri);
+              await (await getRequest.close()).drain<void>();
+            } finally {
+              client.close(force: true);
+            }
+            // Simulate a failed launch (e.g. no browser available).
+            return false;
+          },
+        );
+
+        final metadata = OidcProviderMetadata.fromJson({
+          'issuer': 'https://op.example.com',
+          'authorization_endpoint': 'https://op.example.com/authorize',
+        });
+        final request = OidcAuthorizeRequest(
+          responseType: const ['code'],
+          clientId: 'client-1',
+          redirectUri: Uri(
+            scheme: 'http',
+            host: '127.0.0.1',
+            port: 0,
+            path: '/callback',
+          ),
+          scope: const ['openid'],
+        );
+
+        final response = await oidc.getAuthorizationResponse(
+          metadata,
+          request,
+          const OidcPlatformSpecificOptions(),
+          const {},
+        );
+
+        expect(launchAttempted, isTrue);
+        expect(response, isNotNull);
+        expect(response!.code, 'auth-code-fallback');
       },
     );
   });

--- a/packages/oidc_platform_interface/test/native_events_test.dart
+++ b/packages/oidc_platform_interface/test/native_events_test.dart
@@ -71,4 +71,68 @@ void main() {
   test('returns null for an unknown event type (forward-compatible)', () {
     expect(OidcNativeBrowserEvent.fromMap(const {'type': 'mystery'}), isNull);
   });
+
+  test('OidcNativeError.toString formats all fields', () {
+    const error = OidcNativeError(
+      kind: OidcNativeErrorKind.noBrowserAvailable,
+      nativeDomain: 'com.example.domain',
+      nativeCode: 7,
+      message: 'no browser',
+    );
+    expect(
+      error.toString(),
+      'OidcNativeError(noBrowserAvailable, domain: com.example.domain, '
+      'code: 7, message: no browser)',
+    );
+  });
+
+  test('OidcNativeError.fromMap defaults raw to an empty map when absent', () {
+    final error = OidcNativeError.fromMap(const {'kind': 'startFailed'});
+    expect(error.kind, OidcNativeErrorKind.startFailed);
+    expect(error.raw, isEmpty);
+    expect(error.nativeDomain, isNull);
+    expect(error.nativeCode, isNull);
+  });
+
+  group('error kind parsing covers every native failure bucket', () {
+    for (final entry in {
+      'userCancelled': OidcNativeErrorKind.userCancelled,
+      'presentationContextNotProvided':
+          OidcNativeErrorKind.presentationContextNotProvided,
+      'presentationContextInvalid':
+          OidcNativeErrorKind.presentationContextInvalid,
+      'startFailed': OidcNativeErrorKind.startFailed,
+      'verificationFailed': OidcNativeErrorKind.verificationFailed,
+      'verificationTimedOut': OidcNativeErrorKind.verificationTimedOut,
+      'noBrowserAvailable': OidcNativeErrorKind.noBrowserAvailable,
+      'somethingUnmodeled': OidcNativeErrorKind.platformError,
+    }.entries) {
+      test('${entry.key} -> ${entry.value.name}', () {
+        final e = OidcNativeBrowserEvent.fromMap({
+          'type': 'failed',
+          'error': {'kind': entry.key},
+        })! as OidcBrowserFlowFailedEvent;
+        expect(e.error.kind, entry.value);
+      });
+    }
+  });
+
+  test('fromMap without a timestamp falls back to DateTime.now()', () {
+    final before = DateTime.now();
+    final e = OidcNativeBrowserEvent.fromMap(const {'type': 'cancelled'})!;
+    final after = DateTime.now();
+    expect(
+      e.at.isAfter(before.subtract(const Duration(seconds: 1))) &&
+          e.at.isBefore(after.add(const Duration(seconds: 1))),
+      isTrue,
+    );
+  });
+
+  test('opened event defaults session type and capture mode to unknown', () {
+    final e = OidcNativeBrowserEvent.fromMap(const {'type': 'opened'})!
+        as OidcBrowserOpenedEvent;
+    expect(e.sessionType, OidcNativeSessionType.unknown);
+    expect(e.captureMode, OidcRedirectCaptureMode.unknown);
+    expect(e.resolvedBrowserPackage, isNull);
+  });
 }

--- a/packages/oidc_platform_interface/test/oidc_platform_interface_test.dart
+++ b/packages/oidc_platform_interface/test/oidc_platform_interface_test.dart
@@ -1,24 +1,225 @@
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:oidc_core/oidc_core.dart';
 import 'package:oidc_platform_interface/oidc_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// A fake [OidcPlatform] implementation, following the
+/// `plugin_platform_interface` mock-platform pattern: it must call
+/// `PlatformInterface.verifyToken` against the base class's protected token
+/// via `MockPlatformInterfaceMixin`, otherwise `OidcPlatform.instance = ...`
+/// throws.
+class _FakeOidcPlatform extends OidcPlatform with MockPlatformInterfaceMixin {
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) {
+    return {'prepared': true};
+  }
+
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async {
+    return null;
+  }
+
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async {
+    return null;
+  }
+
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+      listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) {
+    return const Stream.empty();
+  }
+
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) {
+    return const Stream.empty();
+  }
+}
+
+/// A type that does *not* extend [OidcPlatform] via the token mechanism, used
+/// to prove `PlatformInterface.verify` actually gates the setter.
+class _UnverifiedOidcPlatform implements OidcPlatform {
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) =>
+      throw UnimplementedError();
+
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) =>
+      throw UnimplementedError();
+
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) =>
+      throw UnimplementedError();
+
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+      listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) =>
+          throw UnimplementedError();
+
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Stream<OidcNativeBrowserEvent> nativeBrowserEvents() => const Stream.empty();
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  group('OidcPlatformInterface', () {
-    late OidcPlatform oidcPlatform;
 
-    setUp(() {
-      oidcPlatform = NoOpOidcPlatform();
-      OidcPlatform.instance = oidcPlatform;
+  final metadata = OidcProviderMetadata.fromJson(const {});
+  final authorizeRequest = OidcAuthorizeRequest(
+    responseType: const ['code'],
+    clientId: 'client',
+    redirectUri: Uri.parse('https://example.com/cb'),
+    scope: const ['openid'],
+  );
+  const endSessionRequest = OidcEndSessionRequest();
+  const platformOptions = OidcPlatformSpecificOptions();
+  const frontChannelOptions = OidcFrontChannelRequestListeningOptions();
+  const monitorRequest = OidcMonitorSessionStatusRequest(
+    clientId: 'client',
+    sessionState: 'state',
+    interval: Duration(seconds: 1),
+  );
+
+  group('OidcPlatform.instance', () {
+    test('defaults to a NoOpOidcPlatform', () {
+      // Reset in case a previous test in this process replaced it.
+      OidcPlatform.instance = NoOpOidcPlatform();
+      expect(OidcPlatform.instance, isA<NoOpOidcPlatform>());
     });
 
-    group('getPlatformName', () {
-      test('returns correct name', () async {
-        // expect(
-        //   await OidcPlatform.instance.getPlatformName(),
-        //   equals(OidcMock.mockPlatformName),
-        // );
-      });
+    test('setter replaces the singleton with a verified platform', () {
+      final fake = _FakeOidcPlatform();
+      OidcPlatform.instance = fake;
+      expect(OidcPlatform.instance, same(fake));
+      expect(
+        OidcPlatform.instance.prepareForRedirectFlow(platformOptions),
+        {'prepared': true},
+      );
+      // restore default for other tests in this file.
+      OidcPlatform.instance = NoOpOidcPlatform();
+    });
+
+    test(
+      'setter throws AssertionError for a platform not built on the token',
+      () {
+        expect(
+          () => OidcPlatform.instance = _UnverifiedOidcPlatform(),
+          throwsAssertionError,
+        );
+        // The singleton must remain unchanged after a rejected assignment.
+        expect(OidcPlatform.instance, isNot(isA<_UnverifiedOidcPlatform>()));
+      },
+    );
+
+    test('nativeBrowserEvents() default implementation is an empty stream',
+        () async {
+      final fake = _FakeOidcPlatform();
+      final events = await fake.nativeBrowserEvents().toList();
+      expect(events, isEmpty);
+    });
+  });
+
+  group('NoOpOidcPlatform', () {
+    late NoOpOidcPlatform platform;
+
+    setUp(() {
+      platform = NoOpOidcPlatform();
+    });
+
+    test('prepareForRedirectFlow throws UnimplementedError', () {
+      expect(
+        () => platform.prepareForRedirectFlow(platformOptions),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('getAuthorizationResponse throws UnimplementedError', () {
+      expect(
+        () => platform.getAuthorizationResponse(
+          metadata,
+          authorizeRequest,
+          platformOptions,
+          const {},
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('getEndSessionResponse throws UnimplementedError', () {
+      expect(
+        () => platform.getEndSessionResponse(
+          metadata,
+          endSessionRequest,
+          platformOptions,
+          const {},
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('listenToFrontChannelLogoutRequests throws UnimplementedError', () {
+      expect(
+        () => platform.listenToFrontChannelLogoutRequests(
+          Uri.parse('https://example.com'),
+          frontChannelOptions,
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('monitorSessionStatus throws UnimplementedError', () {
+      expect(
+        () => platform.monitorSessionStatus(
+          checkSessionIframe: Uri.parse('https://example.com/session'),
+          request: monitorRequest,
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('nativeBrowserEvents falls back to the default empty stream',
+        () async {
+      final events = await platform.nativeBrowserEvents().toList();
+      expect(events, isEmpty);
     });
   });
 }

--- a/packages/oidc_web_core/test/oidc_web_crypto_test.dart
+++ b/packages/oidc_web_core/test/oidc_web_crypto_test.dart
@@ -1,0 +1,172 @@
+@TestOn('js')
+library;
+
+import 'package:oidc_web_core/src/oidc_web_crypto.dart';
+import 'package:test/test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  setUp(() {
+    web.window.localStorage.clear();
+    OidcWebCrypto.debugReset();
+  });
+
+  group('OidcWebCrypto.isEncryptedEnvelope', () {
+    test('is true for a well-formed envelope prefix', () {
+      expect(
+        OidcWebCrypto.isEncryptedEnvelope(
+          '${oidcWebCryptoEnvelopePrefixV1}a.b',
+        ),
+        isTrue,
+      );
+    });
+
+    test('is false for plain JSON/JWT-shaped values', () {
+      expect(OidcWebCrypto.isEncryptedEnvelope('{"a":1}'), isFalse);
+      expect(
+        OidcWebCrypto.isEncryptedEnvelope('eyJhbGciOiJIUzI1NiJ9'),
+        isFalse,
+      );
+      expect(OidcWebCrypto.isEncryptedEnvelope(''), isFalse);
+    });
+  });
+
+  group('OidcWebCrypto.decryptEnvelope malformed input handling', () {
+    test('returns null for a raw value without the envelope prefix', () async {
+      final result = await OidcWebCrypto.decryptEnvelope(
+        'not-an-envelope-at-all',
+        recordKey: 'malformed-prefix',
+      );
+      expect(result, isNull);
+    });
+
+    test('returns null when the envelope does not have exactly two '
+        'dot-separated segments after the prefix', () async {
+      final tooFew = await OidcWebCrypto.decryptEnvelope(
+        '${oidcWebCryptoEnvelopePrefixV1}onlyonepart',
+        recordKey: 'malformed-parts',
+      );
+      expect(tooFew, isNull);
+
+      final tooMany = await OidcWebCrypto.decryptEnvelope(
+        '${oidcWebCryptoEnvelopePrefixV1}a.b.c',
+        recordKey: 'malformed-parts',
+      );
+      expect(tooMany, isNull);
+    });
+
+    test('returns null when a segment is not valid base64url', () async {
+      final result = await OidcWebCrypto.decryptEnvelope(
+        '${oidcWebCryptoEnvelopePrefixV1}not-base64!!.also-not-base64!!',
+        recordKey: 'malformed-base64',
+      );
+      expect(result, isNull);
+    });
+
+    test('returns null (rather than throwing) for a structurally valid but '
+        'bogus ciphertext when the key IS available', () async {
+      // Well-formed base64url segments, but not a real IV/ciphertext pair
+      // produced by encrypt() -- decrypt() must reject it as a GCM auth
+      // failure, not crash.
+      final result = await OidcWebCrypto.decryptEnvelope(
+        '${oidcWebCryptoEnvelopePrefixV1}AAAAAAAAAAAAAAAA.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        recordKey: 'bogus-ciphertext',
+      );
+      expect(result, isNull);
+    });
+  });
+
+  group('OidcWebCrypto key unavailability', () {
+    test('encrypt returns null (never throws) when WebCrypto/IndexedDB are '
+        'forced unavailable', () async {
+      OidcWebCrypto.debugForceUnavailable = true;
+      final result = await OidcWebCrypto.encrypt(
+        'secret',
+        recordKey: 'unavailable-encrypt',
+      );
+      expect(result, isNull);
+    });
+
+    test('decryptEnvelope returns null when the key is unavailable, even for '
+        'a structurally well-formed envelope', () async {
+      OidcWebCrypto.debugForceUnavailable = true;
+      final result = await OidcWebCrypto.decryptEnvelope(
+        '${oidcWebCryptoEnvelopePrefixV1}AAAAAAAAAAAAAAAA.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        recordKey: 'unavailable-decrypt',
+      );
+      expect(result, isNull);
+    });
+
+    test('warmUpKey never throws when forced unavailable', () async {
+      OidcWebCrypto.debugForceUnavailable = true;
+      await expectLater(
+        OidcWebCrypto.warmUpKey('unavailable-warmup'),
+        completes,
+      );
+    });
+  });
+
+  group('OidcWebCrypto.warnInsecureFallbackOnce', () {
+    test('logs only once per recordKey (second call is a no-op)', () {
+      // Calling twice must not throw; the second call should hit the
+      // early-return "already warned" branch instead of logging again.
+      OidcWebCrypto.warnInsecureFallbackOnce('warn-once-key');
+      expect(
+        () => OidcWebCrypto.warnInsecureFallbackOnce('warn-once-key'),
+        returnsNormally,
+      );
+    });
+
+    test('warns independently per distinct recordKey', () {
+      expect(
+        () => OidcWebCrypto.warnInsecureFallbackOnce('warn-key-a'),
+        returnsNormally,
+      );
+      expect(
+        () => OidcWebCrypto.warnInsecureFallbackOnce('warn-key-b'),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('OidcWebCrypto key persistence/reuse', () {
+    test('a key generated for a recordKey is reused (loaded from IndexedDB) '
+        'after the in-memory cache is cleared via debugReset', () async {
+      const recordKey = 'reuse-across-reset';
+      final envelope = await OidcWebCrypto.encrypt(
+        'hello-world',
+        recordKey: recordKey,
+      );
+      expect(envelope, isNotNull);
+
+      // Clears the in-memory _keyFutures cache, but NOT the underlying
+      // IndexedDB-persisted CryptoKey -- the next _ensureKey call for the
+      // same recordKey must load the existing key rather than generating
+      // a new (undecryptable) one.
+      OidcWebCrypto.debugReset();
+
+      final decrypted = await OidcWebCrypto.decryptEnvelope(
+        envelope!,
+        recordKey: recordKey,
+      );
+      expect(decrypted, 'hello-world');
+    });
+
+    test('encrypt/decrypt round-trips arbitrary unicode plaintext', () async {
+      const recordKey = 'unicode-roundtrip';
+      const plaintext = '{"token":"héllo 世界 🔒"}';
+      final envelope = await OidcWebCrypto.encrypt(
+        plaintext,
+        recordKey: recordKey,
+      );
+      expect(envelope, isNotNull);
+      expect(OidcWebCrypto.isEncryptedEnvelope(envelope!), isTrue);
+
+      final decrypted = await OidcWebCrypto.decryptEnvelope(
+        envelope,
+        recordKey: recordKey,
+      );
+      expect(decrypted, plaintext);
+    });
+  });
+}

--- a/packages/oidc_web_core/test/oidc_web_store_test.dart
+++ b/packages/oidc_web_core/test/oidc_web_store_test.dart
@@ -192,6 +192,100 @@ void main() {
     });
   });
 
+  group(
+    'OidcWebStore session namespace (sessionStorage location, default)',
+    () {
+      test(
+        'setMany/getMany/removeMany round-trip through window.sessionStorage',
+        () async {
+          const store = OidcWebStore(storagePrefix: 'session-default');
+          await store.init();
+
+          await store.setMany(
+            OidcStoreNamespace.session,
+            values: {'sid': 'abc123'},
+          );
+
+          // Written to sessionStorage, NOT localStorage.
+          expect(
+            web.window.sessionStorage.getItem('session-default.session.sid'),
+            'abc123',
+          );
+          expect(
+            web.window.localStorage.getItem('session-default.session.sid'),
+            isNull,
+          );
+
+          final result = await store.getMany(
+            OidcStoreNamespace.session,
+            keys: {'sid'},
+          );
+          expect(result['sid'], 'abc123');
+
+          await store.removeMany(OidcStoreNamespace.session, keys: {'sid'});
+          expect(
+            web.window.sessionStorage.getItem('session-default.session.sid'),
+            isNull,
+          );
+          final afterRemove = await store.getMany(
+            OidcStoreNamespace.session,
+            keys: {'sid'},
+          );
+          expect(afterRemove.containsKey('sid'), isFalse);
+        },
+      );
+
+      test('a missing session key is simply absent from getMany', () async {
+        const store = OidcWebStore(storagePrefix: 'session-missing');
+        await store.init();
+
+        final result = await store.getMany(
+          OidcStoreNamespace.session,
+          keys: {'nope'},
+        );
+        expect(result.containsKey('nope'), isFalse);
+      });
+    },
+  );
+
+  group('OidcWebStore session namespace (localStorage location)', () {
+    test('setMany/getMany/removeMany round-trip through window.localStorage '
+        'instead of sessionStorage', () async {
+      const store = OidcWebStore(
+        storagePrefix: 'session-local',
+        webSessionManagementLocation:
+            OidcWebStoreSessionManagementLocation.localStorage,
+      );
+      await store.init();
+
+      await store.setMany(
+        OidcStoreNamespace.session,
+        values: {'sid': 'xyz789'},
+      );
+
+      expect(
+        web.window.localStorage.getItem('session-local.session.sid'),
+        'xyz789',
+      );
+      expect(
+        web.window.sessionStorage.getItem('session-local.session.sid'),
+        isNull,
+      );
+
+      final result = await store.getMany(
+        OidcStoreNamespace.session,
+        keys: {'sid'},
+      );
+      expect(result['sid'], 'xyz789');
+
+      await store.removeMany(OidcStoreNamespace.session, keys: {'sid'});
+      expect(
+        web.window.localStorage.getItem('session-local.session.sid'),
+        isNull,
+      );
+    });
+  });
+
   group('when WebCrypto/IndexedDB are unavailable', () {
     test('OidcWebStoreEncryption.preferred falls back to a warned plaintext '
         'write', () async {

--- a/packages/x509_plus/test/extension_extra_test.dart
+++ b/packages/x509_plus/test/extension_extra_test.dart
@@ -1,0 +1,269 @@
+import 'dart:typed_data';
+
+import 'package:asn1lib/asn1lib.dart';
+import 'package:test/test.dart';
+import 'package:x509_plus/x509.dart';
+
+/// Builds the DER content-octets for [oid] using the (correct) asn1lib arc
+/// constructor, so tests do not depend on the broken [ObjectIdentifier.toAsn1].
+ASN1ObjectIdentifier _oid(List<int> arcs) => ASN1ObjectIdentifier(arcs);
+
+void main() {
+  group('Extension.fromAsn1', () {
+    test('rejects an unrecognized critical extension', () {
+      final seq = ASN1Sequence()
+        ..add(_oid([2, 5, 29, 99])) // unknown ce extension
+        ..add(ASN1Boolean(true))
+        ..add(ASN1OctetString(ASN1Null().encodedBytes));
+      expect(() => Extension.fromAsn1(seq), throwsA(isA<UnimplementedError>()));
+    });
+
+    test('keeps an unrecognized non-critical extension as UnknownExtension',
+        () {
+      final seq = ASN1Sequence()
+        ..add(_oid([2, 5, 29, 99]))
+        ..add(ASN1OctetString(ASN1Null().encodedBytes));
+      final ext = Extension.fromAsn1(seq);
+      expect(ext.isCritical, isFalse);
+      expect(ext.extnValue, isA<UnknownExtension>());
+    });
+  });
+
+  group('ExtensionValue dispatch', () {
+    test('routes proxy cert info OID to ProxyCertInfo', () {
+      final policy = ASN1Sequence()..add(_oid([1, 3, 6, 1, 5, 5, 7, 21, 1]));
+      final pci = ASN1Sequence()..add(policy);
+      final v = ExtensionValue.fromAsn1(
+          pci, ObjectIdentifier([1, 3, 6, 1, 5, 5, 7, 1, 14]));
+      expect(v, isA<ProxyCertInfo>());
+    });
+
+    test('routes the Google SCT OID to SctList', () {
+      final v = ExtensionValue.fromAsn1(
+          ASN1OctetString(Uint8List.fromList([1, 2, 3])),
+          ObjectIdentifier([1, 3, 6, 1, 4, 1, 11129, 2, 4, 2]));
+      expect(v, isA<SctList>());
+    });
+
+    test('falls back to UnknownExtension for an unrelated OID', () {
+      final v =
+          ExtensionValue.fromAsn1(ASN1Null(), ObjectIdentifier([1, 2, 3, 4]));
+      expect(v, isA<UnknownExtension>());
+      expect((v as UnknownExtension).id, ObjectIdentifier([1, 2, 3, 4]));
+    });
+  });
+
+  group('ExtendedKeyUsage', () {
+    test('toString lists the named purposes', () {
+      final eku = ExtendedKeyUsage([
+        ObjectIdentifier([1, 3, 6, 1, 5, 5, 7, 3, 1]), // serverAuth
+        ObjectIdentifier([1, 3, 6, 1, 5, 5, 7, 3, 2]), // clientAuth
+      ]);
+      expect(eku.toString(), 'serverAuth, clientAuth');
+    });
+  });
+
+  group('PrivateKeyUsagePeriod', () {
+    test('toString shows both bounds', () {
+      final p = PrivateKeyUsagePeriod(
+          notBefore: DateTime.utc(2021), notAfter: DateTime.utc(2022));
+      expect(p.toString(),
+          'NotBefore:${DateTime.utc(2021)}, NotAfter:${DateTime.utc(2022)}');
+    });
+  });
+
+  group('BasicConstraints', () {
+    test('parses cA and pathLenConstraint', () {
+      final seq = ASN1Sequence()
+        ..add(ASN1Boolean(true))
+        ..add(ASN1Integer(BigInt.from(3)));
+      final bc = BasicConstraints.fromAsn1(seq);
+      expect(bc.cA, isTrue);
+      expect(bc.pathLenConstraint, 3);
+      expect(bc.toString(), 'CA:TRUE');
+    });
+
+    test('defaults cA to false for an empty sequence', () {
+      final bc = BasicConstraints.fromAsn1(ASN1Sequence());
+      expect(bc.cA, isFalse);
+      expect(bc.pathLenConstraint, isNull);
+      expect(bc.toString(), 'CA:FALSE');
+    });
+  });
+
+  group('CertificatePolicies', () {
+    test('parses policies and renders them', () {
+      final policyInfo = ASN1Sequence()..add(_oid([2, 5, 29, 32, 0]));
+      final cp = CertificatePolicies.fromAsn1(ASN1Sequence()..add(policyInfo));
+      expect(cp.policies, hasLength(1));
+      expect(cp.toString(), contains('Policy:'));
+    });
+  });
+
+  group('PolicyQualifierInfo', () {
+    test('parses a user-notice qualifier with explicit text', () {
+      // Note: a noticeRef with noticeNumbers is intentionally omitted because
+      // NoticeReference.fromAsn1 throws a TypeError (see bugsFound).
+      final userNotice = ASN1Sequence()
+        ..add(ASN1PrintableString('See the CPS'));
+      final qualifier = ASN1Sequence()
+        ..add(_oid([1, 3, 6, 1, 5, 5, 7, 2, 2])) // id-qt-unotice
+        ..add(userNotice);
+
+      final pqi = PolicyQualifierInfo.fromAsn1(qualifier);
+      expect(pqi.userNotice, isNotNull);
+      expect(pqi.userNotice!.explicitText, 'See the CPS');
+      expect(pqi.userNotice!.noticeRef, isNull);
+      expect(pqi.userNotice.toString(), contains('Explicit Text: See the CPS'));
+      expect(pqi.toString(), contains('User Notice'));
+    });
+
+    test('rejects an unsupported qualifier id when parsing', () {
+      final qualifier = ASN1Sequence()
+        ..add(_oid([1, 3, 6, 1, 5, 5, 7, 2, 99]))
+        ..add(ASN1PrintableString('x'));
+      expect(() => PolicyQualifierInfo.fromAsn1(qualifier),
+          throwsA(isA<UnsupportedError>()));
+    });
+
+    test('toString throws for an unsupported qualifier id', () {
+      final pqi = PolicyQualifierInfo(
+          policyQualifierId: ObjectIdentifier([1, 3, 6, 1, 5, 5, 7, 2, 99]),
+          cpsUri: 'x');
+      expect(() => pqi.toString(), throwsA(isA<UnsupportedError>()));
+    });
+  });
+
+  group('QCStatements', () {
+    test('parses statements and renders them', () {
+      final statement = ASN1Sequence()..add(_oid([0, 4, 0, 1862, 1, 1]));
+      final v = ExtensionValue.fromAsn1(ASN1Sequence()..add(statement),
+          ObjectIdentifier([1, 3, 6, 1, 5, 5, 7, 1, 3]));
+      expect(v, isA<QCStatements>());
+      final qcs = v as QCStatements;
+      expect(qcs.statements, hasLength(1));
+      expect(qcs.statements.first.qcStatementInfo, isNull);
+      expect(qcs.statements.first.toString(), contains('QCStatement{'));
+    });
+  });
+
+  group('ProxyCertInfo / ProxyPolicy', () {
+    test('parses a proxy policy without path length or policy octets', () {
+      final policy = ASN1Sequence()..add(_oid([1, 3, 6, 1, 5, 5, 7, 21, 1]));
+      final pci = ProxyCertInfo.fromAsn1(ASN1Sequence()..add(policy));
+      expect(pci.pCPathLenConstraint, isNull);
+      expect(pci.proxyPolicy.policyLanguage, isA<ObjectIdentifier>());
+      expect(pci.proxyPolicy.policy, isNull);
+    });
+  });
+
+  group('NameConstraints / GeneralSubtree', () {
+    test('parses permitted subtrees and leaves excluded empty', () {
+      final dns = ASN1Object.preEncoded(
+          0x82, Uint8List.fromList('example.com'.codeUnits));
+      final subtree = ASN1Sequence()..add(dns);
+      final permitted = ASN1Sequence()..add(subtree);
+      final v = ExtensionValue.fromAsn1(
+          ASN1Sequence()..add(permitted), ObjectIdentifier([2, 5, 29, 30]));
+      expect(v, isA<NameConstraints>());
+      final nc = v as NameConstraints;
+      expect(nc.permittedSubtrees, hasLength(1));
+      expect(nc.excludedSubtrees, isEmpty);
+      expect(nc.permittedSubtrees.first.minimum, 0);
+      expect(nc.permittedSubtrees.first.maximum, isNull);
+      expect(nc.permittedSubtrees.first.base.choice, 2); // dNSName
+    });
+
+    test('handles an empty NameConstraints sequence', () {
+      final nc = NameConstraints.fromAsn1(ASN1Sequence());
+      expect(nc.permittedSubtrees, isEmpty);
+      expect(nc.excludedSubtrees, isEmpty);
+    });
+
+    test('parses both permitted and excluded subtrees', () {
+      ASN1Sequence subtreeFor(String host) {
+        final dns =
+            ASN1Object.preEncoded(0x82, Uint8List.fromList(host.codeUnits));
+        return ASN1Sequence()..add(dns);
+      }
+
+      final permitted = ASN1Sequence()..add(subtreeFor('permitted.example'));
+      final excluded = ASN1Sequence()..add(subtreeFor('excluded.example'));
+      final nc = NameConstraints.fromAsn1(ASN1Sequence()
+        ..add(permitted)
+        ..add(excluded));
+      expect(nc.permittedSubtrees, hasLength(1));
+      expect(nc.excludedSubtrees, hasLength(1));
+    });
+  });
+
+  group('DistributionPoint', () {
+    test('parses name, reasons and crlIssuer', () {
+      final gnUri = ASN1Object.preEncoded(
+          0x86, Uint8List.fromList('http://crl.example.com/a.crl'.codeUnits));
+      final dpn = ASN1Object.preEncoded(0xA0, gnUri.encodedBytes);
+      final nameEl = ASN1Object.preEncoded(0xA0, dpn.encodedBytes);
+      final seq = ASN1Sequence()
+        ..add(nameEl)
+        ..add(ASN1BitString(Uint8List.fromList([1])))
+        ..add(ASN1PrintableString('CRL Issuer'));
+
+      final dp = DistributionPoint.fromAsn1(seq);
+      expect(dp.name.toString(), contains('http://crl.example.com/a.crl'));
+      expect(dp.reasons, isA<List<DistributionPointReason>>());
+      expect(dp.crlIssuer, 'CRL Issuer');
+    });
+  });
+
+  group('DistributionPointName', () {
+    test('parses a nameRelativeToCRLIssuer choice', () {
+      final obj = ASN1Object.preEncoded(0xA1, ASN1Sequence().encodedBytes);
+      final dpn = DistributionPointName.fromAsn1(obj);
+      expect(dpn.choice, 1);
+      expect(dpn.relativeDistinguishedName, isNotNull);
+      expect(dpn.generalNames, isNull);
+      expect(dpn.toString(), startsWith('CRLIssuer:'));
+    });
+
+    test('rejects an unsupported choice', () {
+      final obj = ASN1Object.preEncoded(0xA2, ASN1Sequence().encodedBytes);
+      expect(() => DistributionPointName.fromAsn1(obj),
+          throwsA(isA<UnsupportedError>()));
+    });
+  });
+
+  group('GeneralName choices', () {
+    test('parses an IP address', () {
+      final gn = GeneralName.fromAsn1(
+          ASN1Object.preEncoded(0x87, Uint8List.fromList([127, 0, 0, 1])));
+      expect(gn.choice, 7);
+      expect(gn.isConstructed, isFalse);
+      expect(gn.toString(), startsWith('IPAddress:'));
+    });
+
+    test('parses a registeredID', () {
+      final oidTlv = ASN1ObjectIdentifier([2, 5, 4, 3]).encodedBytes;
+      final gn = GeneralName.fromAsn1(ASN1Object.preEncoded(0x88, oidTlv));
+      expect(gn.choice, 8);
+      expect(gn.toString(), startsWith('registeredID:'));
+    });
+
+    test('parses a constructed choice by re-parsing its contents', () {
+      final inner = ASN1PrintableString('x').encodedBytes;
+      final gn = GeneralName.fromAsn1(ASN1Object.preEncoded(0xA0, inner));
+      expect(gn.isConstructed, isTrue);
+      expect(gn.choice, 0);
+      expect(gn.toString(), startsWith('otherName:'));
+    });
+
+    test('keeps unsupported primitive choices verbatim', () {
+      for (final entry in {0x83: 3, 0x84: 4, 0x85: 5}.entries) {
+        final gn = GeneralName.fromAsn1(
+            ASN1Object.preEncoded(entry.key, Uint8List.fromList([1, 2])));
+        expect(gn.choice, entry.value);
+        expect(gn.isConstructed, isFalse);
+        expect(gn.contents, isA<ASN1Object>());
+      }
+    });
+  });
+}

--- a/packages/x509_plus/test/util_extra_test.dart
+++ b/packages/x509_plus/test/util_extra_test.dart
@@ -1,0 +1,199 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:asn1lib/asn1lib.dart';
+import 'package:test/test.dart';
+import 'package:x509_plus/src/util.dart';
+import 'package:x509_plus/x509.dart';
+
+/// Big-endian fixed-length byte encoding of [v].
+Uint8List _bigToBytes(BigInt v, int len) {
+  final out = Uint8List(len);
+  final mask = BigInt.from(0xff);
+  for (var i = len - 1; i >= 0; i--) {
+    out[i] = (v & mask).toInt();
+    v = v >> 8;
+  }
+  return out;
+}
+
+void main() {
+  group('ObjectIdentifier', () {
+    test('fromAsn1 decodes multi-byte arcs and equality/hashCode agree', () {
+      // Build the encoded OID via the asn1lib constructor (plain arcs) rather
+      // than ObjectIdentifier.toAsn1, which is broken (see bugsFound).
+      final encoded = ASN1ObjectIdentifier([1, 2, 840, 113549, 1, 1, 11]);
+      final oid = ObjectIdentifier.fromAsn1(encoded);
+      expect(oid, equals(ObjectIdentifier([1, 2, 840, 113549, 1, 1, 11])));
+      expect(oid.hashCode,
+          equals(ObjectIdentifier([1, 2, 840, 113549, 1, 1, 11]).hashCode));
+      expect(oid.name, 'sha256WithRSAEncryption');
+    });
+  });
+
+  group('fromDart', () {
+    test('encodes each supported Dart type', () {
+      expect(fromDart(null), isA<ASN1Null>());
+      expect(fromDart(<int>[1, 2, 3]), isA<ASN1BitString>());
+      expect(fromDart(<BigInt>[BigInt.one]), isA<ASN1Sequence>());
+      expect(fromDart(<BigInt>{BigInt.one, BigInt.two}), isA<ASN1Set>());
+      expect(fromDart(BigInt.from(42)), isA<ASN1Integer>());
+      expect(fromDart(7), isA<ASN1Integer>());
+      expect(fromDart(ObjectIdentifier([2, 5, 4, 3])),
+          isA<ASN1ObjectIdentifier>());
+      expect(fromDart(true), isA<ASN1Boolean>());
+      expect(fromDart('hello'), isA<ASN1PrintableString>());
+      expect(fromDart(DateTime.utc(2020, 1, 1)), isA<ASN1UtcTime>());
+    });
+
+    test('throws ArgumentError for an unsupported type', () {
+      expect(() => fromDart(3.14), throwsArgumentError);
+    });
+  });
+
+  group('toDart', () {
+    test('decodes primitives and containers', () {
+      expect(toDart(ASN1Null()), isNull);
+      expect(toDart(ASN1Integer(BigInt.from(9))), BigInt.from(9));
+      expect(toDart(ASN1Boolean(true)), isTrue);
+      expect(toDart(ASN1PrintableString('abc')), 'abc');
+
+      final seq = ASN1Sequence()
+        ..add(ASN1Integer(BigInt.one))
+        ..add(ASN1Boolean(false));
+      expect(toDart(seq), [BigInt.one, false]);
+    });
+
+    test('unwraps a context-specific [0] constructed object (tag 0xa0)', () {
+      final inner = ASN1PrintableString('nested');
+      final wrapped = ASN1Object.preEncoded(0xa0, inner.encodedBytes);
+      expect(toDart(wrapped), 'nested');
+    });
+
+    test('throws ArgumentError for an unconvertible object', () {
+      final obj = ASN1Object.preEncoded(0x99, Uint8List.fromList([1, 2]));
+      expect(() => toDart(obj), throwsArgumentError);
+    });
+  });
+
+  group('toHexString', () {
+    test('pads odd-length hex to whole bytes', () {
+      expect(toHexString(BigInt.from(0xf)).trim(), '0f');
+    });
+
+    test('joins bytes with colons', () {
+      expect(toHexString(BigInt.from(0xabcd)).trim(), 'ab:cd');
+    });
+  });
+
+  group('keyToString / keyToAsn1', () {
+    final rsaPublic = RsaPublicKey(
+      modulus: BigInt.parse('123456789012345678901234567890123456789'),
+      exponent: BigInt.from(65537),
+    );
+
+    test('renders an RSA public key with modulus and exponent', () {
+      final s = keyToString(rsaPublic);
+      expect(s, contains('Modulus'));
+      expect(s, contains('Exponent: 65537'));
+    });
+
+    test('renders a non-RSA key via its own toString', () {
+      final pem = File('test/files/ec256.public.key').readAsStringSync();
+      final info = parsePem(pem).single as SubjectPublicKeyInfo;
+      expect(keyToString(info.subjectPublicKey), isNotEmpty);
+    });
+
+    test('encodes an RSA public key to a BIT STRING', () {
+      expect(keyToAsn1(rsaPublic), isA<ASN1BitString>());
+    });
+  });
+
+  group('keyPairToAsn1', () {
+    test('encodes a parsed RSA key pair', () {
+      final pem = File('test/files/rsa.key').readAsStringSync();
+      final keyPair = parsePem(pem).single as KeyPair;
+      expect(keyPairToAsn1(keyPair), isA<ASN1BitString>());
+    });
+  });
+
+  group('ecPublicKeyFromAsn1', () {
+    late BigInt x;
+    late BigInt y;
+
+    setUp(() {
+      final pem = File('test/files/ec256.public.key').readAsStringSync();
+      final info = parsePem(pem).single as SubjectPublicKeyInfo;
+      final key = info.subjectPublicKey as EcPublicKey;
+      x = key.xCoordinate;
+      y = key.yCoordinate;
+    });
+
+    test('parses an uncompressed point and infers the curve from length', () {
+      final bytes =
+          Uint8List.fromList([4, ..._bigToBytes(x, 32), ..._bigToBytes(y, 32)]);
+      final key = ecPublicKeyFromAsn1(ASN1BitString(bytes));
+      expect(key.curve, curves.p256);
+      expect(key.xCoordinate, x);
+      expect(key.yCoordinate, y);
+    });
+
+    test('rejects a compressed point', () {
+      final bytes = Uint8List.fromList([2, ..._bigToBytes(x, 32)]);
+      expect(() => ecPublicKeyFromAsn1(ASN1BitString(bytes)),
+          throwsA(isA<UnsupportedError>()));
+    });
+
+    test('rejects an invalid compression byte', () {
+      final bytes = Uint8List.fromList([99, 1, 2, 3]);
+      expect(
+          () => ecPublicKeyFromAsn1(ASN1BitString(bytes)), throwsArgumentError);
+    });
+
+    test('throws when no curve matches the point length', () {
+      final bytes = Uint8List.fromList([4, 1, 2]);
+      expect(() => ecPublicKeyFromAsn1(ASN1BitString(bytes)),
+          throwsA(isA<UnsupportedError>()));
+    });
+  });
+
+  group('keyPairFromAsn1 / publicKeyFromAsn1 unsupported algorithms', () {
+    test('keyPairFromAsn1 throws UnimplementedError for a signature OID', () {
+      final sha1Rsa = ObjectIdentifier([1, 2, 840, 113549, 1, 1, 5]);
+      expect(
+          () => keyPairFromAsn1(
+              ASN1BitString(Uint8List.fromList([1, 2])), sha1Rsa),
+          throwsA(isA<UnimplementedError>()));
+    });
+
+    test('publicKeyFromAsn1 throws UnimplementedError for a signature OID', () {
+      final alg = AlgorithmIdentifier(
+          ObjectIdentifier([1, 2, 840, 113549, 1, 1, 5]), null);
+      expect(
+          () =>
+              publicKeyFromAsn1(ASN1BitString(Uint8List.fromList([1, 2])), alg),
+          throwsA(isA<UnimplementedError>()));
+    });
+
+    test('publicKeyFromAsn1 rejects an unsupported EC curve', () {
+      final alg = AlgorithmIdentifier(
+        ObjectIdentifier([1, 2, 840, 10045, 2, 1]), // ecPublicKey
+        ObjectIdentifier(
+            [1, 2, 840, 10045, 3, 1, 2]), // prime192v2 (unsupported)
+      );
+      expect(
+          () => publicKeyFromAsn1(
+              ASN1BitString(Uint8List.fromList([4, 1, 2])), alg),
+          throwsA(isA<UnsupportedError>()));
+    });
+  });
+
+  group('ecKeyPairFromAsn1', () {
+    test('rejects a non-v1 EC private key', () {
+      final seq = ASN1Sequence()
+        ..add(ASN1Integer(BigInt.two))
+        ..add(ASN1OctetString(Uint8List.fromList([1, 2, 3, 4])));
+      expect(() => ecKeyPairFromAsn1(seq), throwsA(isA<UnsupportedError>()));
+    });
+  });
+}

--- a/packages/x509_plus/test/x509_base_extra_test.dart
+++ b/packages/x509_plus/test/x509_base_extra_test.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:asn1lib/asn1lib.dart';
+import 'package:test/test.dart';
+import 'package:x509_plus/x509.dart';
+
+/// Extracts the raw DER bytes from a single-block PEM file.
+Uint8List _pemBody(String path) {
+  final pem = File(path).readAsStringSync();
+  final b64 = LineSplitter.split(pem)
+      .map((l) => l.trim())
+      .where((l) => l.isNotEmpty && !l.startsWith('-----'))
+      .join();
+  return base64.decode(b64);
+}
+
+/// Wraps [der] bytes into a PEM block of the given [type].
+String _der2pem(List<int> der, String type) {
+  final b64 = base64.encode(der);
+  final buf = StringBuffer()..writeln('-----BEGIN $type-----');
+  for (var i = 0; i < b64.length; i += 64) {
+    buf.writeln(b64.substring(i, i + 64 > b64.length ? b64.length : i + 64));
+  }
+  buf.writeln('-----END $type-----');
+  return buf.toString();
+}
+
+ASN1Sequence _algId(List<int> arcs) => ASN1Sequence()
+  ..add(ASN1ObjectIdentifier(arcs))
+  ..add(ASN1Null());
+
+void main() {
+  group('parsePem - additional key formats', () {
+    test('PKCS#8 RSA PRIVATE KEY yields a PrivateKeyInfo', () {
+      final rsaPkcs1 = _pemBody('test/files/rsa.key');
+      final pkcs8 = ASN1Sequence()
+        ..add(ASN1Integer(BigInt.zero))
+        ..add(_algId([1, 2, 840, 113549, 1, 1, 1])) // rsaEncryption
+        ..add(ASN1OctetString(rsaPkcs1));
+      final info = parsePem(_der2pem(pkcs8.encodedBytes, 'PRIVATE KEY')).single
+          as PrivateKeyInfo;
+      expect(info.version, 1);
+      expect(info.keyPair.privateKey, isA<RsaPrivateKey>());
+      expect(info.algorithm.algorithm.name, 'rsaEncryption');
+    });
+
+    test('PKCS#8 EC PRIVATE KEY yields a PrivateKeyInfo', () {
+      final ecPriv = _pemBody('test/files/ec256.private.key');
+      final pkcs8 = ASN1Sequence()
+        ..add(ASN1Integer(BigInt.zero))
+        ..add(_algId([1, 2, 840, 10045, 2, 1])) // ecPublicKey
+        ..add(ASN1OctetString(ecPriv));
+      final info = parsePem(_der2pem(pkcs8.encodedBytes, 'PRIVATE KEY')).single
+          as PrivateKeyInfo;
+      expect(info.keyPair.privateKey, isA<EcPrivateKey>());
+    });
+
+    test('PKCS#1 RSA PUBLIC KEY yields an RsaPublicKey', () {
+      final seq = ASN1Sequence()
+        ..add(ASN1Integer(BigInt.from(3233)))
+        ..add(ASN1Integer(BigInt.from(17)));
+      final key = parsePem(_der2pem(seq.encodedBytes, 'RSA PUBLIC KEY')).single
+          as RsaPublicKey;
+      expect(key.modulus, BigInt.from(3233));
+      expect(key.exponent, BigInt.from(17));
+    });
+
+    test('ENCRYPTED PRIVATE KEY yields an EncryptedPrivateKeyInfo', () {
+      final der = ASN1Sequence()
+        ..add(_algId([1, 2, 840, 113549, 1, 5, 13])) // pbes2
+        ..add(ASN1OctetString(Uint8List.fromList([1, 2, 3, 4])));
+      final info = parsePem(_der2pem(der.encodedBytes, 'ENCRYPTED PRIVATE KEY'))
+          .single as EncryptedPrivateKeyInfo;
+      expect(info.encryptedData, [1, 2, 3, 4]);
+      expect(info.encryptionAlgorithm.algorithm, isA<ObjectIdentifier>());
+    });
+  });
+
+  group('parsePem - error handling', () {
+    test('throws when the DER is not a SEQUENCE', () {
+      final pem =
+          _der2pem(ASN1Integer(BigInt.from(5)).encodedBytes, 'CERTIFICATE');
+      expect(() => parsePem(pem).toList(), throwsFormatException);
+    });
+
+    test('throws for an unhandled PEM type', () {
+      final pem = _der2pem(ASN1Sequence().encodedBytes, 'DSA PRIVATE KEY');
+      expect(() => parsePem(pem).toList(), throwsFormatException);
+    });
+
+    test('throws when the begin marker is missing', () {
+      expect(() => parsePem('this is not a pem').toList(), throwsArgumentError);
+    });
+
+    test('throws when the end marker is missing', () {
+      expect(() => parsePem('-----BEGIN CERTIFICATE-----\nQUJD').toList(),
+          throwsArgumentError);
+    });
+  });
+
+  group('certificate re-encoding and accessors', () {
+    late X509Certificate cert;
+
+    setUp(() {
+      final bytes = File('test/resources/rfc5280_cert1.cer').readAsBytesSync();
+      cert = X509Certificate.fromAsn1(
+          ASN1Parser(bytes).nextObject() as ASN1Sequence);
+    });
+
+    test('exposes the RSA public key', () {
+      expect(cert.publicKey, isA<RsaPublicKey>());
+    });
+
+    test('toPem wraps the public key with PEM markers', () {
+      final spki = cert.tbsCertificate.subjectPublicKeyInfo!;
+      final pem = toPem(spki);
+      expect(pem, startsWith('-----BEGIN PUBLIC KEY-----'));
+      expect(pem, contains('-----END PUBLIC KEY-----'));
+    });
+
+    test('component toAsn1 methods assemble the expected structures', () {
+      final tbs = cert.tbsCertificate;
+      expect(tbs.issuer!.toAsn1(), isA<ASN1Sequence>());
+      expect(tbs.validity!.toAsn1().elements, hasLength(2));
+      expect(tbs.signature!.toAsn1(), isA<ASN1Sequence>());
+      expect(tbs.subjectPublicKeyInfo!.toAsn1().elements, hasLength(2));
+    });
+
+    test('X509Certificate.toAsn1 produces a three-element SEQUENCE', () {
+      final seq = cert.toAsn1();
+      expect(seq, isA<ASN1Sequence>());
+      expect(seq.elements, hasLength(3));
+    });
+  });
+}


### PR DESCRIPTION
Adds 36 test files (32 new, 4 extended) across 10 packages — roughly +1,300 covered lines.

Notable per-package results: oidc and oidc_default_store to 100%, jose_plus 98.7%, x509_plus 98.3%, crypto_keys_plus 95.3%, oidc_core 83%.

Four real library bugs surfaced while writing these tests; the affected lines are deliberately left uncovered rather than tested-as-is, and each is filed: #356, #357, #358, #359.
