### PR TITLE
fix(oidc_core): honor expectedIssuer in validateUser (Entra multi-tenant)

### DIFF
--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -2160,8 +2160,13 @@ abstract class OidcUserManagerBase {
                 settings.userInfoSettings.getAccessTokenForDistributedSource,
             keyStore: keyStore,
             // OIDC Core 5.3.2/5.3.4: validate iss/aud/exp on a signed
-            // (verified) UserInfo JWT.
-            expectedIssuer: metadata.issuer,
+            // (verified) UserInfo JWT. The UserInfo `iss` MUST match the
+            // id_token `iss`, which for a multi-tenant OP is the concrete
+            // per-tenant issuer — so resolve it through the same
+            // `resolveExpectedIssuer` pin used for the id_token `iss` check
+            // (§3.1.3.7), NOT the advertised (possibly template) metadata
+            // issuer.
+            expectedIssuer: resolveExpectedIssuer(metadata),
             clientId: clientCredentials.clientId,
             validateSignedResponseClaims:
                 settings.userInfoSettings.validateSignedResponseClaims,

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -1937,6 +1937,24 @@ abstract class OidcUserManagerBase {
     }
   }
 
+  /// Resolves the issuer an id_token's `iss` claim is validated against
+  /// (OpenID Connect Core §3.1.3.7 step 2: the `iss` claim MUST exactly match
+  /// the OP's Issuer Identifier).
+  ///
+  /// When [OidcUserManagerSettings.expectedIssuer] is set it is authoritative
+  /// and **overrides** the discovery document's [OidcProviderMetadata.issuer];
+  /// when null (the default) the advertised `metadata.issuer` is used unchanged,
+  /// so the out-of-the-box behavior is identical.
+  ///
+  /// This lets Microsoft Entra ID multi-tenant (`common`/`organizations`) RPs —
+  /// whose discovery `issuer` is a non-substituted template
+  /// (`https://login.microsoftonline.com/{tenantid}/v2.0`) that can never equal
+  /// the concrete per-tenant `iss` a real id_token carries — pin the concrete
+  /// tenant issuer instead of failing the exact-match check.
+  @protected
+  Uri? resolveExpectedIssuer(OidcProviderMetadata metadata) =>
+      settings.expectedIssuer ?? metadata.issuer;
+
   List<Exception> validateUser({
     required OidcUser user,
     required OidcProviderMetadata metadata,
@@ -1957,7 +1975,7 @@ abstract class OidcUserManagerBase {
       errors.addAll(
         claims.validate(
           clientId: clientCredentials.clientId,
-          issuer: metadata.issuer,
+          issuer: resolveExpectedIssuer(metadata),
           expiryTolerance: settings.expiryTolerance,
         ),
       );

--- a/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
+++ b/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
@@ -175,6 +175,15 @@ class OidcUserManagerSettings {
   /// Optional explicit issuer to compare the discovery document's `issuer`
   /// against (authoritative when set).
   ///
+  /// When set it is ALSO the issuer an id_token's `iss` claim is validated
+  /// against (OpenID Connect Core §3.1.3.7 step 2), overriding the advertised
+  /// discovery `issuer`. This is the pin Microsoft Entra ID multi-tenant
+  /// (`common`/`organizations`) RPs need: the OP advertises a non-substituted
+  /// template issuer (`https://login.microsoftonline.com/{tenantid}/v2.0`) that
+  /// never equals the concrete per-tenant `iss` a real id_token carries, so
+  /// pinning the concrete tenant issuer here lets `validateUser` pass. When null
+  /// (the default) the advertised `metadata.issuer` is used unchanged.
+  ///
   /// When null (default) and a `discoveryDocumentUri` is present, the expected
   /// issuer is derived by stripping the trailing
   /// `.well-known/openid-configuration` segments from `discoveryDocumentUri`

--- a/packages/oidc_core/test/id_token_extra_validation_test.dart
+++ b/packages/oidc_core/test/id_token_extra_validation_test.dart
@@ -103,18 +103,21 @@ Future<OidcUser> _user(
   );
 }
 
-_ValidationManager _manager({List<String>? allowedAudiences}) =>
-    _ValidationManager(
-      discoveryDocument: _metadata,
-      clientCredentials: const OidcClientAuthentication.none(
-        clientId: 'client-1',
-      ),
-      store: OidcMemoryStore(),
-      settings: OidcUserManagerSettings(
-        redirectUri: Uri.parse('com.example.app://cb'),
-        allowedAudiences: allowedAudiences,
-      ),
-    );
+_ValidationManager _manager({
+  List<String>? allowedAudiences,
+  Uri? expectedIssuer,
+}) => _ValidationManager(
+  discoveryDocument: _metadata,
+  clientCredentials: const OidcClientAuthentication.none(
+    clientId: 'client-1',
+  ),
+  store: OidcMemoryStore(),
+  settings: OidcUserManagerSettings(
+    redirectUri: Uri.parse('com.example.app://cb'),
+    allowedAudiences: allowedAudiences,
+    expectedIssuer: expectedIssuer,
+  ),
+);
 
 void main() {
   group('oidcComputeTokenHash', () {
@@ -310,6 +313,52 @@ void main() {
         final errors = _manager().run(user, _metadata);
         expect(
           errors.any((e) => e.toString().contains('exp')),
+          isTrue,
+        );
+      },
+    );
+  });
+
+  group('validateUser issuer pinning (#168, Entra multi-tenant §3.1.3.7)', () {
+    // Microsoft Entra ID multi-tenant (`common`/`organizations`) advertises a
+    // non-substituted TEMPLATE issuer, while a real id_token carries the
+    // CONCRETE per-tenant issuer — the two can never be equal, so the
+    // spec-mandated exact `iss` match fails unless the RP pins the concrete one.
+    final templateMetadata = OidcProviderMetadata.fromJson({
+      'issuer': 'https://login.microsoftonline.com/{tenantid}/v2.0',
+      'authorization_endpoint': 'https://op.example.com/authorize',
+      'token_endpoint': 'https://op.example.com/token',
+    });
+    const concreteIssuer =
+        'https://login.microsoftonline.com/'
+        '11c43ee8-b9d3-4e51-b73f-bd9dda66e29c/v2.0';
+
+    Future<OidcUser> concreteTenantUser() =>
+        _user({..._baseClaims(), 'iss': concreteIssuer});
+
+    test(
+      'passes when expectedIssuer pins the concrete tenant issuer',
+      () async {
+        final user = await concreteTenantUser();
+        final errors = _manager(
+          expectedIssuer: Uri.parse(concreteIssuer),
+        ).run(user, templateMetadata);
+        // The concrete `iss` now matches the pinned expectedIssuer, so the
+        // otherwise-valid token produces no validation errors at all.
+        expect(errors, isEmpty);
+      },
+    );
+
+    test(
+      'fails with an issuer mismatch when expectedIssuer is unset '
+      '(regression pin: default behavior is unchanged)',
+      () async {
+        final user = await concreteTenantUser();
+        // No expectedIssuer -> the advertised template `metadata.issuer` is used
+        // exactly as before, and the concrete `iss` fails the exact-match check.
+        final errors = _manager().run(user, templateMetadata);
+        expect(
+          errors.any((e) => e.toString().contains('Issuer does not match')),
           isTrue,
         );
       },

--- a/packages/oidc_core/test/id_token_extra_validation_test.dart
+++ b/packages/oidc_core/test/id_token_extra_validation_test.dart
@@ -5,6 +5,8 @@ import 'dart:convert';
 
 import 'package:clock/clock.dart';
 import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:jose_plus/jose.dart';
 import 'package:oidc_core/oidc_core.dart';
 import 'package:test/test.dart';
@@ -15,6 +17,8 @@ class _ValidationManager extends OidcUserManagerBase {
     required super.clientCredentials,
     required super.store,
     required super.settings,
+    super.httpClient,
+    super.keyStore,
   });
 
   List<Exception> run(
@@ -28,6 +32,14 @@ class _ValidationManager extends OidcUserManagerBase {
     authorizationCode: authorizationCode,
     maxAge: maxAge,
   );
+
+  /// Drives the full validate + UserInfo path (which is where the signed
+  /// UserInfo `iss` check lives) so the advisory tests can pin what issuer that
+  /// check compares against.
+  Future<OidcUser?> runValidateAndSave(
+    OidcUser user,
+    OidcProviderMetadata metadata,
+  ) => validateAndSaveUser(user: user, metadata: metadata);
 
   @override
   bool get isWeb => false;
@@ -106,18 +118,45 @@ Future<OidcUser> _user(
 _ValidationManager _manager({
   List<String>? allowedAudiences,
   Uri? expectedIssuer,
+  http.Client? httpClient,
+  JsonWebKeyStore? keyStore,
+  OidcProviderMetadata? discoveryDocument,
 }) => _ValidationManager(
-  discoveryDocument: _metadata,
+  discoveryDocument: discoveryDocument ?? _metadata,
   clientCredentials: const OidcClientAuthentication.none(
     clientId: 'client-1',
   ),
   store: OidcMemoryStore(),
+  httpClient: httpClient,
+  keyStore: keyStore,
   settings: OidcUserManagerSettings(
     redirectUri: Uri.parse('com.example.app://cb'),
     allowedAudiences: allowedAudiences,
     expectedIssuer: expectedIssuer,
   ),
 );
+
+/// Serves a single RS256-signed `application/jwt` UserInfo response from a
+/// [MockClient], paired with a keyStore that can verify it.
+({http.Client client, JsonWebKeyStore keyStore}) _signedUserInfoFixture(
+  Map<String, dynamic> claims,
+) {
+  final key = JsonWebKey.generate('RS256');
+  final jwt =
+      (JsonWebSignatureBuilder()
+            ..jsonContent = claims
+            ..addRecipient(key, algorithm: 'RS256'))
+          .build()
+          .toCompactSerialization();
+  final client = MockClient(
+    (req) async => http.Response(
+      jwt,
+      200,
+      headers: const {'content-type': 'application/jwt'},
+    ),
+  );
+  return (client: client, keyStore: JsonWebKeyStore()..addKey(key));
+}
 
 void main() {
   group('oidcComputeTokenHash', () {
@@ -361,6 +400,129 @@ void main() {
           errors.any((e) => e.toString().contains('Issuer does not match')),
           isTrue,
         );
+      },
+    );
+
+    test(
+      'rejects a DIFFERENT concrete tenant iss when expectedIssuer pins '
+      'tenant A (security pin: the pin is an exact match, not merely '
+      '"anything but the template")',
+      () async {
+        // expectedIssuer pins concrete tenant A; the token carries a DIFFERENT
+        // concrete tenant B (B != A, and B is not the template metadata issuer
+        // either). §3.1.3.7 demands an EXACT match, so pinning tenant A MUST
+        // still reject tenant B — the pin does not turn into "accept any
+        // non-template issuer". This is the negative counterpart the reviewer
+        // mutation-tested for.
+        const otherConcreteIssuer =
+            'https://login.microsoftonline.com/'
+            '99999999-0000-4000-8000-000000000000/v2.0';
+        final user = await _user({
+          ..._baseClaims(),
+          'iss': otherConcreteIssuer,
+        });
+        final errors = _manager(
+          expectedIssuer: Uri.parse(concreteIssuer),
+        ).run(user, templateMetadata);
+        expect(
+          errors.any((e) => e.toString().contains('Issuer does not match')),
+          isTrue,
+        );
+      },
+    );
+  });
+
+  group('signed UserInfo iss uses resolveExpectedIssuer (#168 advisory, '
+      'OIDC Core §5.3.4)', () {
+    // The §5.3.4 check requires the (verified) signed UserInfo `iss` to match
+    // the id_token `iss`. For a multi-tenant OP that is the CONCRETE per-tenant
+    // issuer, NOT the advertised template `metadata.issuer` — so the UserInfo
+    // path must resolve the expected issuer through the same `expectedIssuer`
+    // pin the id_token `iss` check uses.
+    final templateMetadataWithUserInfo = OidcProviderMetadata.fromJson({
+      'issuer': 'https://login.microsoftonline.com/{tenantid}/v2.0',
+      'authorization_endpoint': 'https://op.example.com/authorize',
+      'token_endpoint': 'https://op.example.com/token',
+      'userinfo_endpoint': 'https://op.example.com/userinfo',
+    });
+    const concreteIssuer =
+        'https://login.microsoftonline.com/'
+        '11c43ee8-b9d3-4e51-b73f-bd9dda66e29c/v2.0';
+
+    // A user whose id_token already carries the concrete tenant issuer and an
+    // access token (so the UserInfo request is actually sent).
+    Future<OidcUser> concreteTenantUserWithAccessToken() => _user(
+      {..._baseClaims(), 'iss': concreteIssuer},
+      accessToken: 'at',
+    );
+
+    int exp() =>
+        clock.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/
+        1000;
+
+    test(
+      'applies a signed UserInfo whose iss is the concrete tenant issuer when '
+      'expectedIssuer pins it (would be rejected if compared to the template)',
+      () async {
+        final fixture = _signedUserInfoFixture({
+          'sub': 'user-1',
+          'iss': concreteIssuer,
+          'aud': 'client-1',
+          'exp': exp(),
+          // A UserInfo-only claim: its presence on the returned user proves the
+          // signed UserInfo passed the §5.3.4 iss check and was applied.
+          'name': 'from-userinfo',
+        });
+        final manager = _manager(
+          expectedIssuer: Uri.parse(concreteIssuer),
+          httpClient: fixture.client,
+          keyStore: fixture.keyStore,
+          discoveryDocument: templateMetadataWithUserInfo,
+        );
+        await manager.init();
+        final result = await manager.runValidateAndSave(
+          await concreteTenantUserWithAccessToken(),
+          templateMetadataWithUserInfo,
+        );
+        expect(result, isNotNull);
+        // If the UserInfo `iss` were compared to the raw template
+        // `metadata.issuer` (the pre-fix behavior), the concrete `iss` would be
+        // rejected, the UserInfo would be dropped, and this claim would be
+        // absent.
+        expect(result!.userInfo['name'], 'from-userinfo');
+      },
+    );
+
+    test(
+      'rejects (does not apply) a signed UserInfo whose iss is a WRONG '
+      'concrete issuer even when expectedIssuer is set',
+      () async {
+        const wrongConcreteIssuer =
+            'https://login.microsoftonline.com/'
+            '99999999-0000-4000-8000-000000000000/v2.0';
+        final fixture = _signedUserInfoFixture({
+          'sub': 'user-1',
+          'iss': wrongConcreteIssuer,
+          'aud': 'client-1',
+          'exp': exp(),
+          'name': 'from-userinfo',
+        });
+        final manager = _manager(
+          expectedIssuer: Uri.parse(concreteIssuer),
+          httpClient: fixture.client,
+          keyStore: fixture.keyStore,
+          discoveryDocument: templateMetadataWithUserInfo,
+        );
+        await manager.init();
+        final result = await manager.runValidateAndSave(
+          await concreteTenantUserWithAccessToken(),
+          templateMetadataWithUserInfo,
+        );
+        // The id_token itself is valid (its `iss` matches the pin), so a user is
+        // still returned — but the §5.3.4 iss mismatch means the forged UserInfo
+        // is rejected and never merged in, so its claim is absent.
+        expect(result, isNotNull);
+        expect(result!.userInfo.containsKey('name'), isFalse);
       },
     );
   });


### PR DESCRIPTION
validateUser() failed for Microsoft Entra ID multi-tenant because the OP advertises a non-substituted template issuer (https://login.microsoftonline.com/{tenantid}/v2.0) that can never equal the concrete per-tenant `iss` a real id_token carries, so the exact-match issuer check in jose's claims.validate (OIDC Core §3.1.3.7 step 2) always threw "Issuer does not match". The fix adds a `@protected resolveExpectedIssuer(metadata)` helper — mirroring the existing `resolveAllowedIdTokenAlgorithms` convention — that returns `settings.expectedIssuer ?? metadata.issuer`, and uses it as the issuer validateUser validates the id_token against. A multi-tenant RP can now pin the concrete tenant issuer through the existing `expectedIssuer` setting (introduced in the earlier audit hardening) instead of mutating the discovery document after init(). Defaults are untouched: with no expectedIssuer set, the advertised metadata.issuer is used exactly as before, so single-tenant behavior is byte-for-byte identical. The expectedIssuer setting doc-comment was extended to state it now also governs id_token issuer validation.

### Test evidence
- `packages/oidc_core/test/id_token_extra_validation_test.dart :: validateUser issuer pinning (#168, Entra multi-tenant §3.1.3.7) passes when expectedIssuer pins the concrete tenant issuer`
- `packages/oidc_core/test/id_token_extra_validation_test.dart :: validateUser issuer pinning (#168, Entra multi-tenant §3.1.3.7) fails with an issuer mismatch when expectedIssuer is unset (regression pin: default behavior is unchanged)`

Gates: format clean, analyzer at the pre-existing baseline with zero new issues, full package test run green.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS
