### PR TITLE
fix(oidc_web_core): secureTokens silently persisted as plaintext on Firefox

### DIFF
--- a/packages/oidc_web_core/lib/src/oidc_web_crypto.dart
+++ b/packages/oidc_web_core/lib/src/oidc_web_crypto.dart
@@ -240,17 +240,45 @@ class OidcWebCrypto {
     try {
       final db = await _openDatabase();
       try {
-        final store = db
-            .transaction(_cryptoKeysStoreName.toJS, 'readwrite')
+        // IndexedDB transactions auto-commit as soon as control returns to
+        // the event loop with no request pending on them, so a transaction
+        // must never be held across a non-IndexedDB await. Firefox enforces
+        // this strictly: reusing the read transaction for the write after
+        // awaiting `generateKey` throws TransactionInactiveError (which made
+        // the store fall back to writing secureTokens as PLAINTEXT on every
+        // Firefox session). Chrome merely happened not to trip the
+        // auto-commit. One transaction per await-separated operation.
+        final readStore = db
+            .transaction(_cryptoKeysStoreName.toJS, 'readonly')
             .objectStore(_cryptoKeysStoreName);
-        final existing = await _requestResult(store.get(recordKey.toJS));
+        final existing = await _requestResult(readStore.get(recordKey.toJS));
         if (existing != null) {
-          await _requestPersistBestEffort();
+          _requestPersistBestEffort();
           return existing as web.CryptoKey;
         }
         final generated = await _generateKey();
-        await _requestResult(store.put(generated, recordKey.toJS));
-        await _requestPersistBestEffort();
+        final writeStore = db
+            .transaction(_cryptoKeysStoreName.toJS, 'readwrite')
+            .objectStore(_cryptoKeysStoreName);
+        try {
+          // `add` (not `put`): fails with ConstraintError if another
+          // same-origin context (tab, iframe) won the generate race between
+          // our read and this write. Overwriting with `put` would leave the
+          // two contexts encrypting under DIFFERENT keys, each unable to
+          // decrypt the other's values on the next load.
+          await _requestResult(writeStore.add(generated, recordKey.toJS));
+        } catch (_) {
+          final rereadStore = db
+              .transaction(_cryptoKeysStoreName.toJS, 'readonly')
+              .objectStore(_cryptoKeysStoreName);
+          final winner = await _requestResult(rereadStore.get(recordKey.toJS));
+          if (winner == null) {
+            rethrow;
+          }
+          _requestPersistBestEffort();
+          return winner as web.CryptoKey;
+        }
+        _requestPersistBestEffort();
         return generated;
       } finally {
         db.close();
@@ -321,9 +349,20 @@ class OidcWebCrypto {
   /// pressure. Failures here must never fail key acquisition -- this is
   /// pure hardening, not a correctness requirement (see the design
   /// proposal's persistence/eviction trade-off section).
-  static Future<void> _requestPersistBestEffort() async {
+  ///
+  /// Fire-and-forget by contract: Firefox surfaces `persist()` as a
+  /// permission doorhanger and the returned promise stays PENDING until the
+  /// user answers it -- in headless/CI (and for any user who ignores the
+  /// prompt) that is forever, so `await`ing it wedges key acquisition.
+  /// Nothing may ever await this.
+  static void _requestPersistBestEffort() {
     try {
-      await web.window.navigator.storage.persist().toDart;
+      unawaited(
+        web.window.navigator.storage.persist().toDart.then(
+          (_) {},
+          onError: (Object _) {},
+        ),
+      );
     } catch (_) {
       // Not all browsers/contexts implement the Storage Manager API; a
       // failure here just means we didn't get the (best-effort) hardening.


### PR DESCRIPTION
On every Firefox session, `OidcWebStore`'s encryption-at-rest failed key acquisition and (per its documented `preferred` mode) degraded to plaintext localStorage writes. Chrome was unaffected only by scheduler luck. Two causes:

1. `_loadOrCreateKey` held one IndexedDB transaction across `await crypto.subtle.generateKey(...)`. IDB transactions auto-commit when control returns to the event loop; Firefox enforces this strictly, so the key `put` always threw `TransactionInactiveError` → null key → plaintext fallback. Fixed with one transaction per await-separated operation, and `put` → `add` + re-read so racing tabs converge on one key.
2. `navigator.storage.persist()` on Firefox raises a doorhanger and its promise stays pending until answered — awaiting it wedged the existing-key path. Now fire-and-forget.

Before: 4 tests failing on Firefox (plaintext persisted, identical envelopes, legacy value never re-encrypted). After: full suite green on Firefox and Chrome.
