### PR TITLE
ci(coverage): normalize macOS-absolute SF paths before combining

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -641,6 +641,22 @@ jobs:
           pattern: "*-integration-coverage"
           merge-multiple: true
 
+      - name: Normalize macOS-absolute SF paths
+        env:
+          REPO_PATH: ${{ github.workspace }}
+        # The ios and macos jobs run on macOS runners, so their lcov files
+        # carry SF: paths under /Users/runner/work/oidc/oidc/... while this
+        # job's combine_coverage strips the LINUX workspace prefix
+        # ($REPO_PATH = /home/runner/work/oidc/oidc). Unrewritten, those
+        # entries (106 of them on run 28821969853) stay absolute in
+        # final-coverage and Codecov cannot map them to repo files. Rewrite
+        # the macOS prefix to this job's workspace prefix so the combine
+        # relativizes every record uniformly.
+        run: |
+          set -e
+          find packages/oidc/example/coverage -type f -name "*.info"             -exec sed -i "s|^SF:/Users/runner/work/oidc/oidc/|SF:$REPO_PATH/|" {} +
+          remaining=$(grep -rhc '^SF:/Users/' packages/oidc/example/coverage --include='*.info' | awk '{s+=$1} END {print s+0}')
+          echo "macOS-absolute SF entries remaining after normalization: $remaining"
       - name: Combine Coverage Results
         env:
           REPO_PATH: ${{ github.workspace }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -655,7 +655,11 @@ jobs:
         run: |
           set -e
           find packages/oidc/example/coverage -type f -name "*.info"             -exec sed -i "s|^SF:/Users/runner/work/oidc/oidc/|SF:$REPO_PATH/|" {} +
-          remaining=$(grep -rhc '^SF:/Users/' packages/oidc/example/coverage --include='*.info' | awk '{s+=$1} END {print s+0}')
+          # `|| true` inside the substitution: in the healthy zero-remaining
+          # case grep exits 1 (no matching lines), and under this workflow's
+          # pipefail+errexit shell that would fail the step; awk's stdout
+          # ("0") is captured either way.
+          remaining=$(grep -rhc '^SF:/Users/' packages/oidc/example/coverage --include='*.info' | awk '{s+=$1} END {print s+0}' || true)
           echo "macOS-absolute SF entries remaining after normalization: $remaining"
       - name: Combine Coverage Results
         env:


### PR DESCRIPTION
The ios and macos jobs run on macOS runners, so their lcov artifacts carry `SF:/Users/runner/...` paths; the Linux upload job strips only the Linux workspace prefix, leaving 106 records absolute in `final-coverage` — Codecov couldn't map them, so macOS/iOS integration coverage was uploaded but unattributable.

Adds a normalization step before combining (macOS prefix → this job's workspace prefix) and prints the count of remaining absolute entries so future runner-image changes are visible.
