### PR TITLE
feat(oidc_darwin): opt-in loopback/system-browser navigation mode for macOS (RFC 8252 §7.3)

### DIFF
--- a/packages/oidc_core/lib/src/models/settings/platform_options.dart
+++ b/packages/oidc_core/lib/src/models/settings/platform_options.dart
@@ -351,6 +351,31 @@ enum OidcAppleCallbackMode {
   https,
 }
 
+/// Selects how the macOS authorization / end-session flow reaches the OpenID
+/// Provider.
+///
+/// iOS ignores this setting — [asWebAuthenticationSession] is the only
+/// mechanism iOS supports (there is no iOS equivalent of opening the default
+/// system browser and binding a loopback listener).
+@JsonEnum()
+enum OidcAppleNavigationMode {
+  /// Default. Preserves the current behavior: the flow runs inside an in-app
+  /// [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession),
+  /// and the native side captures the redirect via the session callback.
+  asWebAuthenticationSession,
+
+  /// **macOS only.** Runs the flow WITHOUT `ASWebAuthenticationSession`:
+  /// opens the authorization URL in the user's default system browser
+  /// (`url_launcher`) and captures the redirect on an
+  /// [RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3)
+  /// loopback interface (`http://127.0.0.1:{port}`). A `redirect_uri` with
+  /// port `0` binds an ephemeral port that is written back into the
+  /// `redirect_uri` before launch, exactly like `oidc_desktop`.
+  ///
+  /// Ignored on iOS (falls back to [asWebAuthenticationSession]).
+  loopbackSystemBrowser,
+}
+
 /// iOS / macOS options for the first-party `ASWebAuthenticationSession` flow.
 @JsonSerializable()
 class OidcNativeOptionsApple implements OidcPlatformOptionsMarker {
@@ -361,6 +386,11 @@ class OidcNativeOptionsApple implements OidcPlatformOptionsMarker {
     this.callbackMode = OidcAppleCallbackMode.auto,
     this.rawSessionOptions = const {},
     this.flowTimeoutSeconds,
+    this.navigationMode = OidcAppleNavigationMode.asWebAuthenticationSession,
+    this.successfulPageResponse,
+    this.methodMismatchResponse,
+    this.notFoundResponse,
+    this.launchUrl,
   });
 
   /// Whether to use an ephemeral session (no shared cookies/cache).
