### PR TITLE
fix(ci): stop the intermittent browser-test hang (#372 root cause)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -205,6 +205,26 @@ jobs:
             exit 1
           fi
           echo "guard: all four Flutter packages present in the combined lcov"
+      - name: "[Coverage] Assert oidc_web_core browser coverage survived"
+        # main + stable only: oidc_web_core browser coverage comes from the
+        # per-file test:web:coverage:webcore step, which is itself main+stable
+        # (PRs collect no browser coverage). Regression guard for #372's fix:
+        # if that step silently stops producing hitmaps (a path change, or
+        # format_coverage ceasing to pick up coverage/chrome), oidc_web_core
+        # would vanish from the combined lcov with only a Codecov delta to
+        # show it. Same shell discipline as the Flutter guard above: a
+        # conditional exit 1 on the failure path only; success falls off the
+        # end (no trailing exit, no SIGPIPE-prone pipe).
+        if: ${{ github.event_name != 'pull_request' && matrix.sdk == 'stable' }}
+        run: |
+          n=$(grep -c "packages/oidc_web_core/lib/" coverage/lcov.info || true)
+          n=${n:-0}
+          echo "guard: packages/oidc_web_core/lib/ -> $n match(es)"
+          if [ "$n" -eq 0 ]; then
+            echo "::error::no browser coverage for oidc_web_core - the per-file step (test:web:coverage:webcore) is being discarded"
+            exit 1
+          fi
+          echo "guard: oidc_web_core browser coverage present in the combined lcov"
       - name: Upload Unit Test Coverage Report
         uses: actions/upload-artifact@v7
         if: ${{ matrix.sdk == 'stable' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -144,6 +144,10 @@ jobs:
             echo "firefox PR-scope attempt $attempt exited rc=$rc; retrying" || true
           done
           exit 1
+      # Full sweep = TEST SIGNAL only (both browsers, no --coverage): #372's
+      # hang needs coverage-gather across multiple suites in one process (see
+      # test:web:single). Without --coverage this sweep is hang-free; the 150m
+      # bound now only covers the honest ~1h40m-2h first-browser compile cost.
       - name: "[Verify step] Test Dart packages [Chrome]"
         if: ${{ github.event_name != 'pull_request' }}
         timeout-minutes: 150
@@ -152,6 +156,16 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         timeout-minutes: 150
         run: melos run test:web:firefox
+      # oidc_web_core is the only package whose browser coverage isn't a
+      # duplicate of its VM coverage, so it's the only one collected on the web
+      # side. Per-file (single-suite) collection is hang-safe where the
+      # multi-suite full sweep was not (#372). Stable + main only, since
+      # coverage is combined on the stable leg. 20m bounds a wedged load; the
+      # honest run is a handful of compiles.
+      - name: "[Coverage] oidc_web_core browser coverage (per-file, hang-safe)"
+        if: ${{ github.event_name != 'pull_request' && matrix.sdk == 'stable' }}
+        timeout-minutes: 20
+        run: melos run test:web:coverage:webcore
       - name: Remove dart_test.yaml Files
         run: melos run remove_dart_test_yaml
       - name: "[Verify step] Test Flutter packages"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -176,17 +176,28 @@ melos:
       name: Dart Web tests in a browser
       env:
         WITH_WASM: false
+      # NO --coverage. Root-caused 2026-07-12 (issue #372): collecting browser
+      # coverage across MULTIPLE suites in one `dart test` process wedges the
+      # Chrome DevTools/V8 channel. package:test enables detailed precise
+      # coverage once on a shared Chrome context (test 1.31 chrome.dart:190,
+      # Profiler.startPreciseCoverage detailed:true) and gathers per-suite; the
+      # accumulating state hangs a later suite's message dispatch. Measured on
+      # a clean worktree of main: multi-suite + --coverage hangs 33% (default
+      # concurrency) to 93% (--concurrency=1, WORSE -- so concurrency is not the
+      # trigger); multi-suite WITHOUT --coverage: 0/15; single-suite WITH
+      # --coverage: 0/15, then 1774/1774 clean under a sustained soak. So this
+      # full sweep is TEST SIGNAL ONLY (all web packages, both browsers), and
+      # oidc_web_core browser coverage -- the only web-divergent package, so the
+      # only one whose browser coverage isn't a duplicate of its VM coverage --
+      # is collected per-file (single-suite) by test:web:coverage:webcore.
       # --timeout 60m: jose_plus's crypto tests are legitimately slow under
-      # dart2js. --suite-load-timeout 2h: package:test 1.31 puts NO timeout
-      # on suite loads by default (suiteLoadTimeout falls back to
-      # Timeout.none), so a wedged browser suite load hangs silently until
-      # GitHub's 6h job limit (run 29118828702; the last two suites never
-      # printed a line). The bound must clear the worst honest wait: the
-      # load timer keeps running while suites queue behind jose's ~55min
-      # crypto executors, so a small bound false-fails healthy suites (a 4m
-      # bound failed 8 of them in run 29140552735). 2h turns a wedge into a
-      # loud, rerunnable failure instead of a 6h hang. Deliberately NO
-      # --ignore-timeouts: it disables all of these bounds.
+      # dart2js. --suite-load-timeout 2h: package:test 1.31 puts NO timeout on
+      # suite loads by default (suiteLoadTimeout falls back to Timeout.none), so
+      # a wedged browser suite load hangs silently until GitHub's 6h job limit
+      # (run 29118828702). The bound must clear the worst honest wait: the load
+      # timer keeps running while suites queue behind jose's ~55min crypto
+      # executors, so a small bound false-fails healthy suites (a 4m bound
+      # failed 8 of them in run 29140552735). Deliberately NO --ignore-timeouts.
       # WEB_EXCLUDE_TAGS: passed through to `dart test --exclude-tags`.
       # jose_plus tags its crypto-executor suites (keygen/sign/encrypt) as
       # slow-web-crypto (see packages/jose_plus/dart_test.yaml) because they
@@ -204,9 +215,9 @@ melos:
         if [ "$TARGET_DART_SDK" = "min" ]; then
           dart test --timeout 60m --platform ${TEST_PLATFORM} --chain-stack-traces ${WEB_EXCLUDE_TAGS:+--exclude-tags "$WEB_EXCLUDE_TAGS"}
         else
-          dart test --timeout 60m --suite-load-timeout 2h --platform ${TEST_PLATFORM} --coverage=coverage/${TEST_PLATFORM} --chain-stack-traces ${WEB_EXCLUDE_TAGS:+--exclude-tags "$WEB_EXCLUDE_TAGS"}
+          dart test --timeout 60m --suite-load-timeout 2h --platform ${TEST_PLATFORM} --chain-stack-traces ${WEB_EXCLUDE_TAGS:+--exclude-tags "$WEB_EXCLUDE_TAGS"}
           if [ "$WITH_WASM" = "true" ]; then
-            dart test --timeout 60m --suite-load-timeout 2h --platform ${TEST_PLATFORM} --coverage=coverage/${TEST_PLATFORM} --chain-stack-traces --compiler=dart2wasm ${WEB_EXCLUDE_TAGS:+--exclude-tags "$WEB_EXCLUDE_TAGS"}
+            dart test --timeout 60m --suite-load-timeout 2h --platform ${TEST_PLATFORM} --chain-stack-traces --compiler=dart2wasm ${WEB_EXCLUDE_TAGS:+--exclude-tags "$WEB_EXCLUDE_TAGS"}
           fi
         fi
       packageFilters:
@@ -214,6 +225,27 @@ melos:
         flutter: false
         ignore:
           - oidc_cli
+    test:web:coverage:webcore:
+      name: Collect oidc_web_core browser coverage per-file (hang-safe)
+      # #372: multi-suite browser coverage-gather in one `dart test` process
+      # wedges the CDP/V8 channel. Running ONE test file per invocation keeps
+      # every gather single-suite -- verified 1774/1774 clean vs 33-93% hang for
+      # the multi-suite form. oidc_web_core is the only package whose browser
+      # coverage isn't a duplicate of its VM coverage (only web-divergent lib
+      # code), so it's the only one collected here; chrome only, since line
+      # coverage is browser-agnostic. Each file's hitmap has a distinct name,
+      # so pointing them all at coverage/chrome accumulates them for the normal
+      # coverage:format:package step. --suite-load-timeout 4m bounds a wedged
+      # load; the workflow adds a step-level timeout as the outer backstop.
+      exec: |
+        set -e
+        rm -rf coverage/chrome
+        for f in test/*_test.dart; do
+          dart test "$f" --suite-load-timeout 4m --platform chrome --coverage=coverage/chrome --chain-stack-traces
+        done
+      packageFilters:
+        scope:
+          - oidc_web_core
     remove_dart_test_yaml:
       name: Remove dart_test.yaml
       run: find . -type f -name 'dart_test.yaml' -delete


### PR DESCRIPTION
## Root cause of #372

The intermittent browser-test hang is caused by collecting coverage across **multiple test suites in one `dart test` process**. package:test enables detailed V8 precise coverage once on a shared Chrome context (`test 1.31 chrome.dart:190`, `Profiler.startPreciseCoverage detailed:true`) and gathers it per-suite; the accumulating state eventually wedges a later suite's message dispatch. Because the test's timeout timer runs *inside* the wedged browser, no dart-level bound catches it.

Isolated on a clean worktree of main (15 iterations per config):

| coverage | suites | concurrency | hang rate |
|---|---|---|---|
| yes | many | default | 5/15 (33%) |
| yes | many | =1 | 14/15 (93%) — worse |
| no | many | default | 0/15 |
| yes | 1 | default | 0/15, then 1774/1774 clean under a soak |

Coverage is necessary; multiple suites are necessary; concurrency is not the trigger (serial is worse, since every suite transition hits the gather). The BroadcastChannel / session-monitor tests are only where the wedge surfaces — single-suite runs of the exact hanging file never hang. This is why the earlier `--concurrency=1` work only helped once coverage was also dropped.

## Fix

- The full browser sweep (`test:web:single`, both browsers, all packages) drops `--coverage` — it is now test signal only, and is hang-free. Every non-web package's browser coverage merely duplicated its VM coverage.
- `oidc_web_core` — the only package with web-divergent lib code — is collected per-file by a new `test:web:coverage:webcore` (one suite per `dart test` invocation, chrome only). Verified locally: 403/431 = 93.50%, identical to the old full-package number, 6/6 files clean.

Preserves the cross-platform test signal and the one browser-coverage number that matters, without the wedge. The upstream package:test bug is noted on #372 for a follow-up report.

Closes #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web test reliability by separating browser coverage collection from the main test run.
  * Added a dedicated coverage process to reduce hangs and improve CI stability.
  * Updated test execution settings to provide clearer timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->