### PR TITLE
fix(oidc_web_core): stop the samePage end-session test from navigating the suite away

### DIFF
--- a/packages/oidc_web_core/test/library_surface_test.dart
+++ b/packages/oidc_web_core/test/library_surface_test.dart
@@ -122,13 +122,35 @@ void main() {
         'given an end_session_endpoint, samePage navigation returns null '
         '(the response only ever arrives via the redirected page)', () async {
       final manager = _buildManager(withEndSessionEndpoint: true);
+      // `samePage` mode performs a REAL `window.location.assign()` before
+      // returning null. With a cross-origin endpoint the navigation commits
+      // an error page a beat later and destroys this suite's browser context
+      // mid-run — a silent hang with no failure and no timeout, because the
+      // in-browser timers die with the context (CI run 29209713144 froze on
+      // both matrix legs this way). So: point the endpoint at THIS page, and
+      // pre-align the document URL via history.replaceState (which does not
+      // navigate) to the exact URL the library will assign — the assign then
+      // differs only in fragment and stays a same-document navigation.
+      const request = OidcEndSessionRequest(clientId: 'client-1');
+      final endpoint = Uri.parse(
+        web.window.location.href,
+      ).replace(fragment: 'end-session');
+      final target = request.generateUri(endpoint);
+      final originalHref = web.window.location.href;
+      web.window.history.replaceState(
+        null,
+        '',
+        target.replace(fragment: 'pre-aligned').toString(),
+      );
+      addTearDown(
+        () => web.window.history.replaceState(null, '', originalHref),
+      );
       final metadata = OidcProviderMetadata.fromJson({
         'issuer': 'https://op.example.com',
         'authorization_endpoint': 'https://op.example.com/authorize',
         'token_endpoint': 'https://op.example.com/token',
-        'end_session_endpoint': 'https://op.example.com/endsession',
+        'end_session_endpoint': endpoint.toString(),
       });
-      const request = OidcEndSessionRequest(clientId: 'client-1');
 
       final result = await manager.getEndSessionResponse(
         metadata,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -114,8 +114,10 @@ melos:
       name: Dart Web tests in chrome
       # test:web:single covers every web package EXCEPT jose_plus (and oidc_cli).
       # jose_plus runs per-file directly in the workflow (a shell loop, not a
-      # melos exec -- melos interpolates $VAR in exec strings and clobbers the
-      # `$f` loop variable to empty). See .github/workflows/tests.yaml.
+      # melos exec -- melos wraps exec scripts in double quotes and runs them
+      # through `sh -c 'eval "$MELOS_SCRIPT"'`, so the outer shell expands
+      # script-internal variables like the `$f` loop variable to empty one
+      # layer too early). See .github/workflows/tests.yaml.
       run: melos run test:web:single
       env:
         TEST_PLATFORM: chrome


### PR DESCRIPTION
Both `unit_tests` legs of run [29209713144](https://github.com/Bdaya-Dev/oidc/actions/runs/29209713144) froze in the full-sweep Chrome step at 46/47 oidc_web_core tests and hit the 150m step timeout. The missing test was `library_surface_test.dart`'s samePage `getEndSessionResponse` test: it exercises the real implementation, which `window.location.assign()`s the suite's own window to `https://op.example.com/endsession` before returning null. The navigation is asynchronous — once the browser commits the NXDOMAIN error page, the suite's context is destroyed mid-run: no failure, no timeout (the in-browser timers die with the context), just silence. It's a race against the few remaining tests, which is why run [29196196735](https://github.com/Bdaya-Dev/oidc/actions/runs/29196196735) passed the same code on the same toolchain, and why per-file isolation wouldn't help either.

Minimal repro: a test that assigns a cross-origin non-resolving URL followed by a test that waits 3s hangs every time (`--timeout 30s` never fires); the identical shape with a same-document assign passes in seconds.

Fix: point the `end_session_endpoint` at the suite page itself and pre-align the document URL via `history.replaceState` (not a navigation) to the exact URL the library will assign, so the assign differs only in fragment — a same-document navigation. The samePage branch, including the real `assign` call, stays covered. Verified locally: 8/8 on Chrome and Firefox, plus a full 47/47 multi-suite package run on Chrome.

Also corrects the melos comment in `pubspec.yaml` per the [#380 discussion](https://github.com/Bdaya-Dev/oidc/pull/380#issuecomment-4953128941): the mechanism is quote-then-`eval "$MELOS_SCRIPT"` early expansion, not `$VAR` interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved web end-session testing to avoid cross-origin navigation issues and reliably restore the page URL afterward.

* **Documentation**
  * Clarified how shell variable expansion behaves when running web test scripts through Melos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->