### PR TITLE
fix(oidc_core): send dpop_jkt on the direct authorization request (RFC 9449 §10)

### DIFF
--- a/packages/oidc_core/lib/src/endpoints/authorize/req.dart
+++ b/packages/oidc_core/lib/src/endpoints/authorize/req.dart
@@ -36,6 +36,7 @@ class OidcAuthorizeRequest extends JsonBasedRequest {
     this.acrValues,
     this.requestUri,
     this.resource,
+    this.dpopJkt,
     this.request,
   });
 
@@ -297,6 +298,18 @@ class OidcAuthorizeRequest extends JsonBasedRequest {
   /// per value (and likewise in the PAR request body).
   @JsonKey(name: OidcConstants_AuthParameters.resource)
   List<Uri>? resource;
+
+  /// RFC 9449 §10: the JWK SHA-256 Thumbprint (`jkt`, per RFC 7638) of the DPoP
+  /// proof key, sent to bind the issued authorization code to that key when
+  /// Pushed Authorization Requests are NOT used.
+  ///
+  /// On the PAR path the identical binding is carried on the (back-channel) PAR
+  /// request body instead (RFC 9126), so this member is only populated for a
+  /// direct authorization request. When set, it is emitted on the front-channel
+  /// authorization URL (and, when a JWT-Secured Authorization Request is used,
+  /// inside the signed [request] object). Leave null when DPoP is disabled.
+  @JsonKey(name: OidcConstants_AuthParameters.dpopJkt)
+  String? dpopJkt;
 
   /// A JWT-Secured Authorization Request object (RFC 9101) carrying the
   /// authorization parameters by value.

--- a/packages/oidc_core/lib/src/endpoints/authorize/req.g.dart
+++ b/packages/oidc_core/lib/src/endpoints/authorize/req.g.dart
@@ -35,6 +35,7 @@ Map<String, dynamic> _$OidcAuthorizeRequestToJson(
   'code_challenge': ?instance.codeChallenge,
   'code_challenge_method': ?instance.codeChallengeMethod,
   'resource': ?instance.resource?.map((e) => e.toString()).toList(),
+  'dpop_jkt': ?instance.dpopJkt,
 };
 
 Json? _$JsonConverterToJson<Json, Value>(

--- a/packages/oidc_core/lib/src/endpoints/facade.dart
+++ b/packages/oidc_core/lib/src/endpoints/facade.dart
@@ -128,11 +128,18 @@ class OidcEndpoints {
   /// information about the flow parameters for later validation.
   ///
   /// If the [store] parameter is passed, it persists the generated nonce/state.
+  ///
+  /// [dpopJkt] is the RFC 7638 thumbprint of the DPoP proof key. When non-null
+  /// it is emitted as the `dpop_jkt` authorization-request parameter (RFC 9449
+  /// §10) to bind the authorization code to the DPoP key; pass it only for the
+  /// direct (non-PAR) path, since the PAR path binds via the pushed request
+  /// body instead.
   static Future<OidcSimpleAuthorizationRequestContainer>
   prepareAuthorizationCodeFlowRequest({
     required OidcProviderMetadata metadata,
     required OidcSimpleAuthorizationCodeFlowRequest input,
     OidcStore? store,
+    String? dpopJkt,
   }) async {
     // OAuth 2.1 / RFC 9700 (Security BCP): ALWAYS use PKCE, defaulting to S256,
     // even when the OP's metadata omits `code_challenge_methods_supported` — a
@@ -219,6 +226,10 @@ class OidcEndpoints {
       prompt: input.prompt,
       uiLocales: input.uiLocales,
       resource: input.resource,
+      // RFC 9449 §10: set before the JAR request object is built below so the
+      // binding is also carried inside a signed request object (RFC 9101) when
+      // one is used. Null (DPoP off / PAR path) omits it entirely.
+      dpopJkt: dpopJkt,
     );
 
     final requestObjectSettings = input.requestObjectSettings;

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -231,6 +231,20 @@ abstract class OidcUserManagerBase {
         discoveryDocumentOverride ?? this.discoveryDocument;
     options = getPlatformOptions(options);
     final prep = prepareForRedirectFlow(options);
+    // RFC 9126 Pushed Authorization Requests: decide up front whether this flow
+    // pushes, because that selects where the DPoP authorization-code binding
+    // (`dpop_jkt`, RFC 9449 §10) is emitted — on the direct authorization
+    // request (below, via `prepareAuthorizationCodeFlowRequest`) or on the
+    // back-channel PAR request body. The two are mutually exclusive so the code
+    // is never double-bound.
+    final shouldPushAuthorizationRequest =
+        switch (settings.pushedAuthorizationRequestsMode) {
+          OidcPushedAuthorizationRequestsMode.never => false,
+          OidcPushedAuthorizationRequestsMode.always => true,
+          OidcPushedAuthorizationRequestsMode.auto =>
+            discoveryDocument.requirePushedAuthorizationRequestsOrDefault,
+        };
+    final dpop = dpopManager;
     final simpleReq = OidcSimpleAuthorizationCodeFlowRequest(
       clientId: clientCredentials.clientId,
       originalUri: originalUri,
@@ -271,19 +285,23 @@ abstract class OidcUserManagerBase {
           input: simpleReq,
           metadata: discoveryDocument,
           store: store,
+          // RFC 9449 §10: when DPoP is enabled and this flow does NOT use PAR,
+          // bind the authorization code to the DPoP key by carrying its
+          // thumbprint as `dpop_jkt` on the (direct) authorization request. The
+          // PAR path binds via the pushed request body below instead, so exactly
+          // one of the two branches emits it.
+          dpopJkt:
+              !shouldPushAuthorizationRequest &&
+                  dpop != null &&
+                  dpop.settings.bindAuthorizationCode
+              ? dpop.thumbprint
+              : null,
         );
     // RFC 9126 Pushed Authorization Requests: when enabled, POST the prepared
     // request to the PAR endpoint (back channel, authenticated) and continue
     // the front channel by reference (`request_uri`). state/nonce/PKCE were
     // already persisted by prepareAuthorizationCodeFlowRequest above, so local
     // validation is unchanged (RFC 9126 §6).
-    final shouldPushAuthorizationRequest =
-        switch (settings.pushedAuthorizationRequestsMode) {
-          OidcPushedAuthorizationRequestsMode.never => false,
-          OidcPushedAuthorizationRequestsMode.always => true,
-          OidcPushedAuthorizationRequestsMode.auto =>
-            discoveryDocument.requirePushedAuthorizationRequestsOrDefault,
-        };
     if (shouldPushAuthorizationRequest) {
       final parEndpoint = discoveryDocument.pushedAuthorizationRequestEndpoint;
       if (parEndpoint == null) {
@@ -293,7 +311,6 @@ abstract class OidcUserManagerBase {
           '`pushed_authorization_request_endpoint`.',
         );
       }
-      final dpop = dpopManager;
       final parResponse = await OidcEndpoints.pushAuthorizationRequest(
         pushedAuthorizationRequestEndpoint: parEndpoint,
         request: requestContainer.request,

--- a/packages/oidc_core/test/login_dpop_flow_test.dart
+++ b/packages/oidc_core/test/login_dpop_flow_test.dart
@@ -25,16 +25,32 @@ class _CodeFlowManager extends OidcUserManagerBase {
   @override
   bool get isWeb => false;
 
+  /// The last [OidcAuthorizeRequest] handed to [getAuthorizationResponse] — the
+  /// exact request the front channel would serialize, so tests can inspect the
+  /// generated authorization URL.
+  OidcAuthorizeRequest? capturedAuthRequest;
+
+  /// The metadata that accompanied [capturedAuthRequest].
+  OidcProviderMetadata? capturedAuthMetadata;
+
+  /// Exposes the session DPoP key thumbprint (the `dpop_jkt` / `cnf.jkt`
+  /// source) for assertions; `dpopManager` is `@protected`, so surface it here.
+  String? get dpopThumbprint => dpopManager?.thumbprint;
+
   @override
   Future<OidcAuthorizeResponse?> getAuthorizationResponse(
     OidcProviderMetadata metadata,
     OidcAuthorizeRequest request,
     OidcPlatformSpecificOptions options,
     Map<String, dynamic> preparationResult,
-  ) async => OidcAuthorizeResponse.fromJson({
-    'code': 'auth-code-1',
-    'state': request.state,
-  });
+  ) async {
+    capturedAuthRequest = request;
+    capturedAuthMetadata = metadata;
+    return OidcAuthorizeResponse.fromJson({
+      'code': 'auth-code-1',
+      'state': request.state,
+    });
+  }
 
   @override
   Future<OidcEndSessionResponse?> getEndSessionResponse(
@@ -276,6 +292,75 @@ void main() {
       final body = Uri.splitQueryString(parPost!.body);
       expect(body['dpop_jkt'], isNotNull);
       expect(body['dpop_jkt'], isNotEmpty);
+      // The binding lives ONLY on the PAR body: the front-channel request must
+      // not also carry it (the code is never double-bound), and after PAR the
+      // authorization URL is just `client_id` + `request_uri` (RFC 9126 §4).
+      final request = manager.capturedAuthRequest!;
+      expect(request.dpopJkt, isNull);
+      final uri = request.generateUri(
+        manager.capturedAuthMetadata!.authorizationEndpoint!,
+      );
+      expect(uri.queryParameters.containsKey('dpop_jkt'), isFalse);
+      expect(uri.queryParameters['request_uri'], 'urn:par:1');
+    },
+  );
+
+  test(
+    'binds the auth code via dpop_jkt on the direct authorization request when '
+    'DPoP is on and PAR is off (RFC 9449 §10)',
+    () async {
+      final posts = <http.Request>[];
+      final manager = await build(posts, dpop: const OidcDPoPSettings());
+      await login(manager);
+
+      final request = manager.capturedAuthRequest;
+      expect(request, isNotNull, reason: 'authorization request must be built');
+      final uri = request!.generateUri(
+        manager.capturedAuthMetadata!.authorizationEndpoint!,
+      );
+      final jkt = uri.queryParameters['dpop_jkt'];
+      expect(jkt, isNotNull);
+      expect(jkt, isNotEmpty);
+      // Derived from the SAME session key used for the token proof / PAR binding.
+      expect(jkt, manager.dpopThumbprint);
+    },
+  );
+
+  test(
+    'sends no dpop_jkt on the authorization request when DPoP is disabled',
+    () async {
+      final posts = <http.Request>[];
+      final manager = await build(posts, dpop: null);
+      await login(manager);
+
+      final request = manager.capturedAuthRequest;
+      expect(request, isNotNull);
+      expect(request!.dpopJkt, isNull);
+      final uri = request.generateUri(
+        manager.capturedAuthMetadata!.authorizationEndpoint!,
+      );
+      expect(uri.queryParameters.containsKey('dpop_jkt'), isFalse);
+    },
+  );
+
+  test(
+    'omits dpop_jkt on the authorization request when bindAuthorizationCode is '
+    'false',
+    () async {
+      final posts = <http.Request>[];
+      final manager = await build(
+        posts,
+        dpop: const OidcDPoPSettings(bindAuthorizationCode: false),
+      );
+      await login(manager);
+
+      final request = manager.capturedAuthRequest;
+      expect(request, isNotNull);
+      expect(request!.dpopJkt, isNull);
+      final uri = request.generateUri(
+        manager.capturedAuthMetadata!.authorizationEndpoint!,
+      );
+      expect(uri.queryParameters.containsKey('dpop_jkt'), isFalse);
     },
   );
 }


### PR DESCRIPTION
RFC 9449 §10 defines the `dpop_jkt` authorization-request parameter that binds the issued authorization code to the DPoP proof key when Pushed Authorization Requests are not used. The library only emitted this binding on the back-channel PAR request body (user_manager_base.dart:304-306), so a DPoP-enabled DIRECT (non-PAR) authorization request left the code unbound. This adds a `dpopJkt` member to `OidcAuthorizeRequest` (RFC 9449 §10 doc comment, regenerated req.g.dart via build_runner) and a `dpopJkt` pass-through parameter on `OidcEndpoints.prepareAuthorizationCodeFlowRequest` that sets it on the request BEFORE any JWT-Secured Authorization Request (JAR) object is built, so the binding rides the front-channel URL and, when JAR is used, travels inside the signed request object. `loginAuthorizationCodeFlow` now resolves the PAR-push decision up front and, when DPoP is enabled with `bindAuthorizationCode` and the flow is NOT pushing, threads the same thumbprint source the PAR path uses (`OidcDPoPManager.thumbprint`) into the direct request. The two binding sites are mutually exclusive — direct-request `dpopJkt` is null on the PAR path, and the PAR body binding is unchanged — so the code is never double-bound.

### Test evidence
- `packages/oidc_core/test/login_dpop_flow_test.dart :: 'binds the auth code via dpop_jkt on the direct authorization request when DPoP is on and PAR is off (RFC 9449 §10)'`
- `packages/oidc_core/test/login_dpop_flow_test.dart :: 'sends no dpop_jkt on the authorization request when DPoP is disabled'`
- `packages/oidc_core/test/login_dpop_flow_test.dart :: 'omits dpop_jkt on the authorization request when bindAuthorizationCode is false'`
- `packages/oidc_core/test/login_dpop_flow_test.dart :: 'binds the auth code via dpop_jkt on the PAR request (RFC 9449 §10)' (strengthened: pins front-channel carries NO dpop_jkt after PAR — regression pin)`

Gates: format clean, analyzer at the pre-existing baseline with zero new issues, full package test run green.

Part of #324 (item 23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS
