### PR TITLE
fix(ci): run per-file browser suites in the workflow shell, not melos (#372)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -148,6 +148,8 @@ jobs:
       # hang needs coverage-gather across multiple suites in one process (see
       # test:web:single). Without --coverage this sweep is hang-free; the 150m
       # bound now only covers the honest ~1h40m-2h first-browser compile cost.
+      # test:web:single covers every web package EXCEPT jose_plus (and oidc_cli).
+      # jose runs per-file in the two steps below.
       - name: "[Verify step] Test Dart packages [Chrome]"
         if: ${{ github.event_name != 'pull_request' }}
         timeout-minutes: 150
@@ -156,16 +158,51 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         timeout-minutes: 150
         run: melos run test:web:firefox
+      # jose_plus per-file (#372): jose's multi-suite `dart test` completes all
+      # suites then never exits on Firefox (post-success exit hang,
+      # dart-lang/test#2294 class), wedging the full sweep. One suite per
+      # process sidesteps it; 15/16 jose suites exit clean alone. Run here as a
+      # workflow shell loop, NOT a melos exec script: melos interpolates $VAR in
+      # exec strings and clobbers the loop variable `$f` to empty (it ran
+      # `dart test ""`, run 29208042920). A plain workflow shell keeps `$f`. Both
+      # browsers for one consistent path. Flags match test:web:single.
+      - name: "[Verify step] Test jose_plus [Chrome, per-file]"
+        if: ${{ github.event_name != 'pull_request' }}
+        timeout-minutes: 60
+        working-directory: packages/jose_plus
+        run: |
+          set -e
+          for f in test/*_test.dart; do
+            dart test "$f" --timeout 60m --suite-load-timeout 2h --platform chrome --chain-stack-traces ${WEB_EXCLUDE_TAGS:+--exclude-tags "$WEB_EXCLUDE_TAGS"}
+          done
+      - name: "[Verify step] Test jose_plus [Firefox, per-file]"
+        if: ${{ github.event_name != 'pull_request' }}
+        timeout-minutes: 60
+        working-directory: packages/jose_plus
+        env:
+          MOZ_HEADLESS: "1"
+        run: |
+          set -e
+          for f in test/*_test.dart; do
+            dart test "$f" --timeout 60m --suite-load-timeout 2h --platform firefox --chain-stack-traces ${WEB_EXCLUDE_TAGS:+--exclude-tags "$WEB_EXCLUDE_TAGS"}
+          done
       # oidc_web_core is the only package whose browser coverage isn't a
       # duplicate of its VM coverage, so it's the only one collected on the web
       # side. Per-file (single-suite) collection is hang-safe where the
-      # multi-suite full sweep was not (#372). Stable + main only, since
-      # coverage is combined on the stable leg. 20m bounds a wedged load; the
-      # honest run is a handful of compiles.
+      # multi-suite full sweep was not (#372). Also a workflow shell loop, not a
+      # melos exec, for the same `$f`-interpolation reason as jose above. Stable +
+      # main only (coverage is combined on the stable leg). Hitmaps accumulate in
+      # coverage/chrome for coverage:format:package. 20m bounds a wedged load.
       - name: "[Coverage] oidc_web_core browser coverage (per-file, hang-safe)"
         if: ${{ github.event_name != 'pull_request' && matrix.sdk == 'stable' }}
         timeout-minutes: 20
-        run: melos run test:web:coverage:webcore
+        working-directory: packages/oidc_web_core
+        run: |
+          set -e
+          rm -rf coverage/chrome
+          for f in test/*_test.dart; do
+            dart test "$f" --suite-load-timeout 4m --platform chrome --coverage=coverage/chrome --chain-stack-traces
+          done
       - name: Remove dart_test.yaml Files
         run: melos run remove_dart_test_yaml
       - name: "[Verify step] Test Flutter packages"
@@ -207,7 +244,7 @@ jobs:
           echo "guard: all four Flutter packages present in the combined lcov"
       - name: "[Coverage] Assert oidc_web_core browser coverage survived"
         # main + stable only: oidc_web_core browser coverage comes from the
-        # per-file test:web:coverage:webcore step, which is itself main+stable
+        # per-file oidc_web_core coverage step, which is itself main+stable
         # (PRs collect no browser coverage). Regression guard for #372's fix:
         # if that step silently stops producing hitmaps (a path change, or
         # format_coverage ceasing to pick up coverage/chrome), oidc_web_core
@@ -221,7 +258,7 @@ jobs:
           n=${n:-0}
           echo "guard: packages/oidc_web_core/lib/ -> $n match(es)"
           if [ "$n" -eq 0 ]; then
-            echo "::error::no browser coverage for oidc_web_core - the per-file step (test:web:coverage:webcore) is being discarded"
+            echo "::error::no browser coverage for oidc_web_core - the per-file oidc_web_core coverage step is being discarded"
             exit 1
           fi
           echo "guard: oidc_web_core browser coverage present in the combined lcov"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -112,22 +112,17 @@ melos:
         melos run test:web:firefox
     test:web:chrome:
       name: Dart Web tests in chrome
-      # test:web:single covers every web package except jose_plus; jose runs
-      # per-file via test:web:jose:single to avoid the #372 post-success exit
-      # hang. Both inherit TEST_PLATFORM from this script's env.
-      run: |
-        set -e
-        melos run test:web:single
-        melos run test:web:jose:single
+      # test:web:single covers every web package EXCEPT jose_plus (and oidc_cli).
+      # jose_plus runs per-file directly in the workflow (a shell loop, not a
+      # melos exec -- melos interpolates $VAR in exec strings and clobbers the
+      # `$f` loop variable to empty). See .github/workflows/tests.yaml.
+      run: melos run test:web:single
       env:
         TEST_PLATFORM: chrome
         WITH_WASM: false
     test:web:firefox:
       name: Dart Web tests in firefox
-      run: |
-        set -e
-        melos run test:web:single
-        melos run test:web:jose:single
+      run: melos run test:web:single
       env:
         TEST_PLATFORM: firefox
         MOZ_HEADLESS: "1"
@@ -198,7 +193,8 @@ melos:
       # full sweep is TEST SIGNAL ONLY (all web packages, both browsers), and
       # oidc_web_core browser coverage -- the only web-divergent package, so the
       # only one whose browser coverage isn't a duplicate of its VM coverage --
-      # is collected per-file (single-suite) by test:web:coverage:webcore.
+      # is collected per-file (single-suite) by a workflow shell loop (see
+      # .github/workflows/tests.yaml).
       # --timeout 60m: jose_plus's crypto tests are legitimately slow under
       # dart2js. --suite-load-timeout 2h: package:test 1.31 puts NO timeout on
       # suite loads by default (suiteLoadTimeout falls back to Timeout.none), so
@@ -234,60 +230,18 @@ melos:
         flutter: false
         ignore:
           - oidc_cli
-          # jose_plus runs per-file via test:web:jose:single. Root-caused
-          # 2026-07-12 (#372): jose_plus's multi-suite Firefox `dart test`
-          # completes ALL suites, prints the passing summary, then never exits
-          # (post-success exit hang, dart-lang/test#2294 class), wedging the
-          # full sweep until the job timeout. It is jose-specific and multi-suite:
-          # every OTHER web package finishes multi-suite on Firefox, and 15/16
-          # jose suites exit cleanly when run alone (the 16th, jwa, is merely
-          # slow pure-Dart RSA keygen, not a hang). One suite per invocation
-          # sidesteps the multi-suite exit entirely. Chrome doesn't hit this, but
-          # jose runs per-file on both browsers for one clean, consistent path.
+          # jose_plus is browser-tested per-file directly in the workflow (see
+          # .github/workflows/tests.yaml), NOT here. Root-caused 2026-07-12
+          # (#372): jose_plus's multi-suite Firefox `dart test` completes ALL
+          # suites, prints the passing summary, then never exits (post-success
+          # exit hang, dart-lang/test#2294 class), wedging the full sweep until
+          # the job timeout. It is jose-specific and multi-suite: every OTHER web
+          # package finishes multi-suite on Firefox, and 15/16 jose suites exit
+          # cleanly run alone (the 16th, jwa, is merely slow pure-Dart RSA keygen,
+          # not a hang). One suite per process sidesteps it. The per-file loop
+          # lives in the workflow because melos exec interpolates $VAR and
+          # clobbers the shell loop variable `$f` to empty.
           - jose_plus
-    test:web:jose:single:
-      name: jose_plus web tests, per-file (hang-safe)
-      env:
-        WITH_WASM: false
-      # See the jose_plus note under test:web:single's ignore list for the #372
-      # root cause. This runs each jose suite in its OWN `dart test` process so
-      # the multi-suite post-success exit hang cannot occur. Same flags as
-      # test:web:single (--timeout 60m for the slow crypto suites,
-      # --suite-load-timeout 2h, WEB_EXCLUDE_TAGS passthrough); min-SDK branch
-      # kept coverage/-timeout-free exactly as the sweep's min branch is.
-      exec: |
-        set -e
-        for f in test/*_test.dart; do
-          if [ "$TARGET_DART_SDK" = "min" ]; then
-            dart test "$f" --timeout 60m --platform ${TEST_PLATFORM} --chain-stack-traces ${WEB_EXCLUDE_TAGS:+--exclude-tags "$WEB_EXCLUDE_TAGS"}
-          else
-            dart test "$f" --timeout 60m --suite-load-timeout 2h --platform ${TEST_PLATFORM} --chain-stack-traces ${WEB_EXCLUDE_TAGS:+--exclude-tags "$WEB_EXCLUDE_TAGS"}
-          fi
-        done
-      packageFilters:
-        scope:
-          - jose_plus
-    test:web:coverage:webcore:
-      name: Collect oidc_web_core browser coverage per-file (hang-safe)
-      # #372: multi-suite browser coverage-gather in one `dart test` process
-      # wedges the CDP/V8 channel. Running ONE test file per invocation keeps
-      # every gather single-suite -- verified 1774/1774 clean vs 33-93% hang for
-      # the multi-suite form. oidc_web_core is the only package whose browser
-      # coverage isn't a duplicate of its VM coverage (only web-divergent lib
-      # code), so it's the only one collected here; chrome only, since line
-      # coverage is browser-agnostic. Each file's hitmap has a distinct name,
-      # so pointing them all at coverage/chrome accumulates them for the normal
-      # coverage:format:package step. --suite-load-timeout 4m bounds a wedged
-      # load; the workflow adds a step-level timeout as the outer backstop.
-      exec: |
-        set -e
-        rm -rf coverage/chrome
-        for f in test/*_test.dart; do
-          dart test "$f" --suite-load-timeout 4m --platform chrome --coverage=coverage/chrome --chain-stack-traces
-        done
-      packageFilters:
-        scope:
-          - oidc_web_core
     remove_dart_test_yaml:
       name: Remove dart_test.yaml
       run: find . -type f -name 'dart_test.yaml' -delete


### PR DESCRIPTION
Fixes a bug I introduced in #378 and a latent one from #376.

#378 moved jose_plus browser tests to a per-file **melos** script. But melos `exec` interpolates `$VAR` in the exec string and clobbered the shell loop variable `$f` to empty — the main run ran `dart test ""` for every iteration and failed in ~3 min (`Failed to load "": Does not exist`, run 29208042920). The identical pattern in `test:web:coverage:webcore` (#376) had the same bug; it was never caught because Firefox always wedged before that step ran, so the census used locally-collected coverage.

## Fix

Both per-file loops move out of melos and into the workflow as plain shell steps, where `$f` survives — the same reason the PR-scope steps run `dart test` directly rather than through melos.

- `jose_plus`: two workflow steps (Chrome + Firefox, main only, 60m bound) looping its 16 test files one per `dart test`, same flags as the sweep. Per-file avoids the multi-suite Firefox post-success exit hang (#372); `test:web:single` still excludes jose.
- `oidc_web_core` coverage: same conversion (chrome, main+stable) into `coverage/chrome` for `coverage:combine`; the survival guard from #376 still asserts it lands.
- The two broken melos scripts are removed; `test:web:chrome`/`firefox` are back to just `test:web:single`.

Verified locally: both YAML parse; the exact workflow loop runs and passes on jose suites (`$f` expands correctly). The full jose Firefox behavior is validated on the first main run after merge.

Refs #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)