@@ -388,8 +418,48 @@ class OidcNativeOptionsApple implements OidcPlatformOptionsMarker {
   /// flow and — on the iOS-26 / Xcode-26 simulator — the redirect may never
   /// auto-arrive), otherwise `loginAuthorizationCodeFlow()` hangs indefinitely.
   /// Mirrors [OidcNativeOptionsAndroid.flowTimeoutSeconds]; honored natively in
-  /// `oidc_darwin`'s `OidcPlugin.scheduleFlowTimeout`.
+  /// `oidc_darwin`'s `OidcPlugin.scheduleFlowTimeout`. On macOS with
+  /// [navigationMode] set to [OidcAppleNavigationMode.loopbackSystemBrowser],
+  /// it instead bounds the wait on the loopback listener (Dart-side).
   final int? flowTimeoutSeconds;
+
+  /// How the macOS flow reaches the OpenID Provider.
+  ///
+  /// Defaults to [OidcAppleNavigationMode.asWebAuthenticationSession] (current
+  /// behavior). Set to [OidcAppleNavigationMode.loopbackSystemBrowser] to run
+  /// the macOS flow in the default system browser with an RFC 8252 §7.3
+  /// loopback redirect. Ignored on iOS.
+  final OidcAppleNavigationMode navigationMode;
+
+  /// The HTML body returned to the browser when the loopback listener matches
+  /// the redirect (only used when [navigationMode] is
+  /// [OidcAppleNavigationMode.loopbackSystemBrowser]).
+  ///
+  /// Mirrors [OidcPlatformSpecificOptions_Native.successfulPageResponse].
+  final String? successfulPageResponse;
+
+  /// The HTML body returned to the browser when a method other than `GET` is
+  /// requested on the loopback listener (only used when [navigationMode] is
+  /// [OidcAppleNavigationMode.loopbackSystemBrowser]).
+  ///
+  /// Mirrors [OidcPlatformSpecificOptions_Native.methodMismatchResponse].
+  final String? methodMismatchResponse;
+
+  /// The HTML body returned to the browser when a request hits a path other
+  /// than the redirect path on the loopback listener (only used when
+  /// [navigationMode] is [OidcAppleNavigationMode.loopbackSystemBrowser]).
+  ///
+  /// Mirrors [OidcPlatformSpecificOptions_Native.notFoundResponse].
+  final String? notFoundResponse;
+
+  /// Test seam: overrides the browser-launch mechanism for the
+  /// [OidcAppleNavigationMode.loopbackSystemBrowser] flow. When null (default),
+  /// `oidc_darwin` falls back to `package:url_launcher`.
+  ///
+  /// Mirrors [OidcPlatformSpecificOptions_Native.launchUrl]; excluded from JSON
+  /// since it is a Dart-only callback that never crosses the native boundary.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  final Future<bool> Function(Uri url)? launchUrl;
 
   Map<String, dynamic> toJson() => _$OidcNativeOptionsAppleToJson(this);
 

--- a/packages/oidc_core/lib/src/models/settings/platform_options.g.dart
+++ b/packages/oidc_core/lib/src/models/settings/platform_options.g.dart
@@ -239,6 +239,15 @@ OidcNativeOptionsApple _$OidcNativeOptionsAppleFromJson(
   rawSessionOptions:
       json['rawSessionOptions'] as Map<String, dynamic>? ?? const {},
   flowTimeoutSeconds: (json['flowTimeoutSeconds'] as num?)?.toInt(),
+  navigationMode:
+      $enumDecodeNullable(
+        _$OidcAppleNavigationModeEnumMap,
+        json['navigationMode'],
+      ) ??
+      OidcAppleNavigationMode.asWebAuthenticationSession,
+  successfulPageResponse: json['successfulPageResponse'] as String?,
+  methodMismatchResponse: json['methodMismatchResponse'] as String?,
+  notFoundResponse: json['notFoundResponse'] as String?,
 );
 
 Map<String, dynamic> _$OidcNativeOptionsAppleToJson(
@@ -250,12 +259,22 @@ Map<String, dynamic> _$OidcNativeOptionsAppleToJson(
   'callbackMode': _$OidcAppleCallbackModeEnumMap[instance.callbackMode]!,
   'rawSessionOptions': instance.rawSessionOptions,
   'flowTimeoutSeconds': instance.flowTimeoutSeconds,
+  'navigationMode': _$OidcAppleNavigationModeEnumMap[instance.navigationMode]!,
+  'successfulPageResponse': instance.successfulPageResponse,
+  'methodMismatchResponse': instance.methodMismatchResponse,
+  'notFoundResponse': instance.notFoundResponse,
 };
 
 const _$OidcAppleCallbackModeEnumMap = {
   OidcAppleCallbackMode.auto: 'auto',
   OidcAppleCallbackMode.customScheme: 'customScheme',
   OidcAppleCallbackMode.https: 'https',
+};
+
+const _$OidcAppleNavigationModeEnumMap = {
+  OidcAppleNavigationMode.asWebAuthenticationSession:
+      'asWebAuthenticationSession',
+  OidcAppleNavigationMode.loopbackSystemBrowser: 'loopbackSystemBrowser',
 };
 
 OidcPlatformSpecificOptions_Native _$OidcPlatformSpecificOptions_NativeFromJson(

--- a/packages/oidc_darwin/README.md
+++ b/packages/oidc_darwin/README.md
@@ -25,6 +25,77 @@ observability events.
 - iOS 17.4+ / macOS 14.4+ additionally support `https` (Universal-Link)
   callbacks and `additionalHeaderFields`.
 
+## macOS: external-browser (loopback) navigation mode
+
+By default both platforms run the flow inside an in-app
+`ASWebAuthenticationSession`. On **macOS only**, you can opt into running the
+flow in the user's default system browser instead, capturing the redirect on an
+[RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3)
+loopback interface — the same transport `oidc_desktop` uses on Windows/Linux.
+This is useful when you want the login to happen in the user's real browser
+(shared session cookies, password managers, extensions) rather than the
+isolated `ASWebAuthenticationSession` web view.
+
+Enable it via `OidcPlatformSpecificOptions.macos`:
+
+```dart
+const OidcPlatformSpecificOptions(
+  macos: OidcNativeOptionsApple(
+    navigationMode: OidcAppleNavigationMode.loopbackSystemBrowser,
+    // Optional: bound the wait so an abandoned flow does not hang forever.
+    flowTimeoutSeconds: 300,
+    // Optional: HTML shown in the browser tab after a successful redirect.
+    successfulPageResponse: '<html><body>You may return to the app.</body></html>',
+  ),
+)
+```
+
+When this mode is selected on macOS:
+
+- The authorization URL is opened in the default browser via `url_launcher`.
+- A loopback HTTP listener binds `http://127.0.0.1:{port}`. Use a
+  `redirect_uri` of `http://127.0.0.1:0` to bind an ephemeral free port — the
+  actual port is written back into the `redirect_uri` before the browser is
+  launched (identical to `oidc_desktop`).
+- The wait for the redirect is bounded by `flowTimeoutSeconds` (a
+  `TimeoutException` surfaces as an `OidcException`).
+
+**iOS ignores this setting** — `ASWebAuthenticationSession` remains the only iOS
+mechanism (there is no iOS equivalent of opening the default system browser and
+binding a loopback interface). The `.ios` field's `navigationMode` is not
+consulted.
+
+### Redirect URI registration
+
+Register a loopback redirect URI of the form `http://127.0.0.1:{port}` (path
+optional, e.g. `http://127.0.0.1:0/callback`) with your OpenID Provider. Most
+providers that follow RFC 8252 allow any port for a `127.0.0.1` loopback
+redirect, so registering the literal `http://127.0.0.1` (or with a fixed path)
+is typically sufficient even when an ephemeral port is used at runtime.
+
+### App Sandbox entitlements
+
+A sandboxed macOS app must be allowed to bind the loopback listener and to make
+the outgoing browser/HTTP connections. Add both of these to your macOS app's
+`*.entitlements` files (`Runner/DebugProfile.entitlements` and
+`Runner/Release.entitlements`):
+
+```xml
+<key>com.apple.security.network.server</key>
+<true/>
+<key>com.apple.security.network.client</key>
+<true/>
+```
+
+`network.server` is required to accept the inbound loopback redirect;
+`network.client` is required to reach the OpenID Provider. Without them the App
+Sandbox blocks the loopback socket and the flow cannot complete.
+
+> **Note:** the exact entitlement requirement for binding a `127.0.0.1`
+> listener under the macOS App Sandbox has not been re-verified on-device for
+> this release; confirm against your target macOS version if you ship a
+> sandboxed build.
+
 ## Migrating from `oidc_ios` / `oidc_macos`
 
 Apps depending on the `oidc` umbrella need no changes. If you depended on

--- a/packages/oidc_darwin/lib/oidc_darwin.dart
+++ b/packages/oidc_darwin/lib/oidc_darwin.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:oidc_core/oidc_core.dart';
+import 'package:oidc_loopback_listener/oidc_loopback_listener.dart';
 import 'package:oidc_platform_interface/oidc_platform_interface.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// The iOS + macOS ("darwin") implementation of [OidcPlatform].
 ///
@@ -14,6 +17,15 @@ import 'package:oidc_platform_interface/oidc_platform_interface.dart';
 /// opens a URL and returns the redirect URI. This replaces the previous
 /// `flutter_appauth`-based path and merges the former `oidc_ios` + `oidc_macos`
 /// packages.
+///
+/// On **macOS**, when
+/// [OidcNativeOptionsApple.navigationMode] is
+/// [OidcAppleNavigationMode.loopbackSystemBrowser], the flow instead skips
+/// `ASWebAuthenticationSession` entirely: it opens the authorization URL in the
+/// user's default system browser (`url_launcher`) and captures the redirect on
+/// an [RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3)
+/// loopback listener (`http://127.0.0.1:{port}`), reusing the same
+/// `oidc_loopback_listener` transport as `oidc_desktop`. iOS ignores the mode.
 class OidcDarwin extends OidcPlatform {
   /// Creates the darwin platform implementation.
   ///
@@ -52,6 +64,18 @@ class OidcDarwin extends OidcPlatform {
   bool preferEphemeral(OidcPlatformSpecificOptions options) =>
       _appleOptions(options).prefersEphemeralWebBrowserSession;
 
+  /// Whether the current flow should run through the default system browser +
+  /// loopback listener instead of `ASWebAuthenticationSession`.
+  ///
+  /// Only honored on macOS; iOS always uses `ASWebAuthenticationSession`
+  /// (there is no iOS equivalent of opening the default system browser and
+  /// binding a loopback interface).
+  @visibleForTesting
+  bool useLoopbackSystemBrowser(OidcPlatformSpecificOptions options) =>
+      defaultTargetPlatform == TargetPlatform.macOS &&
+      _appleOptions(options).navigationMode ==
+          OidcAppleNavigationMode.loopbackSystemBrowser;
+
   @override
   Map<String, dynamic> prepareForRedirectFlow(
     OidcPlatformSpecificOptions options,
@@ -68,6 +92,28 @@ class OidcDarwin extends OidcPlatform {
     if (authorizationEndpoint == null) {
       throw const OidcException(
         "The OpenId Provider doesn't provide an `authorization_endpoint`.",
+      );
+    }
+    if (useLoopbackSystemBrowser(options)) {
+      final redirectUriCompleter = Completer<Uri>();
+      final responseUri = await _startLoopbackListenerAndGetUri(
+        originalRedirectUri: request.redirectUri,
+        redirectUriKey: OidcConstants_AuthParameters.redirectUri,
+        appleOptions: _appleOptions(options),
+        endpoint: authorizationEndpoint,
+        requestParameters: request.toMap(),
+        logRequestDesc: 'authorization',
+        actualRedirectUriCompleter: redirectUriCompleter,
+      );
+      if (responseUri == null) {
+        return null;
+      }
+      return OidcEndpoints.parseAuthorizeResponse(
+        responseUri: responseUri,
+        overrides: {
+          OidcConstants_AuthParameters.redirectUri:
+              (await redirectUriCompleter.future).toString(),
+        },
       );
     }
     final url = request.generateUri(authorizationEndpoint);
@@ -109,8 +155,30 @@ class OidcDarwin extends OidcPlatform {
         "The OpenId Provider doesn't provide an `end_session_endpoint`.",
       );
     }
-    final url = request.generateUri(endSessionEndpoint);
     final postLogout = request.postLogoutRedirectUri;
+    if (useLoopbackSystemBrowser(options)) {
+      // With no post-logout redirect there is nothing to capture on the
+      // loopback listener, so there is no browser round-trip to await
+      // (mirrors `oidc_desktop`).
+      if (postLogout == null) {
+        return null;
+      }
+      final redirectUriCompleter = Completer<Uri>();
+      final responseUri = await _startLoopbackListenerAndGetUri(
+        originalRedirectUri: postLogout,
+        redirectUriKey: OidcConstants_AuthParameters.postLogoutRedirectUri,
+        appleOptions: _appleOptions(options),
+        endpoint: endSessionEndpoint,
+        requestParameters: request.toMap(),
+        logRequestDesc: 'end session',
+        actualRedirectUriCompleter: redirectUriCompleter,
+      );
+      if (responseUri == null) {
+        return null;
+      }
+      return OidcEndSessionResponse.fromJson(responseUri.queryParameters);
+    }
+    final url = request.generateUri(endSessionEndpoint);
     final responseUrl = await _guard(
       OidcNativeMethods.endSession,
       () => _hostApi.endSessionApple(
@@ -127,6 +195,101 @@ class OidcDarwin extends OidcPlatform {
     return OidcEndSessionResponse.fromJson(
       Uri.parse(responseUrl).queryParameters,
     );
+  }
+
+  /// Runs the macOS default-system-browser + loopback flow and returns the
+  /// captured redirect [Uri] (or `null` when the flow ends without one).
+  ///
+  /// Mirrors `oidc_desktop`'s loopback orchestration: bind an
+  /// [OidcLoopbackListener] on the redirect's host/port (port `0` binds an
+  /// ephemeral port), rewrite `[originalRedirectUri]`'s port to the bound one,
+  /// build the provider URL with that redirect, open it in the default browser,
+  /// then await the single loopback redirect bounded by
+  /// [OidcNativeOptionsApple.flowTimeoutSeconds].
+  ///
+  /// The actual (port-rewritten) redirect URI is published through
+  /// [actualRedirectUriCompleter] so the caller can pass it as the
+  /// `redirect_uri` override when parsing the response.
+  Future<Uri?> _startLoopbackListenerAndGetUri({
+    required Uri originalRedirectUri,
+    required String redirectUriKey,
+    required OidcNativeOptionsApple appleOptions,
+    required Uri endpoint,
+    required Map<String, dynamic> requestParameters,
+    required String logRequestDesc,
+    required Completer<Uri> actualRedirectUriCompleter,
+  }) async {
+    final listener = OidcLoopbackListener(
+      path: originalRedirectUri.path,
+      port: originalRedirectUri.port,
+      successfulPageResponse: appleOptions.successfulPageResponse,
+      methodMismatchResponse: appleOptions.methodMismatchResponse,
+      notFoundResponse: appleOptions.notFoundResponse,
+    );
+    final serverCompleter = Completer<HttpServer>();
+    final ts = appleOptions.flowTimeoutSeconds;
+    final timeout = (ts != null && ts > 0) ? Duration(seconds: ts) : null;
+    // Don't await the response future until after the url is launched.
+    final responseUriFuture = listener.listenForSingleResponse(
+      serverCompleter: serverCompleter,
+      timeout: timeout,
+    );
+    // Wait until the server starts listening and we get a (possibly ephemeral)
+    // port.
+    final server = await serverCompleter.future;
+    var redirectUri = originalRedirectUri;
+    if (server.port != redirectUri.port) {
+      // Replace the port in the redirectUri with the actual bound port.
+      redirectUri = redirectUri.replace(port: server.port);
+    }
+    actualRedirectUriCompleter.complete(redirectUri);
+    final uri = endpoint.replace(
+      queryParameters: {
+        ...endpoint.queryParameters,
+        // ignore: invalid_use_of_internal_member
+        ...OidcInternalUtilities.serializeQueryParameters(requestParameters),
+        // Override the redirect uri with the port-rewritten loopback address.
+        redirectUriKey: redirectUri.toString(),
+      },
+    );
+
+    final didLaunch = await _launchLoopbackUrl(uri, appleOptions: appleOptions);
+    if (!didLaunch) {
+      debugPrint(
+        'oidc_darwin: failed to launch the $logRequestDesc request url: $uri',
+      );
+    }
+    // Wait for a response from the loopback listener.
+    final Uri? responseUri;
+    try {
+      responseUri = await responseUriFuture;
+    } on TimeoutException catch (e, st) {
+      throw OidcException(
+        'The $logRequestDesc flow timed out after $ts seconds without '
+        'receiving a redirect on the loopback listener.',
+        internalException: e,
+        internalStackTrace: st,
+      );
+    }
+    return responseUri;
+  }
+
+  /// Opens [uri] for the loopback flow.
+  ///
+  /// When [OidcNativeOptionsApple.launchUrl] is set (a test seam) it is used
+  /// verbatim; otherwise the default system browser is opened through
+  /// `package:url_launcher`.
+  Future<bool> _launchLoopbackUrl(
+    Uri uri, {
+    required OidcNativeOptionsApple appleOptions,
+  }) async {
+    if (appleOptions.launchUrl case final urlLauncher?) {
+      return urlLauncher(uri);
+    }
+    if (!await canLaunchUrl(uri)) {
+      debugPrint('oidc_darwin: might not be able to launch the url: $uri');
+    }
+    return launchUrl(uri);
   }
 
   /// Invokes a native [OidcAppleHostApi] call and normalizes its failure modes:

--- a/packages/oidc_darwin/pubspec.yaml
+++ b/packages/oidc_darwin/pubspec.yaml
@@ -29,7 +29,9 @@ dependencies:
   flutter:
     sdk: flutter
   oidc_core: ^1.0.0
+  oidc_loopback_listener: ^1.0.0
   oidc_platform_interface: ^1.0.0
+  url_launcher: ^6.1.14
 
 dev_dependencies:
   flutter_test:

--- a/packages/oidc_darwin/test/oidc_darwin_loopback_test.dart
+++ b/packages/oidc_darwin/test/oidc_darwin_loopback_test.dart
@@ -1,0 +1,329 @@
+// ignore_for_file: prefer_const_constructors
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:oidc_darwin/oidc_darwin.dart';
+
+// These tests exercise the macOS `loopbackSystemBrowser` navigation mode, which
+// runs entirely in Dart (system browser + `oidc_loopback_listener`) and never
+// touches the Pigeon native channel. They therefore deliberately DO NOT call
+// `TestWidgetsFlutterBinding.ensureInitialized()`: that binding installs an
+// `HttpOverrides` that fakes every `HttpClient`, which would prevent the fake
+// browser launcher below from reaching the real loopback `HttpServer`. The
+// browser is faked through the `OidcNativeOptionsApple.launchUrl` seam, exactly
+// like `oidc_desktop`'s tests fake `launchUrl`.
+void main() {
+  final metadata = OidcProviderMetadata.fromJson(const {
+    'issuer': 'https://op.example.com',
+    'authorization_endpoint': 'https://op.example.com/authorize',
+    'token_endpoint': 'https://op.example.com/token',
+    'end_session_endpoint': 'https://op.example.com/logout',
+  });
+
+  OidcAuthorizeRequest authRequest() => OidcAuthorizeRequest(
+    clientId: 'client-1',
+    // Loopback redirect on an ephemeral port (0 => any free port), as required
+    // by RFC 8252 §7.3.
+    redirectUri: Uri(scheme: 'http', host: '127.0.0.1', port: 0, path: '/cb'),
+    responseType: const [OidcConstants_AuthorizationEndpoint_ResponseType.code],
+    scope: const ['openid'],
+    state: 'state-1',
+  );
+
+  group('macOS loopbackSystemBrowser navigation mode', () {
+    setUp(() {
+      // The mode is only honored on macOS.
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    });
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    test(
+      'useLoopbackSystemBrowser is true on macOS when the macos options select '
+      'the loopback mode, and false for the default mode / on iOS',
+      () {
+        final darwin = OidcDarwin();
+        const loopback = OidcPlatformSpecificOptions(
+          macos: OidcNativeOptionsApple(
+            navigationMode: OidcAppleNavigationMode.loopbackSystemBrowser,
+          ),
+        );
+
+        expect(darwin.useLoopbackSystemBrowser(loopback), isTrue);
+        // Default mode (ASWebAuthenticationSession) => false even on macOS.
+        expect(
+          darwin.useLoopbackSystemBrowser(const OidcPlatformSpecificOptions()),
+          isFalse,
+        );
+
+        // Same loopback selection, but on iOS => ignored (false). The iOS
+        // field carries the mode here to prove the platform gate, not the
+        // field, is what disables it.
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        expect(
+          darwin.useLoopbackSystemBrowser(
+            const OidcPlatformSpecificOptions(
+              ios: OidcNativeOptionsApple(
+                navigationMode: OidcAppleNavigationMode.loopbackSystemBrowser,
+              ),
+            ),
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test('getAuthorizationResponse opens the system browser, captures the '
+        'loopback redirect, and returns the parsed response with the '
+        'configured success page written back to the browser', () async {
+      String? receivedBody;
+      int? receivedStatusCode;
+
+      final response = await OidcDarwin().getAuthorizationResponse(
+        metadata,
+        authRequest(),
+        OidcPlatformSpecificOptions(
+          macos: OidcNativeOptionsApple(
+            navigationMode: OidcAppleNavigationMode.loopbackSystemBrowser,
+            successfulPageResponse: '<html>done</html>',
+            launchUrl: (uri) async {
+              // The launched authorization URL must carry the port-rewritten
+              // loopback redirect_uri.
+              final redirectUriString = uri.queryParameters['redirect_uri'];
+              expect(redirectUriString, isNotNull);
+              final redirectUri = Uri.parse(redirectUriString!);
+              expect(redirectUri.host, '127.0.0.1');
+              expect(redirectUri.port, isNot(0));
+
+              final client = HttpClient();
+              try {
+                final callbackUri = redirectUri.replace(
+                  queryParameters: {
+                    ...redirectUri.queryParameters,
+                    'code': 'auth-code-123',
+                    'state': uri.queryParameters['state'] ?? '',
+                  },
+                );
+                final request = await client.getUrl(callbackUri);
+                final res = await request.close();
+                receivedStatusCode = res.statusCode;
+                receivedBody = await res.transform(utf8.decoder).join();
+              } finally {
+                client.close(force: true);
+              }
+              return true;
+            },
+          ),
+        ),
+        const {},
+      );
+
+      expect(receivedStatusCode, HttpStatus.ok);
+      expect(receivedBody, '<html>done</html>');
+      expect(response, isNotNull);
+      expect(response!.code, 'auth-code-123');
+      expect(response.state, 'state-1');
+    });
+
+    test('getAuthorizationResponse throws a timeout OidcException when no '
+        'redirect arrives within flowTimeoutSeconds', () async {
+      await expectLater(
+        OidcDarwin().getAuthorizationResponse(
+          metadata,
+          authRequest(),
+          OidcPlatformSpecificOptions(
+            macos: OidcNativeOptionsApple(
+              navigationMode: OidcAppleNavigationMode.loopbackSystemBrowser,
+              flowTimeoutSeconds: 1,
+              // Bypass url_launcher: pretend the browser opened but the user
+              // never completes the flow.
+              launchUrl: (uri) async => true,
+            ),
+          ),
+          const {},
+        ),
+        throwsA(
+          isA<OidcException>().having(
+            (e) => e.message,
+            'message',
+            contains('timed out'),
+          ),
+        ),
+      );
+    });
+
+    test(
+      'the loopback listener responds 405 with the configured mismatch body '
+      'to a non-GET request, then still completes on a subsequent GET',
+      () async {
+        int? mismatchStatusCode;
+        String? mismatchBody;
+
+        final response = await OidcDarwin().getAuthorizationResponse(
+          metadata,
+          authRequest(),
+          OidcPlatformSpecificOptions(
+            macos: OidcNativeOptionsApple(
+              navigationMode: OidcAppleNavigationMode.loopbackSystemBrowser,
+              methodMismatchResponse: 'method-not-allowed-body',
+              launchUrl: (uri) async {
+                final redirectUri = Uri.parse(
+                  uri.queryParameters['redirect_uri']!,
+                );
+                final client = HttpClient();
+                try {
+                  // First: a POST, which the listener rejects with 405.
+                  final postRequest = await client.postUrl(redirectUri);
+                  final postResponse = await postRequest.close();
+                  mismatchStatusCode = postResponse.statusCode;
+                  mismatchBody = await postResponse
+                      .transform(utf8.decoder)
+                      .join();
+
+                  // Then: the matching GET so the flow can complete.
+                  final callbackUri = redirectUri.replace(
+                    queryParameters: {
+                      ...redirectUri.queryParameters,
+                      'code': 'auth-code-456',
+                      'state': 'state-1',
+                    },
+                  );
+                  final getRequest = await client.getUrl(callbackUri);
+                  await (await getRequest.close()).drain<void>();
+                } finally {
+                  client.close(force: true);
+                }
+                return true;
+              },
+            ),
+          ),
+          const {},
+        );
+
+        expect(mismatchStatusCode, HttpStatus.methodNotAllowed);
+        expect(mismatchBody, 'method-not-allowed-body');
+        expect(response, isNotNull);
+        expect(response!.code, 'auth-code-456');
+      },
+    );
+
+    test('getAuthorizationResponse still completes (via the timeout-free path) '
+        'when the launcher reports a failed launch but the redirect still '
+        'arrives', () async {
+      var launchAttempted = false;
+
+      final response = await OidcDarwin().getAuthorizationResponse(
+        metadata,
+        authRequest(),
+        OidcPlatformSpecificOptions(
+          macos: OidcNativeOptionsApple(
+            navigationMode: OidcAppleNavigationMode.loopbackSystemBrowser,
+            launchUrl: (uri) async {
+              launchAttempted = true;
+              final redirectUri = Uri.parse(
+                uri.queryParameters['redirect_uri']!,
+              );
+              final client = HttpClient();
+              try {
+                final callbackUri = redirectUri.replace(
+                  queryParameters: {
+                    ...redirectUri.queryParameters,
+                    'code': 'auth-code-fallback',
+                    'state': 'state-1',
+                  },
+                );
+                final getRequest = await client.getUrl(callbackUri);
+                await (await getRequest.close()).drain<void>();
+              } finally {
+                client.close(force: true);
+              }
+              // Simulate a failed launch (e.g. no browser available).
+              return false;
+            },
+          ),
+        ),
+        const {},
+      );
+
+      expect(launchAttempted, isTrue);
+      expect(response, isNotNull);
+      expect(response!.code, 'auth-code-fallback');
+    });
+
+    test(
+      'getEndSessionResponse runs the loopback flow and parses the state from '
+      'the post-logout redirect',
+      () async {
+        final response = await OidcDarwin().getEndSessionResponse(
+          metadata,
+          OidcEndSessionRequest(
+            postLogoutRedirectUri: Uri(
+              scheme: 'http',
+              host: '127.0.0.1',
+              port: 0,
+              path: '/post-logout',
+            ),
+          ),
+          OidcPlatformSpecificOptions(
+            macos: OidcNativeOptionsApple(
+              navigationMode: OidcAppleNavigationMode.loopbackSystemBrowser,
+              launchUrl: (uri) async {
+                final redirectUri = Uri.parse(
+                  uri.queryParameters['post_logout_redirect_uri']!,
+                );
+                final client = HttpClient();
+                try {
+                  final callbackUri = redirectUri.replace(
+                    queryParameters: {
+                      ...redirectUri.queryParameters,
+                      'state': 'logout-state-1',
+                    },
+                  );
+                  final getRequest = await client.getUrl(callbackUri);
+                  await (await getRequest.close()).drain<void>();
+                } finally {
+                  client.close(force: true);
+                }
+                return true;
+              },
+            ),
+          ),
+          const {},
+        );
+
+        expect(response, isNotNull);
+        expect(response!.state, 'logout-state-1');
+      },
+    );
+
+    test(
+      'getEndSessionResponse returns null without launching a browser when the '
+      'request has no postLogoutRedirectUri',
+      () async {
+        var launchAttempted = false;
+        final response = await OidcDarwin().getEndSessionResponse(
+          metadata,
+          const OidcEndSessionRequest(),
+          OidcPlatformSpecificOptions(
+            macos: OidcNativeOptionsApple(
+              navigationMode: OidcAppleNavigationMode.loopbackSystemBrowser,
+              launchUrl: (uri) async {
+                launchAttempted = true;
+                return true;
+              },
+            ),
+          ),
+          const {},
+        );
+
+        expect(response, isNull);
+        expect(launchAttempted, isFalse);
+      },
+    );
+  });
+}

--- a/packages/oidc_darwin/test/oidc_darwin_test.dart
+++ b/packages/oidc_darwin/test/oidc_darwin_test.dart
@@ -225,6 +225,34 @@ void main() {
     expect(received![3], true);
   });
 
+  test('iOS ignores navigationMode=loopbackSystemBrowser and still uses the '
+      'native ASWebAuthenticationSession (Pigeon) path', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    var pigeonCalled = false;
+    mockHostApi('authorizeApple', (args) async {
+      pigeonCalled = true;
+      return 'com.example.app://callback?code=c&state=state-1';
+    });
+
+    final resp = await OidcDarwin().getAuthorizationResponse(
+      metadata,
+      _authRequest(),
+      const OidcPlatformSpecificOptions(
+        ios: OidcNativeOptionsApple(
+          navigationMode: OidcAppleNavigationMode.loopbackSystemBrowser,
+        ),
+      ),
+      const {},
+    );
+
+    // The loopback path never calls the Pigeon host API; asserting it WAS
+    // called proves iOS fell through to ASWebAuthenticationSession.
+    expect(pigeonCalled, isTrue);
+    expect(resp, isNotNull);
+    expect(resp!.code, 'c');
+  });
+
   test('getAuthorizationResponse returns null on USER_CANCELLED', () async {
     mockHostApi('authorizeApple', (args) async {
       throw PlatformException(code: 'USER_CANCELLED', message: 'cancelled');


### PR DESCRIPTION
Adds an opt-in external-browser (loopback) navigation mode for macOS, resolving #124 (Option A).

`OidcNativeOptionsApple` gains a `navigationMode` field
(`OidcAppleNavigationMode { asWebAuthenticationSession (default), loopbackSystemBrowser }`). When `loopbackSystemBrowser` is selected on macOS, `oidc_darwin` runs the authorization / end-session flow WITHOUT `ASWebAuthenticationSession`: it binds an `oidc_loopback_listener` on `http://127.0.0.1:{port}` (RFC 8252 §7.3 — a `redirect_uri` port of `0` binds an ephemeral port that is written back into the `redirect_uri` before launch, exactly as `oidc_desktop` does), opens the authorization URL in the default system browser via `url_launcher`, and awaits the single loopback redirect bounded by the existing `flowTimeoutSeconds` (a `TimeoutException` surfaces as an `OidcException`). The loopback orchestration mirrors `oidc_desktop`'s `startListenerAndGetUri` and reuses the shared `OidcLoopbackListener` transport.

iOS ignores the mode — `ASWebAuthenticationSession` remains the only iOS mechanism (the platform gate is `defaultTargetPlatform == macOS`, so the `.ios` field's `navigationMode` is never consulted).

The loopback page-response sub-options (`successfulPageResponse`, `methodMismatchResponse`, `notFoundResponse`) are added additively to `OidcNativeOptionsApple`, mirroring `OidcPlatformSpecificOptions_Native`, along with a JSON-excluded `launchUrl` test seam (mirrors the desktop seam). The `oidc_darwin` README documents the mode, the `http://127.0.0.1:{port}` redirect-uri registration requirement, and the required App Sandbox entitlements (`com.apple.security.network.server` + `.client`). Native Swift is untouched.

### Test evidence
- `packages/oidc_darwin/test/oidc_darwin_loopback_test.dart (new file, 7 tests): mode-selection gate (useLoopbackSystemBrowser true on macOS+loopback, false for default mode and false on iOS); authorize success + ephemeral-port rewrite + configured success page body written to browser; timeout -> OidcException; 405 method-mismatch body then completion on subsequent GET; failed-launch still completes when redirect arrives; end-session loopback state parse; end-session returns null without launching when no postLogoutRedirectUri`
- `packages/oidc_darwin/test/oidc_darwin_test.dart (added test): iOS ignores navigationMode=loopbackSystemBrowser and still calls the native ASWebAuthenticationSession (Pigeon) path`

Gates re-ran green after rebasing onto post-1.0.0 main (full oidc_core/oidc_cli/oidc/oidc_default_store set plus package-specific suites; see commits).

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macOS option to complete OIDC authorization and logout in the system browser using loopback redirects.
  * Added customizable browser response pages and configurable flow timeouts.
  * iOS continues using the standard authentication session flow.

* **Documentation**
  * Documented macOS browser navigation, redirect setup, and required sandbox permissions.

* **Tests**
  * Added coverage for successful, timed-out, failed-launch, and logout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->