### PR TITLE
feat(oidc_default_store): SharedPreferencesAsync backend with scoped legacy migration

### DIFF
--- a/packages/oidc_default_store/lib/src/oidc_default_store.dart
+++ b/packages/oidc_default_store/lib/src/oidc_default_store.dart
@@ -32,23 +32,49 @@ enum OidcDefaultStoreWebSessionManagementLocation {
 ///         - if [webSessionManagementLocation] is set to [OidcDefaultStoreWebSessionManagementLocation.sessionStorage]
 ///           we use [html.Window.sessionStorage].
 ///         - if it's set to [OidcDefaultStoreWebSessionManagementLocation.sessionStorage] we use [html.Window.localStorage].
-///     - we use [SharedPreferences] for other platforms
+///     - we use `shared_preferences` for other platforms
 /// - for the [OidcStoreNamespace.state] namespace
 ///     - we use `package:universal_html` + `localStorage` for web.
 ///       this is a MUST and other implementations can't change this behavior, for the `samePage` navigation mode to work.
-/// - [SharedPreferences] for all other operations.
+/// - `shared_preferences` for all other operations.
 ///
+/// The non-secure `shared_preferences` persistence uses the modern
+/// [SharedPreferencesAsync] API by default (see #301). You can inject your own
+/// instance via the `sharedPreferencesAsync` constructor parameter to share it
+/// with the rest of your app. The legacy synchronous [SharedPreferences] path
+/// is still supported through the deprecated `sharedPreferences` parameter for
+/// backward compatibility. On the default path, this store performs a one-time,
+/// best-effort migration of its own keys from the legacy store into
+/// [SharedPreferencesAsync] (see [OidcDefaultStore.new]).
 /// {@endtemplate}
 class OidcDefaultStore implements OidcStore {
   /// {@macro oidc_default_store}
+  ///
+  /// [sharedPreferencesAsync] lets you inject a [SharedPreferencesAsync]
+  /// instance so this store shares the same async preferences as the rest of
+  /// your app. When omitted (and no legacy [sharedPreferences] is provided),
+  /// [init] creates a default [SharedPreferencesAsync] and runs a one-time,
+  /// best-effort migration of this store's own keys from the legacy store (see
+  /// `_migrateLegacyPrefsToAsyncIfNeeded`).
+  ///
+  /// [sharedPreferences] is the deprecated synchronous backend; passing it keeps
+  /// the legacy behavior end-to-end (no migration, same data location).
   OidcDefaultStore({
     FlutterSecureStorage? secureStorageInstance,
+    @Deprecated(
+      'The synchronous SharedPreferences API is now legacy. Pass '
+      '`sharedPreferencesAsync` (a SharedPreferencesAsync instance) instead. '
+      'See https://pub.dev/packages/shared_preferences and issue #301.',
+    )
     SharedPreferences? sharedPreferences,
+    SharedPreferencesAsync? sharedPreferencesAsync,
     this.storagePrefix = 'oidc',
     this.webSessionManagementLocation =
         OidcDefaultStoreWebSessionManagementLocation.sessionStorage,
   })  : secureStorage = secureStorageInstance,
-        __sharedPreferences = sharedPreferences;
+        // ignore: deprecated_member_use_from_same_package
+        _legacySharedPreferences = sharedPreferences,
+        _injectedSharedPreferencesAsync = sharedPreferencesAsync;
 
   /// Recommended hardened [AndroidOptions] for storing OIDC tokens at rest.
   ///
@@ -142,8 +168,17 @@ class OidcDefaultStore implements OidcStore {
     );
   }
 
-  SharedPreferences? __sharedPreferences;
-  SharedPreferences get _sharedPreferences => __sharedPreferences!;
+  /// Legacy (synchronous) `shared_preferences` instance, if one was injected
+  /// through the deprecated `sharedPreferences` constructor parameter.
+  final SharedPreferences? _legacySharedPreferences;
+
+  /// A caller-supplied [SharedPreferencesAsync] instance, if one was injected
+  /// through the `sharedPreferencesAsync` constructor parameter.
+  final SharedPreferencesAsync? _injectedSharedPreferencesAsync;
+
+  /// The resolved non-secure persistence backend, populated by [init].
+  _OidcPrefsBackend? _backend;
+  _OidcPrefsBackend get _prefs => _backend!;
 
   /// prefix to put before the keys.
   ///
@@ -179,8 +214,89 @@ class OidcDefaultStore implements OidcStore {
   Future<void> init() async {
     await initMemoizer.runOnce(() async {
       html.initWeb();
-      __sharedPreferences ??= await SharedPreferences.getInstance();
+      _backend ??= await _resolveBackend();
     });
+  }
+
+  /// Resolves which non-secure persistence backend [OidcDefaultStore] uses.
+  ///
+  /// Precedence:
+  /// 1. An explicitly injected [SharedPreferencesAsync] (the caller owns its
+  ///    lifecycle and any data migration).
+  /// 2. The deprecated synchronous [SharedPreferences] (kept end-to-end so its
+  ///    data location never moves — full backward compatibility).
+  /// 3. The default: a fresh [SharedPreferencesAsync], after a one-time
+  ///    best-effort migration of this store's keys from the legacy store.
+  Future<_OidcPrefsBackend> _resolveBackend() async {
+    if (_injectedSharedPreferencesAsync case final injected?) {
+      return _OidcAsyncPrefsBackend(injected);
+    }
+    if (_legacySharedPreferences case final legacy?) {
+      return _OidcLegacyPrefsBackend(legacy);
+    }
+    final async = SharedPreferencesAsync();
+    // On web the `shared_preferences` backend is never exercised (session/state
+    // go through window.localStorage), and there the async API shares the same
+    // localStorage as the legacy one, so there is nothing to migrate.
+    if (!testIsWeb) {
+      await _migrateLegacyPrefsToAsyncIfNeeded(async);
+    }
+    return _OidcAsyncPrefsBackend(async);
+  }
+
+  /// One-time, best-effort copy of this store's own keys from the legacy
+  /// synchronous `shared_preferences` store into [async].
+  ///
+  /// The two APIs do not always share the same platform storage: on Android the
+  /// legacy API is backed by `SharedPreferences` while [SharedPreferencesAsync]
+  /// defaults to DataStore Preferences, so data written before this package
+  /// adopted the async API would otherwise appear lost after an upgrade. (On
+  /// iOS/macOS/web/Windows/Linux both APIs share one store, so this is a no-op
+  /// copy.) See the `shared_preferences` README section "SharedPreferences vs
+  /// SharedPreferencesAsync vs SharedPreferencesWithCache" and issue #301.
+  ///
+  /// Only keys under [storagePrefix] are migrated (never the whole app store),
+  /// the copy runs once (guarded by a marker written into [async]), and existing
+  /// async values are never overwritten.
+  Future<void> _migrateLegacyPrefsToAsyncIfNeeded(
+    SharedPreferencesAsync async,
+  ) async {
+    final prefix = storagePrefix;
+    // Without a prefix we cannot scope the migration to this package's keys, so
+    // we skip it rather than copying the entire (potentially large) app store.
+    if (prefix == null || prefix.isEmpty) {
+      return;
+    }
+    final migrationMarkerKey = '$prefix.__oidc_async_migration_done';
+    try {
+      if (await async.getBool(migrationMarkerKey) ?? false) {
+        return;
+      }
+      final legacy = await SharedPreferences.getInstance();
+      final ownedKeys =
+          legacy.getKeys().where((key) => key.startsWith('$prefix.'));
+      for (final key in ownedKeys) {
+        final value = legacy.get(key);
+        if (value is String) {
+          if (await async.getString(key) == null) {
+            await async.setString(key, value);
+          }
+        } else if (value is List) {
+          if (await async.getStringList(key) == null) {
+            await async.setStringList(key, value.cast<String>());
+          }
+        }
+      }
+      await async.setBool(migrationMarkerKey, true);
+    } catch (e) {
+      // coverage:ignore-start
+      _logger.warning(
+        'OidcDefaultStore: failed to migrate legacy shared_preferences data to '
+        'SharedPreferencesAsync; existing values under "$prefix" may need to be '
+        're-established. Error: $e',
+      );
+      // coverage:ignore-end
+    }
   }
 
   Future<void> _registerKeyForNamespace(
@@ -222,8 +338,8 @@ class OidcDefaultStore implements OidcStore {
           '[]';
       return (jsonDecode(keysRaw) as List).cast<String>().toSet();
     } else {
-      return _sharedPreferences
-              .getStringList(_getNamespaceKeys(namespace, managerId))
+      return (await _prefs
+                  .getStringList(_getNamespaceKeys(namespace, managerId)))
               ?.toSet() ??
           {};
     }
@@ -240,7 +356,7 @@ class OidcDefaultStore implements OidcStore {
         jsonEncode(keys),
       );
     } else {
-      await _sharedPreferences.setStringList(
+      await _prefs.setStringList(
         _getNamespaceKeys(namespace, managerId),
         keys,
       );
@@ -263,14 +379,15 @@ class OidcDefaultStore implements OidcStore {
           )
           .purify();
     } else {
-      return keys
-          .map(
-            (key) => MapEntry(
-              key,
-              _sharedPreferences.getString(_getKey(namespace, key, managerId)),
-            ),
-          )
-          .purify();
+      final entries = await Future.wait(
+        keys.map(
+          (key) async => MapEntry(
+            key,
+            await _prefs.getString(_getKey(namespace, key, managerId)),
+          ),
+        ),
+      );
+      return entries.purify();
     }
   }
 
@@ -287,7 +404,7 @@ class OidcDefaultStore implements OidcStore {
     } else {
       await Future.wait(
         values.entries.map(
-          (entry) => _sharedPreferences.setString(
+          (entry) => _prefs.setString(
             _getKey(namespace, entry.key, managerId),
             entry.value,
           ),
@@ -308,8 +425,7 @@ class OidcDefaultStore implements OidcStore {
     } else {
       await Future.wait(
         keys.map(
-          (key) =>
-              _sharedPreferences.remove(_getKey(namespace, key, managerId)),
+          (key) => _prefs.remove(_getKey(namespace, key, managerId)),
         ),
       );
     }
@@ -480,4 +596,67 @@ extension on Iterable<MapEntry<String, String?>> {
     return Map.fromEntries(where((element) => element.value != null))
         .cast<String, String>();
   }
+}
+
+/// Minimal async persistence surface shared by the legacy [SharedPreferences]
+/// and the modern [SharedPreferencesAsync] backends, so the rest of
+/// [OidcDefaultStore] can stay backend-agnostic (see issue #301).
+abstract class _OidcPrefsBackend {
+  Future<List<String>?> getStringList(String key);
+  Future<void> setStringList(String key, List<String> value);
+  Future<String?> getString(String key);
+  Future<void> setString(String key, String value);
+  Future<void> remove(String key);
+}
+
+/// Adapts the deprecated synchronous [SharedPreferences] to
+/// [_OidcPrefsBackend]. Kept for backward compatibility with the deprecated
+/// `sharedPreferences` constructor parameter.
+class _OidcLegacyPrefsBackend implements _OidcPrefsBackend {
+  _OidcLegacyPrefsBackend(this._prefs);
+
+  final SharedPreferences _prefs;
+
+  @override
+  Future<List<String>?> getStringList(String key) async =>
+      _prefs.getStringList(key);
+
+  @override
+  Future<void> setStringList(String key, List<String> value) =>
+      _prefs.setStringList(key, value);
+
+  @override
+  Future<String?> getString(String key) async => _prefs.getString(key);
+
+  @override
+  Future<void> setString(String key, String value) =>
+      _prefs.setString(key, value);
+
+  @override
+  Future<void> remove(String key) => _prefs.remove(key);
+}
+
+/// Adapts [SharedPreferencesAsync] (the default, non-legacy backend) to
+/// [_OidcPrefsBackend].
+class _OidcAsyncPrefsBackend implements _OidcPrefsBackend {
+  _OidcAsyncPrefsBackend(this._prefs);
+
+  final SharedPreferencesAsync _prefs;
+
+  @override
+  Future<List<String>?> getStringList(String key) => _prefs.getStringList(key);
+
+  @override
+  Future<void> setStringList(String key, List<String> value) =>
+      _prefs.setStringList(key, value);
+
+  @override
+  Future<String?> getString(String key) => _prefs.getString(key);
+
+  @override
+  Future<void> setString(String key, String value) =>
+      _prefs.setString(key, value);
+
+  @override
+  Future<void> remove(String key) => _prefs.remove(key);
 }

--- a/packages/oidc_default_store/pubspec.yaml
+++ b/packages/oidc_default_store/pubspec.yaml
@@ -16,10 +16,16 @@ dependencies:
   flutter_secure_storage: ^10.0.0
   logging: ^1.2.0
   oidc_core: ^1.0.0
-  shared_preferences: ^2.2.1
+  # >=2.3.0 is the first release that ships SharedPreferencesAsync /
+  # SharedPreferencesWithCache (the non-legacy APIs, see #301).
+  shared_preferences: ^2.3.0
   web: ^1.1.1
 dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.3
+  # Test-only: provides InMemorySharedPreferencesAsync +
+  # SharedPreferencesAsyncPlatform so the SharedPreferencesAsync backend can be
+  # exercised in-memory on the VM (see the async store tests).
+  shared_preferences_platform_interface: ^2.4.0
   very_good_analysis: ^10.0.0

--- a/packages/oidc_default_store/test/oidc_default_store_async_test.dart
+++ b/packages/oidc_default_store/test/oidc_default_store_async_test.dart
@@ -1,0 +1,153 @@
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:oidc_default_store/oidc_default_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+/// Tests for the SharedPreferencesAsync support added for #301:
+/// - the default backend is now [SharedPreferencesAsync],
+/// - an injected [SharedPreferencesAsync] is honored,
+/// - the deprecated synchronous [SharedPreferences] constructor path still
+///   works end-to-end,
+/// - and existing legacy data is migrated once into the async store.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('OidcDefaultStore SharedPreferencesAsync support (#301)', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
+    });
+
+    testWidgets(
+        'default (non-injected) backend round-trips through '
+        'SharedPreferencesAsync', (tester) async {
+      final store = OidcDefaultStore();
+      await store.init();
+
+      const ns = OidcStoreNamespace.state;
+      await store.setMany(ns, values: {'k1': 'v1', 'k2': 'v2'});
+
+      // readable back through the store.
+      final values = await store.getMany(ns, keys: {'k1', 'k2'});
+      expect(values, {'k1': 'v1', 'k2': 'v2'});
+
+      // and it truly landed in the async store, not the legacy one: a
+      // separately-constructed SharedPreferencesAsync shares the same
+      // in-memory platform and sees the same value.
+      final async = SharedPreferencesAsync();
+      expect(await async.getString('oidc.state.k1'), 'v1');
+
+      // the legacy store must NOT hold it.
+      final legacy = await SharedPreferences.getInstance();
+      expect(legacy.getString('oidc.state.k1'), isNull);
+    });
+
+    testWidgets(
+        'an injected SharedPreferencesAsync is used for all non-secure '
+        'persistence', (tester) async {
+      final injected = SharedPreferencesAsync();
+      final store = OidcDefaultStore(sharedPreferencesAsync: injected);
+      await store.init();
+
+      const ns = OidcStoreNamespace.discoveryDocument;
+      await store.set(ns, key: 'doc', value: 'discovery');
+
+      // readable directly through the injected instance.
+      expect(
+        await injected.getString('oidc.discoveryDocument.doc'),
+        'discovery',
+      );
+      // and through the store.
+      expect(await store.get(ns, key: 'doc'), 'discovery');
+
+      await store.remove(ns, key: 'doc');
+      expect(await injected.getString('oidc.discoveryDocument.doc'), isNull);
+    });
+
+    testWidgets(
+        'the deprecated synchronous SharedPreferences constructor path still '
+        'works end-to-end', (tester) async {
+      final legacy = await SharedPreferences.getInstance();
+      // ignore: deprecated_member_use_from_same_package
+      final store = OidcDefaultStore(sharedPreferences: legacy);
+      await store.init();
+
+      const ns = OidcStoreNamespace.request;
+      await store.setMany(ns, values: {'a': '1', 'b': '2'});
+
+      // full round-trip through the store.
+      expect(await store.getMany(ns, keys: {'a', 'b'}), {'a': '1', 'b': '2'});
+      expect(await store.getAllKeys(ns), {'a', 'b'});
+
+      // data lands in the SAME legacy instance we passed.
+      expect(legacy.getString('oidc.request.a'), '1');
+
+      // and it must NOT have leaked into the async store.
+      final async = SharedPreferencesAsync();
+      expect(await async.getString('oidc.request.a'), isNull);
+
+      await store.removeMany(ns, keys: {'a'});
+      expect(legacy.getString('oidc.request.a'), isNull);
+      expect(await store.getAllKeys(ns), {'b'});
+    });
+
+    testWidgets(
+        'existing legacy data under the storagePrefix is migrated once into '
+        'the async store, and unrelated keys are left untouched',
+        (tester) async {
+      // Seed the legacy store as if a previous app version had written OIDC
+      // data through the synchronous API, plus an unrelated key.
+      SharedPreferences.setMockInitialValues({
+        'oidc.keys.state': <String>['k1'],
+        'oidc.state.k1': 'legacy-value',
+        'some.other.app.key': 'do-not-touch',
+      });
+
+      final store = OidcDefaultStore();
+      await store.init();
+
+      const ns = OidcStoreNamespace.state;
+      // migrated data is now visible through the (async-backed) store.
+      expect(await store.getAllKeys(ns), {'k1'});
+      expect(await store.get(ns, key: 'k1'), 'legacy-value');
+
+      // it physically exists in the async store now.
+      final async = SharedPreferencesAsync();
+      expect(await async.getString('oidc.state.k1'), 'legacy-value');
+      expect(await async.getStringList('oidc.keys.state'), ['k1']);
+
+      // the unrelated (non-prefixed) key was NOT migrated.
+      expect(await async.getString('some.other.app.key'), isNull);
+
+      // the one-time migration marker was written.
+      expect(await async.getBool('oidc.__oidc_async_migration_done'), isTrue);
+    });
+
+    testWidgets(
+        'migration does not overwrite values already in the async store',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({
+        'oidc.state.k1': 'legacy-value',
+      });
+      // The async store already has a newer value for the same key.
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.withData({
+        'oidc.state.k1': 'async-value',
+      });
+
+      final store = OidcDefaultStore();
+      await store.init();
+
+      // the pre-existing async value wins; the legacy copy must not clobber it.
+      expect(
+        await store.get(OidcStoreNamespace.state, key: 'k1'),
+        'async-value',
+      );
+    });
+  });
+}

