### PR TITLE
fix(ci): stop swallowing web test failures; pin dart:io fixture tests to vm

### DIFF
--- a/packages/jose_plus/test/jwk_test.dart
+++ b/packages/jose_plus/test/jwk_test.dart
@@ -330,7 +330,7 @@ void main() {
       expect(key.cryptoKeyPair.publicKey, isA<RsaPublicKey>());
       expect(key.cryptoKeyPair.privateKey, isNull);
     });
-  });
+  }, testOn: 'vm');
 
   group('Issues', () {
     test(

--- a/packages/x509_plus/test/util_extra_test.dart
+++ b/packages/x509_plus/test/util_extra_test.dart
@@ -107,7 +107,7 @@ void main() {
     test('encodes an RSA public key to a BIT STRING', () {
       expect(keyToAsn1(rsaPublic), isA<ASN1BitString>());
     });
-  });
+  }, testOn: 'vm');
 
   group('keyPairToAsn1', () {
     test('encodes a parsed RSA key pair', () {
@@ -115,7 +115,7 @@ void main() {
       final keyPair = parsePem(pem).single as KeyPair;
       expect(keyPairToAsn1(keyPair), isA<ASN1BitString>());
     });
-  });
+  }, testOn: 'vm');
 
   group('ecPublicKeyFromAsn1', () {
     late BigInt x;
@@ -155,7 +155,7 @@ void main() {
       expect(() => ecPublicKeyFromAsn1(ASN1BitString(bytes)),
           throwsA(isA<UnsupportedError>()));
     });
-  });
+  }, testOn: 'vm');
 
   group('keyPairFromAsn1 / publicKeyFromAsn1 unsupported algorithms', () {
     test('keyPairFromAsn1 throws UnimplementedError for a signature OID', () {

--- a/packages/x509_plus/test/x509_base_extra_test.dart
+++ b/packages/x509_plus/test/x509_base_extra_test.dart
@@ -76,7 +76,7 @@ void main() {
       expect(info.encryptedData, [1, 2, 3, 4]);
       expect(info.encryptionAlgorithm.algorithm, isA<ObjectIdentifier>());
     });
-  });
+  }, testOn: 'vm');
 
   group('parsePem - error handling', () {
     test('throws when the DER is not a SEQUENCE', () {
@@ -133,5 +133,5 @@ void main() {
       expect(seq, isA<ASN1Sequence>());
       expect(seq.elements, hasLength(3));
     });
-  });
+  }, testOn: 'vm');
 }

--- a/packages/x509_plus/test/x509_test.dart
+++ b/packages/x509_plus/test/x509_test.dart
@@ -18,7 +18,7 @@ void main() {
       expect(privateKey.privateExponent, isNotNull);
       expect(publicKey.exponent, isNotNull);
     });
-  });
+  }, testOn: 'vm');
 
   group('ec', () {
     test('parse ec 256 public key', () {
@@ -162,14 +162,14 @@ void main() {
 
       expect(verified, isTrue);
     });
-  });
+  }, testOn: 'vm');
 
   group('csr', () {
     test('parse csr', () {
       var pem = File('test/files/csr.pem').readAsStringSync();
       parsePem(pem).single as CertificationRequest;
     });
-  });
+  }, testOn: 'vm');
 
   group('rfc5280', () {
     test('RSA Self-Signed Certificate', () {
@@ -189,7 +189,7 @@ void main() {
           ASN1Parser(bytes).nextObject() as ASN1Sequence);
       expect(c, isA<X509Certificate>());
     });
-  });
+  }, testOn: 'vm');
 
   group('v3 extension General Name', () {
     var generalNameEncodeBytes = [
@@ -366,7 +366,7 @@ MIIIHzCCB8WgAwIBAgIJf35N0O0if7S5MAoGCCqGSM49BAMCMIGwMT8wPQYDVQQDDDZFQURUcnVzdCBF
         ['https://eadtrust.eu/documentos-vigentes/', 'es']
       ]);
     });
-  });
+  }, testOn: 'vm');
 
   group('PolicyInformation', () {
     var subject = ASN1Sequence.fromBytes(Uint8List.fromList([
@@ -457,5 +457,5 @@ MIIIHzCCB8WgAwIBAgIJf35N0O0if7S5MAoGCCqGSM49BAMCMIGwMT8wPQYDVQQDDDZFQURUcnVzdCBF
       var c = X509Certificate.fromAsn1(parser.nextObject() as ASN1Sequence);
       expect(c, isA<X509Certificate>());
     });
-  });
+  }, testOn: 'vm');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ melos:
 
     generate:
       run: |
+        set -e
         melos run generate:dart
         melos run generate:native
       description: Regenerate every generated file (Dart build_runner + native Pigeon).
@@ -85,6 +86,7 @@ melos:
     test:
       name: All tests
       run: |
+        set -e
         melos run test:vm
         TEST_PLATFORM=chrome melos run test:web
         TEST_PLATFORM=firefox melos run test:web
@@ -105,6 +107,7 @@ melos:
     test:web:
       name: Dart Web tests
       run: |
+        set -e
         melos run test:web:chrome
         melos run test:web:firefox
     test:web:chrome:
@@ -126,6 +129,11 @@ melos:
         WITH_WASM: false
       # We have to use --timeout 60m alongside --ignore-timeouts
       exec: |
+        # set -e: without it this script's exit status is that of its LAST
+        # statement -- the WITH_WASM if-block, which is 0 whenever WITH_WASM
+        # != true -- so a `dart test` failure was silently discarded and the
+        # CI step stayed green (issue #353: 27 web test failures hidden).
+        set -e
         if [ "$TARGET_DART_SDK" = "min" ]; then
           dart test --timeout 60m --ignore-timeouts --platform ${TEST_PLATFORM} --chain-stack-traces
         else
@@ -216,6 +224,7 @@ melos:
     coverage:format:
       name: Format coverage
       run: |
+        set -e
         dart pub global activate coverage
         melos run coverage:format:package
 
@@ -228,6 +237,7 @@ melos:
     coverage:combine:
       name: Combine & convert coverage report
       run: |
+        set -e
         rm -rf coverage
         dart pub global activate combine_coverage
         dart pub global activate remove_from_coverage


### PR DESCRIPTION
Closes #353.

The `test:web:single` melos script's exit status was that of its last statement — the `WITH_WASM` if-block, which is 0 whenever `WITH_WASM != true` — so web test failures were silently discarded and `unit_tests` stayed green while 27 web tests failed on main. `set -e` restores propagation (applied to the other chained melos scripts too).

The hidden failures were `dart:io` fixture reads, impossible on the web platform. The fixture-reading groups are now pinned `testOn: 'vm'` (x509_plus: 11 groups across 3 files, jose_plus: 1); pure-parsing groups keep their web coverage.

Verified on real browsers: x509_plus 47/47, jose_plus 212/212, oidc_web_core 27/27 on both Chrome and Firefox (the oidc_web_core Firefox failures needed #360).
