### PR TITLE
feat(oidc_web_core): structured redirect wire v2 with app acknowledgement; state-driven redirect.html

### DIFF
--- a/docs/oidc-getting-started.md
+++ b/docs/oidc-getting-started.md
@@ -212,7 +212,26 @@ Note how `frontChannelLogoutUri` needs `requestType=front-channel-logout` for th
 
 you will have to register these urls with the openid provider first, depending on your configuration.
 
-also the html page is completely customizable, but it's preferred to leave the javascript part as is, since it's well-integrated with the plugin.
+also the html page is completely customizable, but it's preferred to leave the javascript part as is, since it's well-integrated with the plugin. All user-visible copy lives in a single `messages` object near the top of the script and is safe to translate.
+
+#### How the page talks to the app
+
+The page and the app exchange messages over a `BroadcastChannel`:
+
+- on load, the page posts the incoming redirect to the app as a small JSON envelope: `{"v":2,"type":"redirect","uri":"<full redirect url>"}`;
+- once the app has processed it (the token exchange finished — or failed), the app posts an acknowledgement back: `{"v":2,"type":"ack","status":"ok"|"error","message":"<short message>"}`.
+
+The page only shows a **success** state after an `ok` ack — so it no longer claims "Operation Successful" when the app-side exchange actually failed. It shows an **error** state on an `error` ack, or when the provider returned an error directly in the redirect (`error`/`error_description`/`error_uri`, per [RFC 6749 §4.1.2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1)). If no ack arrives within ~10s (e.g. an older app version that never acks), or the browser refuses to close a tab the script didn't open (email-link tabs), it falls back to a neutral "you can now close this tab" state.
+
+The app still accepts the older bare-URL message, so an outdated copy of the page keeps working after you upgrade the package. The reverse does not hold: this v2 page needs the matching (v2-aware) package version.
+
+#### Upgrading
+
+`redirect.html` is copied into your own project, not shipped by the package, so `flutter pub upgrade` never updates it. When you upgrade `oidc`, **re-copy the page** from the example so the app and the page stay on the same wire version.
+
+#### Troubleshooting
+
+- **The page never loads (blank tab, or your host/proxy's `502`/`504`).** None of the javascript above can run if the `redirect_uri` doesn't actually serve this page. Make sure your host or reverse proxy serves `redirect.html` at the exact `redirect_uri` path in every environment. While that tab is broken the app receives nothing, so the pending login stays unresolved — return to the app to cancel it (or let it time out) and retry once the page is served correctly.
 
 [Read more](oidc-usage.md)
 

--- a/docs/oidc_web_core.md
+++ b/docs/oidc_web_core.md
@@ -50,7 +50,26 @@ Note how `frontChannelLogoutUri` needs `requestType=front-channel-logout` for th
 
 you will have to register these urls with the openid provider first, depending on your configuration.
 
-also the html page is completely customizable, but it's preferred to leave the javascript part as is, since it's well-integrated with the plugin.
+also the html page is completely customizable, but it's preferred to leave the javascript part as is, since it's well-integrated with the plugin. All user-visible copy lives in a single `messages` object near the top of the script and is safe to translate.
+
+#### How the page talks to the app
+
+The page and the app exchange messages over a `BroadcastChannel`:
+
+- on load, the page posts the incoming redirect to the app as a small JSON envelope: `{"v":2,"type":"redirect","uri":"<full redirect url>"}`;
+- once the app has processed it (the token exchange finished — or failed), the app posts an acknowledgement back: `{"v":2,"type":"ack","status":"ok"|"error","message":"<short message>"}`.
+
+The page only shows a **success** state after an `ok` ack — so it no longer claims "Operation Successful" when the app-side exchange actually failed. It shows an **error** state on an `error` ack, or when the provider returned an error directly in the redirect (`error`/`error_description`/`error_uri`, per [RFC 6749 §4.1.2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1)). If no ack arrives within ~10s (e.g. an older app version that never acks), or the browser refuses to close a tab the script didn't open (email-link tabs), it falls back to a neutral "you can now close this tab" state.
+
+The app still accepts the older bare-URL message, so an outdated copy of the page keeps working after you upgrade the package. The reverse does not hold: this v2 page needs the matching (v2-aware) package version.
+
+#### Upgrading
+
+`redirect.html` is copied into your own project, not shipped by the package, so `dart pub upgrade` never updates it. When you upgrade `oidc_web_core`, **re-copy the page** from the example so the app and the page stay on the same wire version.
+
+#### Troubleshooting
+
+- **The page never loads (blank tab, or your host/proxy's `502`/`504`).** None of the javascript above can run if the `redirect_uri` doesn't actually serve this page. Make sure your host or reverse proxy serves `redirect.html` at the exact `redirect_uri` path in every environment. While that tab is broken the app receives nothing, so the pending login stays unresolved — return to the app to cancel it (or let it time out) and retry once the page is served correctly.
 
 ## Usage
 

--- a/packages/oidc/example/web/redirect.html
+++ b/packages/oidc/example/web/redirect.html
@@ -1,122 +1,355 @@
-<!-- 
-    This HTML page works as a redirect_uri, post_logout_redirect_uri, frontchannel_logout_uri 
-    but for frontchannel_logout_uri to work, it must be called like this:
+<!--
+    This HTML page works as a redirect_uri, post_logout_redirect_uri and
+    frontchannel_logout_uri for `package:oidc` / `package:oidc_web_core`.
 
-    /redirect.html?requestType=front-channel-logout
+    For it to work as a frontchannel_logout_uri, it must be called like this:
+
+        /redirect.html?requestType=front-channel-logout
+
+    The javascript below speaks the structured "wire v2" protocol with the app:
+      1. it posts the incoming redirect to the app on a BroadcastChannel as
+         {"v":2,"type":"redirect","uri":"<full redirect url>"} , and
+      2. it waits for the app to post back an acknowledgement
+         {"v":2,"type":"ack","status":"ok"|"error","message":<string?>} ,
+         and only then shows a success / failure state.
+
+    It stays backward compatible: the app also still understands a bare redirect
+    URL string, but this page requires the matching (v2-aware) package version.
+    If you upgrade the package you should RE-COPY this file.
+
+    The page is fully customizable, but it's preferred to keep the javascript as
+    is, since it's tightly integrated with the plugin. All user-visible copy
+    lives in the `messages` object below and is safe to translate.
 -->
 <!DOCTYPE html>
 <html lang="en">
 
 <head>
     <meta charset="utf-8">
-    <title>Flutter Oidc Redirect</title>
+    <title>Sign-in redirect</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script type="text/javascript">
-        const stateNamespace = 'state';
-        const stateResponseNamespace = 'response.state';
-        const requestNamespace = 'request';
-
-        const requestBroadcastChannel = 'oidc_flutter_web/request';
-        const redirectBroadcastChannel = 'oidc_flutter_web/redirect';
-
-
-        //if the OP isn't requesting logout, handle redirect.
-        if (!handleFrontChannelLogout()) {
-            handleRedirect();
+    <style>
+        :root {
+            color-scheme: light dark;
         }
 
-        function handleRedirect() {
-            // For supported browsers: https://caniuse.com/broadcastchannel
-            var bc = new BroadcastChannel(redirectBroadcastChannel);
-            bc.postMessage(window.location.toString());
-            bc.close();
-            //The rest of this function handles same page redirects
-            let dataSrc;
-            dataSrc = new URLSearchParams(window.location.search);
-            var state = dataSrc.get('state');
-            if (!state) {
-                if (window.location.hash) {
-                    dataSrc = new URLSearchParams(
-                        window.location.hash.substring(1)
-                    );
-                    state = dataSrc.get('state');
-                }
-            }
-            if (!state) {
-                return;
-            }
-            const stateDataRaw = getLocalStorage(stateNamespace, state);
-            if (!stateDataRaw) {
-                console.error('state not found, key: ' + state);
-                return;
-            }
-            setLocalStorage(stateResponseNamespace, state, window.location.toString());
-            //we call JSON.parse twice, since shared_preferences double encodes json strings for some reason.
-            const parsedStateString = JSON.parse(stateDataRaw);
-            if (!parsedStateString) {
-                console.error('parsed state is null');
-                return;
-            }
-            // Read the mode from the state.
-            const webLaunchMode = parsedStateString.options?.webLaunchMode;
-            if (!webLaunchMode) {
-                console.error('webLaunchMode not found in parsed state.');
-                return;
-            }
-            if (webLaunchMode != 'samePage') {
-                return;
-            }
-            const original_uri = parsedStateString.original_uri;
-            if (!original_uri) {
-                console.warn("it's preferred that original_uri is used when webLaunchMode is samePage.");
-                return;
-            }
-            window.location.assign(original_uri);
+        html,
+        body {
+            height: 100%;
+            margin: 0;
         }
 
-        function handleFrontChannelLogout() {
-            const queryParams = new URLSearchParams(window.location.search);
-            if (queryParams.get('requestType') == 'front-channel-logout') {
-                // For supported browsers: https://caniuse.com/broadcastchannel
-                var bc = new BroadcastChannel(requestBroadcastChannel);
-                bc.postMessage(window.location.toString());
-                bc.close();
-                // this puts a marker for the flutter app that the user wants to logout.
-                //
-                // in the flutter app, if this marker exists, 
-                // we don't auth the cached user in `UserManager.init()`, and we clear the cached data.
-                setLocalStorage(requestNamespace, 'front-channel-logout', window.location.toString());
-                return true;
-            }
-            return false;
+        body {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+            box-sizing: border-box;
+            font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+            line-height: 1.5;
         }
 
-        function getLocalStorage(namespace, key) {
-            const rawRes = localStorage.getItem('oidc.' + namespace + '.' + key);
-            if (!rawRes) {
-                return null;
-            }
-            return rawRes;
+        .oidc-card {
+            max-width: 32rem;
+            text-align: center;
         }
-        function setLocalStorage(namespace, key, value) {
-            const keysEntryKey = 'oidc.keys.' + namespace;
-            var keys = localStorage.getItem(keysEntryKey);
-            if (!keys) {
-                keys = "[]";
-            }
-            const parsedKeys = JSON.parse(keys);
-            if (!(parsedKeys instanceof Array)) {
-                console.error('parsedKeys is not an array.', parsedKeys);
-            }
-            parsedKeys.push(key);
-            localStorage.setItem(keysEntryKey, JSON.stringify(parsedKeys));
-            localStorage.setItem('oidc.' + namespace + '.' + key, value);
+
+        .oidc-card h3 {
+            margin: 0 0 0.5rem;
+            font-weight: 600;
         }
-    </script>
+
+        .oidc-card p {
+            margin: 0.25rem 0;
+            opacity: 0.85;
+        }
+
+        .oidc-card[data-state="error"] h3 {
+            color: #c0392b;
+        }
+    </style>
 </head>
 
 <body>
-    <h3>Operation Successful! Please close this page.</h3>
+    <main class="oidc-card" id="oidc-card" role="status" aria-live="polite">
+        <h3 id="oidc-title">Completing your request...</h3>
+        <p id="oidc-detail"></p>
+        <p id="oidc-error-uri" hidden></p>
+    </main>
+
+    <script type="text/javascript">
+        (function () {
+            'use strict';
+
+            // --- protocol / storage constants (keep in sync with the plugin) ---
+            const WIRE_VERSION = 2;
+            const requestBroadcastChannel = 'oidc_flutter_web/request';
+            const redirectBroadcastChannel = 'oidc_flutter_web/redirect';
+            const stateNamespace = 'state';
+            const stateResponseNamespace = 'response.state';
+            const requestNamespace = 'request';
+
+            // How long to wait for the app's ack before falling back to a
+            // neutral "return to the app" state. Covers older app versions that
+            // never ack.
+            const ACK_TIMEOUT_MS = 10000;
+
+            // --- user-visible copy (localize here) ---
+            const messages = {
+                working: 'Completing your request...',
+                redirecting: 'Redirecting...',
+                success: 'All done. You can now close this tab and return to the app.',
+                loggedOut: 'You have been signed out. You can now close this tab and return to the app.',
+                safeToClose: 'You can now close this tab and return to the app.',
+                errorTitle: 'Something went wrong',
+                appError: 'The request could not be completed. Please return to the app and try again.',
+                noChannel: 'Your browser does not support cross-tab messaging. Please return to the app; it will continue automatically.',
+            };
+
+            const channelSupported = typeof BroadcastChannel !== 'undefined';
+
+            // Front-channel logout takes precedence; otherwise handle a redirect.
+            if (!handleFrontChannelLogout()) {
+                handleRedirect();
+            }
+
+            // --- redirect (redirect_uri / post_logout_redirect_uri) ---
+            function handleRedirect() {
+                render('status', messages.working, '');
+
+                const errorInfo = parseError();
+                let bc = null;
+                let settled = false;
+                let timer = null;
+
+                function finish(state, title, detail, errorUri, close) {
+                    if (settled) {
+                        return;
+                    }
+                    settled = true;
+                    if (timer !== null) {
+                        clearTimeout(timer);
+                    }
+                    if (bc) {
+                        try { bc.close(); } catch (e) { /* ignore */ }
+                    }
+                    render(state, title, detail, errorUri);
+                    if (close) {
+                        attemptClose();
+                    }
+                }
+
+                // Open the channel BEFORE posting so an immediate ack isn't
+                // missed; a BroadcastChannel never receives its own messages, so
+                // our own "redirect" post won't come back to us.
+                if (channelSupported) {
+                    try {
+                        bc = new BroadcastChannel(redirectBroadcastChannel);
+                        bc.onmessage = function (event) {
+                            let msg;
+                            try { msg = JSON.parse(event.data); } catch (e) { return; }
+                            if (!msg || msg.v !== WIRE_VERSION || msg.type !== 'ack') {
+                                return;
+                            }
+                            if (msg.status === 'ok') {
+                                finish('status', messages.success, '', null, true);
+                            } else {
+                                finish('error', messages.errorTitle, msg.message || messages.appError, null, false);
+                            }
+                        };
+                        bc.postMessage(JSON.stringify({
+                            v: WIRE_VERSION,
+                            type: 'redirect',
+                            uri: window.location.toString(),
+                        }));
+                    } catch (e) {
+                        bc = null;
+                    }
+                }
+
+                // If this is a same-page launch, the SPA is navigated back to
+                // its original url and reads the response from storage; the page
+                // unloads, so there is no ack to await.
+                if (maybeSelfNavigate()) {
+                    if (timer !== null) {
+                        clearTimeout(timer);
+                    }
+                    render('status', messages.redirecting, '');
+                    return;
+                }
+
+                // The OP returned an error in the url (RFC 6749 sec 4.1.2.1): show
+                // it immediately, we already know the outcome.
+                if (errorInfo) {
+                    finish('error', messages.errorTitle, errorInfo.description || errorInfo.error, errorInfo.uri, true);
+                    return;
+                }
+
+                if (!bc) {
+                    // No channel: nothing to await, surface a neutral state.
+                    render('status', messages.working, messages.noChannel);
+                    attemptClose();
+                    return;
+                }
+
+                // Await the app's ack, with a timeout for old app versions.
+                timer = setTimeout(function () {
+                    finish('status', messages.safeToClose, '', null, true);
+                }, ACK_TIMEOUT_MS);
+            }
+
+            // --- front-channel logout (frontchannel_logout_uri) ---
+            function handleFrontChannelLogout() {
+                const queryParams = new URLSearchParams(window.location.search);
+                if (queryParams.get('requestType') !== 'front-channel-logout') {
+                    return false;
+                }
+                if (channelSupported) {
+                    try {
+                        // Legacy plain-string wire: the front-channel listener
+                        // consumes a bare url.
+                        const bc = new BroadcastChannel(requestBroadcastChannel);
+                        bc.postMessage(window.location.toString());
+                        bc.close();
+                    } catch (e) { /* ignore */ }
+                }
+                // Marker for the flutter app: if this exists we don't auth the
+                // cached user in `UserManager.init()`, and we clear cached data.
+                setLocalStorage(requestNamespace, 'front-channel-logout', window.location.toString());
+                render('status', messages.loggedOut, '');
+                attemptClose();
+                return true;
+            }
+
+            // Handles the same-page launch mode: stores the response for the app
+            // and, when webLaunchMode == samePage, navigates back to the
+            // original url. Returns true if it navigated the page away.
+            function maybeSelfNavigate() {
+                let dataSrc = new URLSearchParams(window.location.search);
+                let state = dataSrc.get('state');
+                if (!state && window.location.hash) {
+                    dataSrc = new URLSearchParams(window.location.hash.substring(1));
+                    state = dataSrc.get('state');
+                }
+                if (!state) {
+                    return false;
+                }
+                const stateDataRaw = getLocalStorage(stateNamespace, state);
+                if (!stateDataRaw) {
+                    console.error('state not found, key: ' + state);
+                    return false;
+                }
+                setLocalStorage(stateResponseNamespace, state, window.location.toString());
+                const parsedStateString = JSON.parse(stateDataRaw);
+                if (!parsedStateString) {
+                    console.error('parsed state is null');
+                    return false;
+                }
+                const webLaunchMode = parsedStateString.options?.webLaunchMode;
+                if (webLaunchMode !== 'samePage') {
+                    return false;
+                }
+                const original_uri = parsedStateString.original_uri;
+                if (!original_uri) {
+                    console.warn("it's preferred that original_uri is used when webLaunchMode is samePage.");
+                    return false;
+                }
+                window.location.assign(original_uri);
+                return true;
+            }
+
+            // Parses error/error_description/error_uri from both the query and
+            // the fragment (RFC 6749 sec 4.1.2.1). Returns null when there is none.
+            function parseError() {
+                function read(params) {
+                    const error = params.get('error');
+                    if (!error) {
+                        return null;
+                    }
+                    return {
+                        error: error,
+                        description: params.get('error_description'),
+                        uri: params.get('error_uri'),
+                    };
+                }
+                const fromQuery = read(new URLSearchParams(window.location.search));
+                if (fromQuery) {
+                    return fromQuery;
+                }
+                if (window.location.hash) {
+                    return read(new URLSearchParams(window.location.hash.substring(1)));
+                }
+                return null;
+            }
+
+            // Best-effort close. Only works for tabs the script itself opened
+            // (newPage / popup); for email-link orphan tabs it's a silent no-op,
+            // so the visible copy always tells the user they may close manually.
+            function attemptClose() {
+                try { window.close(); } catch (e) { /* ignore */ }
+            }
+
+            // Renders a state. `title`/`detail` are set with textContent so the
+            // attacker-influenced error params can never inject markup.
+            function render(state, title, detail, errorUri) {
+                const card = document.getElementById('oidc-card');
+                const titleEl = document.getElementById('oidc-title');
+                const detailEl = document.getElementById('oidc-detail');
+                const errUriEl = document.getElementById('oidc-error-uri');
+                if (card) {
+                    card.setAttribute('data-state', state);
+                }
+                if (titleEl) {
+                    titleEl.textContent = title || '';
+                }
+                if (detailEl) {
+                    detailEl.textContent = detail || '';
+                }
+                if (!errUriEl) {
+                    return;
+                }
+                // Only render http(s) error_uri values, and as text/link only.
+                if (errorUri && /^https?:\/\//i.test(errorUri)) {
+                    errUriEl.textContent = '';
+                    const a = document.createElement('a');
+                    a.href = errorUri;
+                    a.textContent = errorUri;
+                    a.rel = 'noopener noreferrer';
+                    errUriEl.appendChild(a);
+                    errUriEl.hidden = false;
+                } else if (errorUri) {
+                    errUriEl.textContent = errorUri;
+                    errUriEl.hidden = false;
+                } else {
+                    errUriEl.textContent = '';
+                    errUriEl.hidden = true;
+                }
+            }
+
+            function getLocalStorage(namespace, key) {
+                const rawRes = localStorage.getItem('oidc.' + namespace + '.' + key);
+                if (!rawRes) {
+                    return null;
+                }
+                return rawRes;
+            }
+
+            function setLocalStorage(namespace, key, value) {
+                const keysEntryKey = 'oidc.keys.' + namespace;
+                var keys = localStorage.getItem(keysEntryKey);
+                if (!keys) {
+                    keys = "[]";
+                }
+                const parsedKeys = JSON.parse(keys);
+                if (!(parsedKeys instanceof Array)) {
+                    console.error('parsedKeys is not an array.', parsedKeys);
+                }
+                parsedKeys.push(key);
+                localStorage.setItem(keysEntryKey, JSON.stringify(parsedKeys));
+                localStorage.setItem('oidc.' + namespace + '.' + key, value);
+            }
+        })();
+    </script>
 </body>
 
 </html>

--- a/packages/oidc_web_core/example/web/redirect.html
+++ b/packages/oidc_web_core/example/web/redirect.html
@@ -1,122 +1,355 @@
-<!-- 
-    This HTML page works as a redirect_uri, post_logout_redirect_uri, frontchannel_logout_uri 
-    but for frontchannel_logout_uri to work, it must be called like this:
+<!--
+    This HTML page works as a redirect_uri, post_logout_redirect_uri and
+    frontchannel_logout_uri for `package:oidc` / `package:oidc_web_core`.
 
-    /redirect.html?requestType=front-channel-logout
+    For it to work as a frontchannel_logout_uri, it must be called like this:
+
+        /redirect.html?requestType=front-channel-logout
+
+    The javascript below speaks the structured "wire v2" protocol with the app:
+      1. it posts the incoming redirect to the app on a BroadcastChannel as
+         {"v":2,"type":"redirect","uri":"<full redirect url>"} , and
+      2. it waits for the app to post back an acknowledgement
+         {"v":2,"type":"ack","status":"ok"|"error","message":<string?>} ,
+         and only then shows a success / failure state.
+
+    It stays backward compatible: the app also still understands a bare redirect
+    URL string, but this page requires the matching (v2-aware) package version.
+    If you upgrade the package you should RE-COPY this file.
+
+    The page is fully customizable, but it's preferred to keep the javascript as
+    is, since it's tightly integrated with the plugin. All user-visible copy
+    lives in the `messages` object below and is safe to translate.
 -->
 <!DOCTYPE html>
 <html lang="en">
 
 <head>
     <meta charset="utf-8">
-    <title>Flutter Oidc Redirect</title>
+    <title>Sign-in redirect</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script type="text/javascript">
-        const stateNamespace = 'state';
-        const stateResponseNamespace = 'response.state';
-        const requestNamespace = 'request';
-
-        const requestBroadcastChannel = 'oidc_flutter_web/request';
-        const redirectBroadcastChannel = 'oidc_flutter_web/redirect';
-
-
-        //if the OP isn't requesting logout, handle redirect.
-        if (!handleFrontChannelLogout()) {
-            handleRedirect();
+    <style>
+        :root {
+            color-scheme: light dark;
         }
 
-        function handleRedirect() {
-            // For supported browsers: https://caniuse.com/broadcastchannel
-            var bc = new BroadcastChannel(redirectBroadcastChannel);
-            bc.postMessage(window.location.toString());
-            bc.close();
-            //The rest of this function handles same page redirects
-            let dataSrc;
-            dataSrc = new URLSearchParams(window.location.search);
-            var state = dataSrc.get('state');
-            if (!state) {
-                if (window.location.hash) {
-                    dataSrc = new URLSearchParams(
-                        window.location.hash.substring(1)
-                    );
-                    state = dataSrc.get('state');
-                }
-            }
-            if (!state) {
-                return;
-            }
-            const stateDataRaw = getLocalStorage(stateNamespace, state);
-            if (!stateDataRaw) {
-                console.error('state not found, key: ' + state);
-                return;
-            }
-            setLocalStorage(stateResponseNamespace, state, window.location.toString());
-            //we call JSON.parse twice, since shared_preferences double encodes json strings for some reason.
-            const parsedStateString = JSON.parse(stateDataRaw);
-            if (!parsedStateString) {
-                console.error('parsed state is null');
-                return;
-            }
-            // Read the mode from the state.
-            const webLaunchMode = parsedStateString.options?.webLaunchMode;
-            if (!webLaunchMode) {
-                console.error('webLaunchMode not found in parsed state.');
-                return;
-            }
-            if (webLaunchMode != 'samePage') {
-                return;
-            }
-            const original_uri = parsedStateString.original_uri;
-            if (!original_uri) {
-                console.warn("it's preferred that original_uri is used when webLaunchMode is samePage.");
-                return;
-            }
-            window.location.assign(original_uri);
+        html,
+        body {
+            height: 100%;
+            margin: 0;
         }
 
-        function handleFrontChannelLogout() {
-            const queryParams = new URLSearchParams(window.location.search);
-            if (queryParams.get('requestType') == 'front-channel-logout') {
-                // For supported browsers: https://caniuse.com/broadcastchannel
-                var bc = new BroadcastChannel(requestBroadcastChannel);
-                bc.postMessage(window.location.toString());
-                bc.close();
-                // this puts a marker for the flutter app that the user wants to logout.
-                //
-                // in the flutter app, if this marker exists, 
-                // we don't auth the cached user in `UserManager.init()`, and we clear the cached data.
-                setLocalStorage(requestNamespace, 'front-channel-logout', window.location.toString());
-                return true;
-            }
-            return false;
+        body {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+            box-sizing: border-box;
+            font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+            line-height: 1.5;
         }
 
-        function getLocalStorage(namespace, key) {
-            const rawRes = localStorage.getItem('oidc.' + namespace + '.' + key);
-            if (!rawRes) {
-                return null;
-            }
-            return rawRes;
+        .oidc-card {
+            max-width: 32rem;
+            text-align: center;
         }
-        function setLocalStorage(namespace, key, value) {
-            const keysEntryKey = 'oidc.keys.' + namespace;
-            var keys = localStorage.getItem(keysEntryKey);
-            if (!keys) {
-                keys = "[]";
-            }
-            const parsedKeys = JSON.parse(keys);
-            if (!(parsedKeys instanceof Array)) {
-                console.error('parsedKeys is not an array.', parsedKeys);
-            }
-            parsedKeys.push(key);
-            localStorage.setItem(keysEntryKey, JSON.stringify(parsedKeys));
-            localStorage.setItem('oidc.' + namespace + '.' + key, value);
+
+        .oidc-card h3 {
+            margin: 0 0 0.5rem;
+            font-weight: 600;
         }
-    </script>
+
+        .oidc-card p {
+            margin: 0.25rem 0;
+            opacity: 0.85;
+        }
+
+        .oidc-card[data-state="error"] h3 {
+            color: #c0392b;
+        }
+    </style>
 </head>
 
 <body>
-    <h3>Operation Successful! Please close this page.</h3>
+    <main class="oidc-card" id="oidc-card" role="status" aria-live="polite">
+        <h3 id="oidc-title">Completing your request...</h3>
+        <p id="oidc-detail"></p>
+        <p id="oidc-error-uri" hidden></p>
+    </main>
+
+    <script type="text/javascript">
+        (function () {
+            'use strict';
+
+            // --- protocol / storage constants (keep in sync with the plugin) ---
+            const WIRE_VERSION = 2;
+            const requestBroadcastChannel = 'oidc_flutter_web/request';
+            const redirectBroadcastChannel = 'oidc_flutter_web/redirect';
+            const stateNamespace = 'state';
+            const stateResponseNamespace = 'response.state';
+            const requestNamespace = 'request';
+
+            // How long to wait for the app's ack before falling back to a
+            // neutral "return to the app" state. Covers older app versions that
+            // never ack.
+            const ACK_TIMEOUT_MS = 10000;
+
+            // --- user-visible copy (localize here) ---
+            const messages = {
+                working: 'Completing your request...',
+                redirecting: 'Redirecting...',
+                success: 'All done. You can now close this tab and return to the app.',
+                loggedOut: 'You have been signed out. You can now close this tab and return to the app.',
+                safeToClose: 'You can now close this tab and return to the app.',
+                errorTitle: 'Something went wrong',
+                appError: 'The request could not be completed. Please return to the app and try again.',
+                noChannel: 'Your browser does not support cross-tab messaging. Please return to the app; it will continue automatically.',
+            };
+
+            const channelSupported = typeof BroadcastChannel !== 'undefined';
+
+            // Front-channel logout takes precedence; otherwise handle a redirect.
+            if (!handleFrontChannelLogout()) {
+                handleRedirect();
+            }
+
+            // --- redirect (redirect_uri / post_logout_redirect_uri) ---
+            function handleRedirect() {
+                render('status', messages.working, '');
+
+                const errorInfo = parseError();
+                let bc = null;
+                let settled = false;
+                let timer = null;
+
+                function finish(state, title, detail, errorUri, close) {
+                    if (settled) {
+                        return;
+                    }
+                    settled = true;
+                    if (timer !== null) {
+                        clearTimeout(timer);
+                    }
+                    if (bc) {
+                        try { bc.close(); } catch (e) { /* ignore */ }
+                    }
+                    render(state, title, detail, errorUri);
+                    if (close) {
+                        attemptClose();
+                    }
+                }
+
+                // Open the channel BEFORE posting so an immediate ack isn't
+                // missed; a BroadcastChannel never receives its own messages, so
+                // our own "redirect" post won't come back to us.
+                if (channelSupported) {
+                    try {
+                        bc = new BroadcastChannel(redirectBroadcastChannel);
+                        bc.onmessage = function (event) {
+                            let msg;
+                            try { msg = JSON.parse(event.data); } catch (e) { return; }
+                            if (!msg || msg.v !== WIRE_VERSION || msg.type !== 'ack') {
+                                return;
+                            }
+                            if (msg.status === 'ok') {
+                                finish('status', messages.success, '', null, true);
+                            } else {
+                                finish('error', messages.errorTitle, msg.message || messages.appError, null, false);
+                            }
+                        };
+                        bc.postMessage(JSON.stringify({
+                            v: WIRE_VERSION,
+                            type: 'redirect',
+                            uri: window.location.toString(),
+                        }));
+                    } catch (e) {
+                        bc = null;
+                    }
+                }
+
+                // If this is a same-page launch, the SPA is navigated back to
+                // its original url and reads the response from storage; the page
+                // unloads, so there is no ack to await.
+                if (maybeSelfNavigate()) {
+                    if (timer !== null) {
+                        clearTimeout(timer);
+                    }
+                    render('status', messages.redirecting, '');
+                    return;
+                }
+
+                // The OP returned an error in the url (RFC 6749 sec 4.1.2.1): show
+                // it immediately, we already know the outcome.
+                if (errorInfo) {
+                    finish('error', messages.errorTitle, errorInfo.description || errorInfo.error, errorInfo.uri, true);
+                    return;
+                }
+
+                if (!bc) {
+                    // No channel: nothing to await, surface a neutral state.
+                    render('status', messages.working, messages.noChannel);
+                    attemptClose();
+                    return;
+                }
+
+                // Await the app's ack, with a timeout for old app versions.
+                timer = setTimeout(function () {
+                    finish('status', messages.safeToClose, '', null, true);
+                }, ACK_TIMEOUT_MS);
+            }
+
+            // --- front-channel logout (frontchannel_logout_uri) ---
+            function handleFrontChannelLogout() {
+                const queryParams = new URLSearchParams(window.location.search);
+                if (queryParams.get('requestType') !== 'front-channel-logout') {
+                    return false;
+                }
+                if (channelSupported) {
+                    try {
+                        // Legacy plain-string wire: the front-channel listener
+                        // consumes a bare url.
+                        const bc = new BroadcastChannel(requestBroadcastChannel);
+                        bc.postMessage(window.location.toString());
+                        bc.close();
+                    } catch (e) { /* ignore */ }
+                }
+                // Marker for the flutter app: if this exists we don't auth the
+                // cached user in `UserManager.init()`, and we clear cached data.
+                setLocalStorage(requestNamespace, 'front-channel-logout', window.location.toString());
+                render('status', messages.loggedOut, '');
+                attemptClose();
+                return true;
+            }
+
+            // Handles the same-page launch mode: stores the response for the app
+            // and, when webLaunchMode == samePage, navigates back to the
+            // original url. Returns true if it navigated the page away.
+            function maybeSelfNavigate() {
+                let dataSrc = new URLSearchParams(window.location.search);
+                let state = dataSrc.get('state');
+                if (!state && window.location.hash) {
+                    dataSrc = new URLSearchParams(window.location.hash.substring(1));
+                    state = dataSrc.get('state');
+                }
+                if (!state) {
+                    return false;
+                }
+                const stateDataRaw = getLocalStorage(stateNamespace, state);
+                if (!stateDataRaw) {
+                    console.error('state not found, key: ' + state);
+                    return false;
+                }
+                setLocalStorage(stateResponseNamespace, state, window.location.toString());
+                const parsedStateString = JSON.parse(stateDataRaw);
+                if (!parsedStateString) {
+                    console.error('parsed state is null');
+                    return false;
+                }
+                const webLaunchMode = parsedStateString.options?.webLaunchMode;
+                if (webLaunchMode !== 'samePage') {
+                    return false;
+                }
+                const original_uri = parsedStateString.original_uri;
+                if (!original_uri) {
+                    console.warn("it's preferred that original_uri is used when webLaunchMode is samePage.");
+                    return false;
+                }
+                window.location.assign(original_uri);
+                return true;
+            }
+
+            // Parses error/error_description/error_uri from both the query and
+            // the fragment (RFC 6749 sec 4.1.2.1). Returns null when there is none.
+            function parseError() {
+                function read(params) {
+                    const error = params.get('error');
+                    if (!error) {
+                        return null;
+                    }
+                    return {
+                        error: error,
+                        description: params.get('error_description'),
+                        uri: params.get('error_uri'),
+                    };
+                }
+                const fromQuery = read(new URLSearchParams(window.location.search));
+                if (fromQuery) {
+                    return fromQuery;
+                }
+                if (window.location.hash) {
+                    return read(new URLSearchParams(window.location.hash.substring(1)));
+                }
+                return null;
+            }
+
+            // Best-effort close. Only works for tabs the script itself opened
+            // (newPage / popup); for email-link orphan tabs it's a silent no-op,
+            // so the visible copy always tells the user they may close manually.
+            function attemptClose() {
+                try { window.close(); } catch (e) { /* ignore */ }
+            }
+
+            // Renders a state. `title`/`detail` are set with textContent so the
+            // attacker-influenced error params can never inject markup.
+            function render(state, title, detail, errorUri) {
+                const card = document.getElementById('oidc-card');
+                const titleEl = document.getElementById('oidc-title');
+                const detailEl = document.getElementById('oidc-detail');
+                const errUriEl = document.getElementById('oidc-error-uri');
+                if (card) {
+                    card.setAttribute('data-state', state);
+                }
+                if (titleEl) {
+                    titleEl.textContent = title || '';
+                }
+                if (detailEl) {
+                    detailEl.textContent = detail || '';
+                }
+                if (!errUriEl) {
+                    return;
+                }
+                // Only render http(s) error_uri values, and as text/link only.
+                if (errorUri && /^https?:\/\//i.test(errorUri)) {
+                    errUriEl.textContent = '';
+                    const a = document.createElement('a');
+                    a.href = errorUri;
+                    a.textContent = errorUri;
+                    a.rel = 'noopener noreferrer';
+                    errUriEl.appendChild(a);
+                    errUriEl.hidden = false;
+                } else if (errorUri) {
+                    errUriEl.textContent = errorUri;
+                    errUriEl.hidden = false;
+                } else {
+                    errUriEl.textContent = '';
+                    errUriEl.hidden = true;
+                }
+            }
+
+            function getLocalStorage(namespace, key) {
+                const rawRes = localStorage.getItem('oidc.' + namespace + '.' + key);
+                if (!rawRes) {
+                    return null;
+                }
+                return rawRes;
+            }
+
+            function setLocalStorage(namespace, key, value) {
+                const keysEntryKey = 'oidc.keys.' + namespace;
+                var keys = localStorage.getItem(keysEntryKey);
+                if (!keys) {
+                    keys = "[]";
+                }
+                const parsedKeys = JSON.parse(keys);
+                if (!(parsedKeys instanceof Array)) {
+                    console.error('parsedKeys is not an array.', parsedKeys);
+                }
+                parsedKeys.push(key);
+                localStorage.setItem(keysEntryKey, JSON.stringify(parsedKeys));
+                localStorage.setItem('oidc.' + namespace + '.' + key, value);
+            }
+        })();
+    </script>
 </body>
 
 </html>

--- a/packages/oidc_web_core/lib/src/oidc_web_core.dart
+++ b/packages/oidc_web_core/lib/src/oidc_web_core.dart
@@ -1,5 +1,6 @@
 //cspell: disable
 import 'dart:async';
+import 'dart:convert';
 import 'dart:js_interop';
 
 import 'package:collection/collection.dart';
@@ -15,6 +16,70 @@ class OidcWebCore {
   const OidcWebCore();
 
   static const _windowCloseCheckInterval = Duration(milliseconds: 250);
+
+  /// Version of the structured redirect wire protocol understood by this
+  /// consumer and emitted by the bundled `redirect.html` template.
+  ///
+  /// See `docs/oidc_web_core.md` ("How the page talks to the app") for the full
+  /// message shapes.
+  static const _redirectWireVersion = 2;
+
+  /// Extracts the response URI from a message posted on the redirect
+  /// [BroadcastChannel].
+  ///
+  /// Accepts both wire formats, so an existing (older) copy of `redirect.html`
+  /// keeps working after the package is upgraded:
+  ///  * the structured v2 envelope emitted by the current template —
+  ///    `{"v":2,"type":"redirect","uri":"<full redirect url>"}`, and
+  ///  * a bare redirect URL string emitted by older copied templates.
+  ///
+  /// Returns `null` for anything else — including the app's own `ack` envelope
+  /// (see [_postRedirectAck]) echoed back on the channel — so the caller
+  /// ignores it.
+  static String? _extractRedirectUri(String raw) {
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      // Not JSON -> a legacy plain redirect URL string.
+      return raw;
+    }
+    if (decoded is Map &&
+        decoded['v'] == _redirectWireVersion &&
+        decoded['type'] == 'redirect') {
+      final uri = decoded['uri'];
+      return uri is String ? uri : null;
+    }
+    // Valid JSON, but not a v2 redirect envelope (e.g. an `ack`).
+    return null;
+  }
+
+  /// Posts the app-side acknowledgement of a processed redirect back on the
+  /// redirect [BroadcastChannel], so the `redirect.html` template can render a
+  /// truthful terminal state (success vs. failure) instead of the hardcoded
+  /// "Operation Successful" it used to show (#116).
+  ///
+  /// Emits `{"v":2,"type":"ack","status":"ok"|"error","message":<string?>}`.
+  /// A fresh channel is opened for the post because the receiving channel used
+  /// during the flow is already torn down by the time processing finishes.
+  static void _postRedirectAck(
+    String broadcastChannel, {
+    required bool ok,
+    String? message,
+  }) {
+    final channel = BroadcastChannel(broadcastChannel);
+    try {
+      final payload = <String, Object?>{
+        'v': _redirectWireVersion,
+        'type': 'ack',
+        'status': ok ? 'ok' : 'error',
+        if (message != null) 'message': message,
+      };
+      channel.postMessage(jsonEncode(payload).toJS);
+    } finally {
+      channel.close();
+    }
+  }
 
   String _calculatePopupOptions(OidcPlatformSpecificOptions_Web options) {
     final h = options.popupHeight;
@@ -74,7 +139,11 @@ class OidcWebCore {
       if (!data.isA<JSString>()) {
         return;
       }
-      final parsed = Uri.tryParse((data! as JSString).toDart);
+      final uriString = _extractRedirectUri((data! as JSString).toDart);
+      if (uriString == null) {
+        return;
+      }
+      final parsed = Uri.tryParse(uriString);
       if (parsed == null) {
         return;
       }
@@ -225,10 +294,27 @@ class OidcWebCore {
     if (respUri == null) {
       return null;
     }
-    return OidcEndpoints.parseAuthorizeResponse(
-      responseUri: respUri,
-      responseMode: request.responseMode,
-    );
+    try {
+      final response = await OidcEndpoints.parseAuthorizeResponse(
+        responseUri: respUri,
+        responseMode: request.responseMode,
+      );
+      // Structured wire v2 (#116): acknowledge that the app accepted the
+      // response, so `redirect.html` renders success only after the app-side
+      // processing actually succeeded — not unconditionally.
+      _postRedirectAck(options.broadcastChannel, ok: true);
+      return response;
+    } on Object {
+      // The response was delivered but couldn't be processed — an OP error
+      // redirect (RFC 6749 §4.1.2.1), a JARM/`iss` failure, etc. Tell the page
+      // to render an error state instead of success, then surface the failure.
+      _postRedirectAck(
+        options.broadcastChannel,
+        ok: false,
+        message: 'Sign-in could not be completed.',
+      );
+      rethrow;
+    }
   }
 
   /// Returns the end session response for an RP initiated logout request.
@@ -255,6 +341,9 @@ class OidcWebCore {
     if (respUri == null) {
       return null;
     }
+    // Structured wire v2: acknowledge the processed logout redirect so the page
+    // can render a truthful terminal state.
+    _postRedirectAck(options.broadcastChannel, ok: true);
     return OidcEndSessionResponse.fromJson(respUri.queryParameters);
   }
 

--- a/packages/oidc_web_core/test/redirect_wire_test.dart
+++ b/packages/oidc_web_core/test/redirect_wire_test.dart
@@ -1,0 +1,292 @@
+@TestOn('js')
+library;
+
+// ignore_for_file: prefer_const_constructors
+
+import 'dart:convert';
+import 'dart:js_interop';
+
+import 'package:oidc_core/oidc_core.dart';
+import 'package:oidc_web_core/oidc_web_core.dart';
+import 'package:test/test.dart';
+import 'package:web/web.dart' as web;
+
+// Exercises the structured redirect wire v2 protocol between the app-side
+// consumer in `lib/src/oidc_web_core.dart` and the bundled `redirect.html`
+// template:
+//
+//  * the page posts `{"v":2,"type":"redirect","uri":...}` (v2) OR a bare
+//    redirect URL string (legacy) on the redirect BroadcastChannel, and
+//  * after processing, the app posts
+//    `{"v":2,"type":"ack","status":"ok"|"error","message":<string?>}` back.
+//
+// These run in a real browser (`dart test -p chrome`) because they use the
+// browser's BroadcastChannel via `package:web`.
+
+OidcProviderMetadata _authMetadata() => OidcProviderMetadata.fromJson(const {
+  'issuer': 'https://op.example.com',
+  'authorization_endpoint': 'https://op.example.com/authorize',
+  'token_endpoint': 'https://op.example.com/token',
+});
+
+OidcAuthorizeRequest _authRequest({String? state}) => OidcAuthorizeRequest(
+  responseType: const ['code'],
+  clientId: 'client-1',
+  redirectUri: Uri.parse('https://app.example.com/cb'),
+  scope: const ['openid'],
+  state: state,
+  // 'none' so the hiddenIFrame navigation mode is permitted (no user
+  // interaction), letting the test post the response on the channel directly.
+  prompt: const ['none'],
+);
+
+/// A hidden-iframe options bag on [channelName]; hiddenIFrame lets the flow be
+/// driven purely over the BroadcastChannel with no prepared window.
+OidcPlatformSpecificOptions_Web _options(String channelName) =>
+    OidcPlatformSpecificOptions_Web(
+      navigationMode:
+          OidcPlatformSpecificOptions_Web_NavigationMode.hiddenIFrame,
+      broadcastChannel: channelName,
+    );
+
+/// Opens a channel that records every message posted on [channelName] as a
+/// decoded JSON map (non-JSON / non-map messages are dropped). Used to observe
+/// the app-side `ack`.
+({List<Map<String, Object?>> messages, web.BroadcastChannel channel}) _sink(
+  String channelName,
+) {
+  final messages = <Map<String, Object?>>[];
+  final channel = web.BroadcastChannel(channelName)
+    ..onmessage = ((web.MessageEvent event) {
+      final data = event.data;
+      if (!data.isA<JSString>()) {
+        return;
+      }
+      Object? decoded;
+      try {
+        decoded = jsonDecode((data! as JSString).toDart);
+      } on FormatException {
+        return;
+      }
+      if (decoded is Map<String, dynamic>) {
+        messages.add(decoded);
+      }
+    }).toJS;
+  return (messages: messages, channel: channel);
+}
+
+List<Map<String, Object?>> _acks(List<Map<String, Object?>> messages) =>
+    messages.where((m) => m['type'] == 'ack').toList();
+
+void main() {
+  const core = OidcWebCore();
+
+  group('redirect wire v2 — consumer accepts both formats', () {
+    test('accepts the structured v2 redirect envelope', () async {
+      const channelName = 'wire-accept-v2';
+      final options = _options(channelName);
+
+      final future = core.getAuthorizationResponse(
+        _authMetadata(),
+        _authRequest(state: 'st-v2'),
+        options,
+        const {},
+      );
+      // Let `_getResponseUri` attach `channel.onmessage` before we post.
+      await Future<void>.delayed(Duration.zero);
+
+      final channel = web.BroadcastChannel(channelName);
+      // ignore: unnecessary_lambdas
+      addTearDown(() => channel.close());
+      channel.postMessage(
+        jsonEncode({
+          'v': 2,
+          'type': 'redirect',
+          'uri': 'https://app.example.com/cb?state=st-v2&code=code-v2',
+        }).toJS,
+      );
+
+      final resp = await future.timeout(const Duration(seconds: 8));
+      expect(resp, isNotNull);
+      expect(resp!.code, 'code-v2');
+      expect(resp.state, 'st-v2');
+    });
+
+    test('accepts a legacy bare redirect URL string', () async {
+      const channelName = 'wire-accept-legacy';
+      final options = _options(channelName);
+
+      final future = core.getAuthorizationResponse(
+        _authMetadata(),
+        _authRequest(state: 'st-legacy'),
+        options,
+        const {},
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final channel = web.BroadcastChannel(channelName);
+      // ignore: unnecessary_lambdas
+      addTearDown(() => channel.close());
+      channel.postMessage(
+        'https://app.example.com/cb?state=st-legacy&code=code-legacy'.toJS,
+      );
+
+      final resp = await future.timeout(const Duration(seconds: 8));
+      expect(resp, isNotNull);
+      expect(resp!.code, 'code-legacy');
+      expect(resp.state, 'st-legacy');
+    });
+
+    test('ignores a v2 envelope whose type is not "redirect" (e.g. an ack '
+        'echoed on the channel), then resolves on the real redirect', () async {
+      const channelName = 'wire-ignore-nonredirect';
+      final options = _options(channelName);
+
+      final future = core.getAuthorizationResponse(
+        _authMetadata(),
+        _authRequest(state: 'st-ignore'),
+        options,
+        const {},
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final channel = web.BroadcastChannel(channelName);
+      // ignore: unnecessary_lambdas
+      addTearDown(() => channel.close());
+      channel
+        // An ack envelope must not be mistaken for a redirect.
+        ..postMessage(jsonEncode({'v': 2, 'type': 'ack', 'status': 'ok'}).toJS)
+        // A v2 redirect envelope missing its `uri` must be ignored.
+        ..postMessage(jsonEncode({'v': 2, 'type': 'redirect'}).toJS)
+        // The real redirect.
+        ..postMessage(
+          jsonEncode({
+            'v': 2,
+            'type': 'redirect',
+            'uri': 'https://app.example.com/cb?state=st-ignore&code=real',
+          }).toJS,
+        );
+
+      final resp = await future.timeout(const Duration(seconds: 8));
+      expect(resp, isNotNull);
+      expect(resp!.code, 'real');
+    });
+  });
+
+  group('redirect wire v2 — app posts an ack', () {
+    test('posts an ok ack after a successful authorize response', () async {
+      const channelName = 'wire-ack-ok';
+      final options = _options(channelName);
+
+      final sink = _sink(channelName);
+      // `close` is an external interop member and can't be torn off.
+      // ignore: unnecessary_lambdas
+      addTearDown(() => sink.channel.close());
+
+      final future = core.getAuthorizationResponse(
+        _authMetadata(),
+        _authRequest(state: 'st-ok'),
+        options,
+        const {},
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      sink.channel.postMessage(
+        jsonEncode({
+          'v': 2,
+          'type': 'redirect',
+          'uri': 'https://app.example.com/cb?state=st-ok&code=ok-code',
+        }).toJS,
+      );
+
+      final resp = await future.timeout(const Duration(seconds: 8));
+      expect(resp, isNotNull);
+      expect(resp!.code, 'ok-code');
+
+      // Give the ack MessageEvent a turn to be delivered to the sink.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      final acks = _acks(sink.messages);
+      expect(acks, isNotEmpty, reason: 'expected an ack to be posted');
+      expect(acks.last['v'], 2);
+      expect(acks.last['status'], 'ok');
+    });
+
+    test('posts an error ack (and rethrows) when the response is an OP error '
+        'redirect per RFC 6749 §4.1.2.1', () async {
+      const channelName = 'wire-ack-error';
+      final options = _options(channelName);
+
+      final sink = _sink(channelName);
+      // `close` is an external interop member and can't be torn off.
+      // ignore: unnecessary_lambdas
+      addTearDown(() => sink.channel.close());
+
+      final future = core.getAuthorizationResponse(
+        _authMetadata(),
+        _authRequest(state: 'st-err'),
+        options,
+        const {},
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      sink.channel.postMessage(
+        jsonEncode({
+          'v': 2,
+          'type': 'redirect',
+          'uri':
+              'https://app.example.com/cb?state=st-err'
+              '&error=access_denied&error_description=user+said+no',
+        }).toJS,
+      );
+
+      await expectLater(
+        future.timeout(const Duration(seconds: 8)),
+        throwsA(isA<OidcException>()),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      final acks = _acks(sink.messages);
+      expect(acks, isNotEmpty, reason: 'expected an ack to be posted');
+      expect(acks.last['status'], 'error');
+      expect(acks.last['message'], isA<String>());
+    });
+
+    test('posts an ok ack after a processed end-session response', () async {
+      const channelName = 'wire-ack-endsession';
+      final options = _options(channelName);
+
+      final sink = _sink(channelName);
+      // `close` is an external interop member and can't be torn off.
+      // ignore: unnecessary_lambdas
+      addTearDown(() => sink.channel.close());
+
+      final future = core.getEndSessionResponse(
+        OidcProviderMetadata.fromJson(const {
+          'issuer': 'https://op.example.com',
+          'end_session_endpoint': 'https://op.example.com/logout',
+        }),
+        const OidcEndSessionRequest(clientId: 'client-1', state: 'es-state'),
+        options,
+        const {},
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      sink.channel.postMessage(
+        jsonEncode({
+          'v': 2,
+          'type': 'redirect',
+          'uri': 'https://app.example.com/cb?state=es-state',
+        }).toJS,
+      );
+
+      final resp = await future.timeout(const Duration(seconds: 8));
+      expect(resp, isNotNull);
+      expect(resp!.state, 'es-state');
+
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      final acks = _acks(sink.messages);
+      expect(acks, isNotEmpty, reason: 'expected an ack to be posted');
+      expect(acks.last['status'], 'ok');
+    });
+  });
+}


### PR DESCRIPTION
Reworks the bundled web `redirect.html` and its app-side consumer so the page reflects the real outcome of a sign-in/logout instead of hardcoding "Operation Successful" (#116), handles email-link orphan tabs it can't close (#227), and documents the case where the `redirect_uri` never serves the page at all (#256).

Structured wire v2 (legacy-compatible). On load the page posts the incoming redirect to the app as a JSON envelope `{"v":2,"type":"redirect","uri":"<full redirect url>"}` on the existing BroadcastChannel. After the app processes it, the app posts an acknowledgement back: `{"v":2,"type":"ack","status":"ok"|"error","message":<string?>}`. The consumer (`OidcWebCore._getResponseUri`) now accepts both the v2 envelope and the legacy bare-URL string, so an older copied page keeps working after an upgrade; `getAuthorizationResponse` posts an `ok` ack on a parsed success and an `error` ack when parsing throws (an OP error redirect per RFC 6749 §4.1.2.1, a JARM/`iss` failure, …) then rethrows, and `getEndSessionResponse` posts an `ok` ack. The ack is posted on a fresh channel because the receiving channel is torn down by the time processing finishes.

Parse-first, state-driven page. The template reads `error`/`error_description`/`error_uri` from both the query and the fragment and renders an error state directly; otherwise it shows success only after an `ok` ack, an app-error on an `error` ack, and a neutral "you can now close this tab" fallback when no ack arrives within ~10s (older app versions that never ack) or when `window.close()` is a no-op for a tab the script didn't open (#227). Front-channel logout (unchanged bare-URL wire on the request channel) and same-page self-navigation keep distinct states, there's a graceful message when BroadcastChannel is unsupported, and error text is rendered via `textContent` so attacker-influenced params can't inject markup. All user-visible copy sits in one `messages` object for translation. Both example copies (`packages/oidc/example/web/redirect.html` and `packages/oidc_web_core/example/web/redirect.html`) are byte-identical.

Docs. `docs/oidc_web_core.md` and `docs/oidc-getting-started.md` gain a "How the page talks to the app" section, an upgrade note that `redirect.html` is copied (not shipped) and must be re-copied on upgrade, and a troubleshooting entry for a `redirect_uri` that never serves the page (e.g. a 502 at the proxy, #256).

Tests. `packages/oidc_web_core/test/redirect_wire_test.dart` (browser, `@TestOn('js')`, package:test + package:web BroadcastChannel, matching the existing flows test) covers v2-envelope accepted, legacy-string accepted, non-redirect/ack envelopes ignored, and `ok`/`error`/end-session acks emitted.

### Test evidence
- `redirect wire v2 — consumer accepts both formats > accepts the structured v2 redirect envelope`
- `redirect wire v2 — consumer accepts both formats > accepts a legacy bare redirect URL string`
- `redirect wire v2 — consumer accepts both formats > ignores a v2 envelope whose type is not "redirect" (e.g. an ack echoed on the channel), then resolves on the real redirect`
- `redirect wire v2 — app posts an ack > posts an ok ack after a successful authorize response`
- `redirect wire v2 — app posts an ack > posts an error ack (and rethrows) when the response is an OP error redirect per RFC 6749 §4.1.2.1`
- `redirect wire v2 — app posts an ack > posts an ok ack after a processed end-session response`

Gates re-ran green after rebasing onto post-1.0.0 main (full oidc_core/oidc_cli/oidc/oidc_default_store set plus package-specific suites; see commits).

Closes #116
Closes #227

Also adds the #256 troubleshooting docs (a 502 served at the redirect_uri is upstream of the page; the app-side flow timeout surfaces the abandonment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS
