### PR TITLE
fix(oidc_cli): bound the interactive loopback wait with flowTimeoutSeconds

### DIFF
--- a/packages/oidc_cli/lib/src/cli_user_manager.dart
+++ b/packages/oidc_cli/lib/src/cli_user_manager.dart
@@ -36,6 +36,12 @@ class CliUserManager extends OidcUserManagerBase {
 
   /// starts a listener and gets a response Uri.
   /// The user needs to click on the printed link to complete the login.
+  ///
+  /// When [options] carries a positive `flowTimeoutSeconds` for the current
+  /// desktop OS, the loopback wait is bounded: an abandoned browser flow
+  /// (the user closes the tab, or none opens) surfaces an [OidcException]
+  /// instead of hanging the CLI forever and leaking the bound loopback socket.
+  /// `null`/non-positive means unbounded, matching `oidc_desktop`'s default.
   Future<Uri?> startListenerAndGetUri({
     required Uri originalRedirectUri,
     required String redirectUriKey,
@@ -44,15 +50,22 @@ class CliUserManager extends OidcUserManagerBase {
     required String logRequestDesc,
     required Completer<Uri> actualRedirectUriCompleter,
     required Future<void> Function(Uri) printFunction,
+    OidcPlatformSpecificOptions options = const OidcPlatformSpecificOptions(),
   }) async {
     final listener = OidcLoopbackListener(
       path: originalRedirectUri.path,
       port: originalRedirectUri.port,
     );
     final serverCompleter = Completer<HttpServer>();
+    // Mirror `oidc_desktop.startListenerAndGetUri`: an opt-in, per-OS flow
+    // timeout bounds the wait so the listener force-closes its socket and
+    // throws a `TimeoutException` if no redirect arrives in time.
+    final ts = _resolveFlowTimeoutSeconds(options);
+    final timeout = (ts != null && ts > 0) ? Duration(seconds: ts) : null;
     //don't await the responseUriFuture until we launch the url.
     final responseUriFuture = listener.listenForSingleResponse(
       serverCompleter: serverCompleter,
+      timeout: timeout,
     );
     // wait until the server starts listening and we get a port.
     final server = await serverCompleter.future;
@@ -73,11 +86,43 @@ class CliUserManager extends OidcUserManagerBase {
     await printFunction(uri);
 
     // wait for a response from the server listener.
-    final responseUri = await responseUriFuture;
+    final Uri? responseUri;
+    try {
+      responseUri = await responseUriFuture;
+    } on TimeoutException catch (e, st) {
+      final message =
+          'The $logRequestDesc flow timed out after $ts seconds without '
+          'receiving a redirect on the loopback listener.';
+      cliLogger.warn(message);
+      throw OidcException(
+        message,
+        internalException: e,
+        internalStackTrace: st,
+      );
+    }
     if (responseUri == null) {
       return null;
     }
     return responseUri;
+  }
+
+  /// Resolves the loopback flow timeout (in seconds) from the platform-specific
+  /// [options], reading the native-options object for the current desktop OS.
+  ///
+  /// Mirrors `oidc_desktop`'s `getNativeOptions` convention, which selects
+  /// `options.windows` / `options.linux` per platform package; a single CLI
+  /// binary can run on any desktop OS, so it selects the field matching
+  /// [Platform.operatingSystem] instead. Returns `null` (unbounded wait) unless
+  /// the caller opted in with a positive value for that OS.
+  int? _resolveFlowTimeoutSeconds(OidcPlatformSpecificOptions options) {
+    if (Platform.isMacOS) {
+      return options.macos.flowTimeoutSeconds;
+    }
+    if (Platform.isWindows) {
+      return options.windows.flowTimeoutSeconds;
+    }
+    // Linux and any other POSIX host a Dart CLI may run on.
+    return options.linux.flowTimeoutSeconds;
   }
 
   @override
@@ -101,6 +146,7 @@ class CliUserManager extends OidcUserManagerBase {
       logRequestDesc: 'authorization',
       requestParameters: request.toMap(),
       actualRedirectUriCompleter: redirectUriCompleter,
+      options: options,
       printFunction: (uri) async {
         cliLogger.info('Please open the following link: $uri');
         // coverage:ignore-start
@@ -170,6 +216,7 @@ class CliUserManager extends OidcUserManagerBase {
       logRequestDesc: 'end session',
       requestParameters: request.toMap(),
       actualRedirectUriCompleter: redirectUriCompleter,
+      options: options,
       printFunction: (uri) async {
         logger.info('Please open the following link: $uri');
         // coverage:ignore-start

--- a/packages/oidc_cli/test/src/cli_user_manager_test.dart
+++ b/packages/oidc_cli/test/src/cli_user_manager_test.dart
@@ -189,6 +189,56 @@ void main() {
         expect(actualRedirectUri.port, freePort);
       },
     );
+
+    test(
+      'throws a timeout OidcException when an abandoned flow never delivers a '
+      'redirect within flowTimeoutSeconds',
+      () async {
+        final manager = buildLazyManager();
+        final actualRedirectUriCompleter = Completer<Uri>();
+
+        // The same finite timeout is set on every desktop-OS native-options
+        // field so `_resolveFlowTimeoutSeconds` picks it up regardless of the
+        // host OS running the suite.
+        const options = OidcPlatformSpecificOptions(
+          windows: OidcPlatformSpecificOptions_Native(flowTimeoutSeconds: 1),
+          linux: OidcPlatformSpecificOptions_Native(flowTimeoutSeconds: 1),
+          macos: OidcNativeOptionsApple(flowTimeoutSeconds: 1),
+        );
+
+        await expectLater(
+          manager.startListenerAndGetUri(
+            originalRedirectUri: Uri(
+              scheme: 'http',
+              host: '127.0.0.1',
+              port: 0,
+              path: '/callback',
+            ),
+            redirectUriKey: 'redirect_uri',
+            endpoint: Uri.parse('https://op.example.com/authorize'),
+            requestParameters: const {},
+            logRequestDesc: 'authorization',
+            actualRedirectUriCompleter: actualRedirectUriCompleter,
+            options: options,
+            // Simulate an abandoned flow: the link is "opened" but the user
+            // never completes it, so the listener never receives a GET and the
+            // wait must terminate via the timeout instead of hanging forever.
+            printFunction: (uri) async {},
+          ),
+          throwsA(
+            isA<OidcException>().having(
+              (e) => e.message,
+              'message',
+              contains('timed out'),
+            ),
+          ),
+        );
+
+        // The redirect URI was still resolved before the wait began, proving
+        // the timeout fired on the listener wait (not on server startup).
+        expect(await actualRedirectUriCompleter.future, isNotNull);
+      },
+    );
   });
 
   group('getAuthorizationResponse', () {


### PR DESCRIPTION
Fixes #369: the oidc_cli interactive login/logout loopback wait had no flow timeout, so the CLI hung forever (and leaked the bound loopback socket) if the browser flow was abandoned. `CliUserManager.startListenerAndGetUri` now threads the caller's `OidcPlatformSpecificOptions` and resolves a per-OS `flowTimeoutSeconds` (windows/linux/macos), passing it to `OidcLoopbackListener.listenForSingleResponse` — which already force-closes the socket and throws a `TimeoutException` on expiry. That exception is caught and rethrown as an `OidcException` whose message contains "timed out" (after a user-facing `cliLogger.warn`), and both `getAuthorizationResponse` and `getEndSessionResponse` now forward their `options`. The default semantics mirror `oidc_desktop` exactly: `null`/non-positive => unbounded wait, so existing behavior is unchanged unless the timeout is opted into. Pinned by a new `cli_user_manager_test` case simulating an abandoned flow (listener never receives a redirect) that asserts the wait completes with a timeout `OidcException` instead of hanging.

### Test evidence
- `packages/oidc_cli/test/src/cli_user_manager_test.dart :: startListenerAndGetUri > 'throws a timeout OidcException when an abandoned flow never delivers a redirect within flowTimeoutSeconds'`

Gates: format clean, analyzer at the pre-existing baseline with zero new issues, full package test run green.

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeouts for interactive command-line authentication flows across macOS, Windows, and Linux.
  * Authentication now reports a clear error when a browser redirect is not received within the configured time.

* **Bug Fixes**
  * Prevented abandoned authentication flows from waiting indefinitely when no redirect response arrives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->