--- a/packages/oidc_default_store/test/oidc_default_store_test.dart
+++ b/packages/oidc_default_store/test/oidc_default_store_test.dart
@@ -5,12 +5,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oidc_core/oidc_core.dart';
 import 'package:oidc_default_store/oidc_default_store.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   group('OidcDefaultStore', () {
     setUp(() {
+      // The default (non-injected) backend is now SharedPreferencesAsync, so
+      // register an in-memory async platform alongside the legacy mock.
       SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
     });
     test('can be instantiated', () {
       expect(OidcDefaultStore(), isNotNull);

--- a/packages/oidc_default_store/test/oidc_default_store_web_and_secure_test.dart
+++ b/packages/oidc_default_store/test/oidc_default_store_web_and_secure_test.dart
@@ -6,6 +6,8 @@ import 'package:oidc_core/oidc_core.dart';
 import 'package:oidc_default_store/oidc_default_store.dart';
 import 'package:oidc_default_store/src/html_stub.dart' as html_stub;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -13,6 +15,8 @@ void main() {
   group('OidcDefaultStore web branches (testIsWeb = true)', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
     });
 
     for (final webSessionManagementLocation
@@ -81,6 +85,8 @@ void main() {
       () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
       FlutterSecureStorage.setMockInitialValues({});
     });
 
@@ -157,6 +163,8 @@ void main() {
   group('OidcDefaultStore namespace/managerId isolation', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.empty();
     });
 
     testWidgets(


### PR DESCRIPTION
Migrates oidc_default_store's non-secure persistence from the legacy synchronous SharedPreferences to the modern SharedPreferencesAsync API (issue #301), so callers can share their own async instance with the store. Adds a `sharedPreferencesAsync` constructor parameter (also injectable for tests), keeps the existing `sharedPreferences` parameter working end-to-end but marks it `@Deprecated` (following the repo's existing deprecation style, pointing at the async replacement). Backend selection is abstracted behind a small internal `_OidcPrefsBackend` interface with legacy and async adapters, so all non-secure reads/writes are now awaited while the store logic stays backend-agnostic. On the default (non-injected) path, `init()` runs a one-time, storagePrefix-scoped, best-effort migration of only this store's own keys from the legacy store into SharedPreferencesAsync — guarded by a marker key, never overwriting existing async values — to preserve data on Android where the legacy API (SharedPreferences) and SharedPreferencesAsync (DataStore Preferences) use different backing stores. Bumps the `shared_preferences` dependency constraint `^2.2.1` -> `^2.3.0` (first release shipping the async API).

### Test evidence
- `packages/oidc_default_store/test/oidc_default_store_async_test.dart :: default (non-injected) backend round-trips through SharedPreferencesAsync`
- `packages/oidc_default_store/test/oidc_default_store_async_test.dart :: an injected SharedPreferencesAsync is used for all non-secure persistence`
- `packages/oidc_default_store/test/oidc_default_store_async_test.dart :: the deprecated synchronous SharedPreferences constructor path still works end-to-end`
- `packages/oidc_default_store/test/oidc_default_store_async_test.dart :: existing legacy data under the storagePrefix is migrated once into the async store, and unrelated keys are left untouched`
- `packages/oidc_default_store/test/oidc_default_store_async_test.dart :: migration does not overwrite values already in the async store`

Gates: format clean, analyzer at the pre-existing baseline with zero new issues, full package test run green.

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS
