### PR TITLE
feat(oidc_core)!: cache-first init as the new default, discovery TTL cache, loaded-token validity controls

### DIFF
--- a/packages/oidc/test/oidc_test.dart
+++ b/packages/oidc/test/oidc_test.dart
@@ -25,6 +25,10 @@ void main() {
   );
   final settings = OidcUserManagerSettings(
     redirectUri: Uri.parse('http://example.com/redirect.html'),
+    // These tests pin the pre-existing blocking init semantics (the cached
+    // token is validated/refreshed before init() completes). The new default,
+    // OidcInitMode.cacheFirst, defers that to a background pass.
+    initMode: OidcInitMode.blockingValidate,
   );
   // Signature verification is always-strict now; every manager below is
   // constructed with a keyStore holding the mock id_tokens' HS256 signing
@@ -379,6 +383,7 @@ void main() {
               final eventSettings = OidcUserManagerSettings(
                 redirectUri: settings.redirectUri,
                 refreshBefore: (_) => const Duration(milliseconds: 700),
+                initMode: OidcInitMode.blockingValidate,
               );
               manager = OidcUserManager(
                 id: managerId,

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -137,6 +137,21 @@ abstract class OidcUserManagerBase {
   Future<({OidcUser? user, OidcTokenRefreshFailureKind? failureKind})>?
   _autoRefreshInFlight;
 
+  /// #201: while a cache-first background revalidation owns the refresh of the
+  /// just-restored (possibly already-expired) cached token, the expiry-driven
+  /// auto-refresh ([handleTokenExpiring] / [handleTokenExpired]) is suppressed.
+  ///
+  /// On a cache-first cold start the restored expired user is surfaced through
+  /// [userChanges], which arms the token-events timers; those fire immediately
+  /// for an expired token and would kick off `_autoRefresh` — a SECOND
+  /// `/token` exchange racing the background revalidation's own
+  /// `startupLoad` refresh. Two concurrent refresh-token exchanges can trip an
+  /// OP's RFC 9700 refresh-rotation reuse detection and revoke the whole token
+  /// family (a real logout on an ordinary reopen). This flag lets the single
+  /// background pass own that first refresh; it is cleared once the pass
+  /// settles, after which normal on-expiry auto-refresh resumes.
+  bool _cacheFirstRevalidationInFlight = false;
+
   /// Returns true if the manager is currently in offline mode.
   bool get isInOfflineMode => offlineModeStartedAt != null;
 
@@ -1682,6 +1697,13 @@ abstract class OidcUserManagerBase {
     if (refreshToken == null) {
       return;
     }
+    // #201: during a cache-first cold start the background revalidation owns the
+    // first refresh of the just-restored expired token (source `startupLoad`).
+    // Skipping here keeps that refresh a SINGLE `/token` exchange instead of
+    // racing a second one (see [_cacheFirstRevalidationInFlight]).
+    if (_cacheFirstRevalidationInFlight) {
+      return;
+    }
     // #154: share the refresh with [handleTokenExpired] through the in-flight
     // latch so a resume that fires both timers exchanges the refresh token
     // exactly once. All success bookkeeping, failure signalling, and offline
@@ -1939,6 +1961,16 @@ abstract class OidcUserManagerBase {
       //                         network must not nuke a possibly-valid session.
       // A token with NO refresh token is unrecoverable, so forget immediately as
       // before.
+      //
+      // #201: on a cache-first cold start the background revalidation owns the
+      // keep/discard decision for the just-restored expired token — it runs the
+      // full [loadCachedTokens] pass (refresh-if-possible, then the
+      // shouldRemoveInvalidToken / offline policy) and reconciles the surfaced
+      // user afterwards. Defer to it here so this handler neither races a second
+      // refresh nor forgets a user the background pass may still keep.
+      if (_cacheFirstRevalidationInFlight) {
+        return;
+      }
       final refreshToken = event.refreshToken;
       if (refreshToken == null) {
         unawaited(forgetUser());
@@ -3263,9 +3295,14 @@ abstract class OidcUserManagerBase {
   ///   by a pure local deserialize (no network) and `init()` completes
   ///   immediately, then the user is revalidated in the background. When there
   ///   is no cached user / cached discovery document, this transparently falls
-  ///   back to the blocking network path below.
+  ///   back to the blocking network path below. Note this surfaces the user
+  ///   through [userChanges] TWICE on a cold start (restored-then-revalidated) —
+  ///   see [OidcInitMode.cacheFirst] for why the second emission is intentional.
   /// - [OidcInitMode.blockingValidate]: the previous semantics — block until
   ///   the discovery document is fetched and the cached token fully re-verified.
+  ///   Not a byte-for-byte replica of the pre-1.0 network behavior unless
+  ///   combined with `discoveryDocumentMaxAge: Duration.zero` (the discovery
+  ///   document is otherwise served from its TTL cache).
   Future<void> init() {
     return initMemoizer.runOnce(() async {
       await store.init();
@@ -3329,6 +3366,12 @@ abstract class OidcUserManagerBase {
       }
       return false;
     }
+    // #201: arm the gate BEFORE returning (so it is set before `init()` attaches
+    // the lifecycle listeners and the restored-user replay arms the expiry
+    // timers). The background pass owns the first refresh; the expiry-driven
+    // auto-refresh stays suppressed until [_scheduleBackgroundRevalidation]
+    // clears the gate.
+    _cacheFirstRevalidationInFlight = true;
     unawaited(_scheduleBackgroundRevalidation(restored));
     return true;
   }
@@ -3398,17 +3441,31 @@ abstract class OidcUserManagerBase {
     try {
       await _refreshDiscoveryInBackgroundIfStale();
       await loadCachedTokens(forceRebuild: true);
-      // If loadCachedTokens discarded the tokens as invalid without replacing
-      // the surfaced user, reconcile by forgetting the stale restored user.
-      if (identical(currentUser, restoredUser)) {
-        final raw = await store.get(
-          OidcStoreNamespace.secureTokens,
-          key: OidcConstants_Store.currentToken,
-          managerId: id,
-        );
-        if (raw == null) {
-          await forgetUser();
-        }
+      // Reconcile the optimistically-surfaced restore with the authoritative
+      // [loadCachedTokens] outcome so cache-first converges on exactly what
+      // blockingValidate would have surfaced.
+      //
+      // [loadCachedTokens] REPLACES the surfaced user (a freshly-rebuilt object,
+      // `ignoreCurrentUser: true`) on every path where it accepts a token —
+      // refresh success, an explicit `isLoadedTokenAcceptable == true`, or a
+      // clean validation. So if `currentUser` is STILL the exact restored object
+      // afterwards, the pass rejected/discarded that token (policy or
+      // validation) and surfaced no replacement — blockingValidate would show no
+      // user here.
+      //
+      // #201/#205: retract it IN-MEMORY regardless of whether the on-disk copy
+      // was removed. The on-disk retention is a SEPARATE decision owned by
+      // `shouldRemoveInvalidToken` / `supportOfflineAuth`; a policy that KEEPS a
+      // rejected token on disk (reject-but-keep) must not leave that rejected
+      // user logged in — matching blockingValidate, which keeps the disk tokens
+      // yet surfaces no user under identical settings.
+      if (!_isDisposed && identical(currentUser, restoredUser)) {
+        emitEvent(OidcPreLogoutEvent.now(currentUser: restoredUser));
+        // Surface null WITHOUT clearing the store: `forgetUser()` would delete
+        // the secureTokens namespace and defeat a reject-but-keep policy. The
+        // null userChange also unloads the token-events timers (via the
+        // userSubject listener), retiring the stale expired token's timers.
+        userSubject.add(null);
       }
     } on Object catch (e, st) {
       logger.warning(
@@ -3416,6 +3473,13 @@ abstract class OidcUserManagerBase {
         e,
         st,
       );
+    } finally {
+      // Re-arm normal on-expiry auto-refresh now that the background pass has
+      // settled. On success the winning token already re-armed the timers; on
+      // rejection the retraction above unloaded them. Either way subsequent real
+      // expiries must go through [handleTokenExpiring] / [handleTokenExpired]
+      // again.
+      _cacheFirstRevalidationInFlight = false;
     }
   }
 

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -1291,8 +1291,15 @@ abstract class OidcUserManagerBase {
     bool validateAndSave = true,
     String? authorizationCode,
     Duration? maxAge,
+    // When true, the user is (re)built from scratch via [OidcUser.fromIdToken]
+    // (verifying the id_token signature) instead of replacing the token on the
+    // existing [currentUser]. Used by cache-first background revalidation, whose
+    // locally-restored user was deserialized WITHOUT verification.
+    bool ignoreCurrentUser = false,
   }) async {
-    final currentUser = currentUserOverride ?? this.currentUser;
+    final currentUser = ignoreCurrentUser
+        ? null
+        : (currentUserOverride ?? this.currentUser);
     OidcUser? newUser;
     final idTokenOverride = await settings.getIdToken?.call(token);
     if (currentUser == null) {
@@ -2593,60 +2600,144 @@ abstract class OidcUserManagerBase {
   /// The discovery document Uri containing openid configuration.
   final Uri? discoveryDocumentUri;
 
-  /// First gets the cached discoveryDocument if any
-  /// (based on discoveryDocumentUri).
-  ///
-  /// Then tries to get it from the network.
-  @protected
-  Future<void> ensureDiscoveryDocument() async {
-    final uri = discoveryDocumentUri;
+  /// Sidecar key suffix that holds the epoch-millis fetched-at timestamp next
+  /// to a persisted discovery document. Mirrors [OidcJwksStoreLoader]'s
+  /// `::oidc_jwks_fetched_at` pattern; cannot collide with a real discovery URL
+  /// key.
+  static const discoveryFetchedAtSuffix = '::oidc_discovery_fetched_at';
 
-    if (currentDiscoveryDocument != null) {
-      // An eagerly-supplied discoveryDocument (eager constructor, where
-      // discoveryDocumentUri is null) is still validated against
-      // `settings.expectedIssuer`.
-      _validateDiscoveryIssuer();
-      return;
+  /// Merges [OidcUserManagerSettings.metadataSeed] UNDER [doc] (doc members
+  /// override the seed),
+  /// matching oidc-client-ts `metadataSeed` semantics. No-op when no seed is set
+  /// or when using an eagerly-supplied document (that path is a full override).
+  OidcProviderMetadata _applyMetadataSeed(OidcProviderMetadata doc) {
+    final seed = settings.metadataSeed;
+    // The eager (non-`.lazy`) constructor path is a full override; the seed only
+    // augments a fetched/cached document (discoveryDocumentUri != null).
+    if (seed == null || discoveryDocumentUri == null) {
+      return doc;
     }
+    return OidcProviderMetadata.fromJson({...seed.src, ...doc.src});
+  }
 
-    if (uri == null) {
-      logAndThrow(
-        'Impossible case of no discoveryDocument and no discoveryDocumentUri',
+  /// Parses a persisted discovery document [OidcProviderMetadata] from [raw],
+  /// removing the stored key on a parse failure. Returns `null` when [raw] is
+  /// null or unparseable.
+  Future<OidcProviderMetadata?> _parseCachedDiscovery(
+    String key,
+    String? raw,
+  ) async {
+    if (raw == null) {
+      return null;
+    }
+    try {
+      return OidcProviderMetadata.fromJson(
+        jsonDecode(raw) as Map<String, dynamic>,
       );
+    } on Object catch (e, st) {
+      logger.warning(
+        "Found a cached discovery document at key: $key, but couldn't parse it.\n"
+        'Removing the bad key now.\n'
+        'cached document: $raw',
+        e,
+        st,
+      );
+      await store
+          .remove(OidcStoreNamespace.discoveryDocument, key: key)
+          .onError((error, stackTrace) => null);
+      return null;
+    }
+  }
+
+  /// Loads the discovery document from the [OidcStore] only (no network),
+  /// applying [OidcUserManagerSettings.metadataSeed] and issuer validation.
+  /// Returns `true` when a usable document is available (either eagerly-supplied
+  /// or cached), `false` otherwise. Used by the [OidcInitMode.cacheFirst] path.
+  Future<bool> _loadDiscoveryFromCacheOnly() async {
+    if (currentDiscoveryDocument != null) {
+      // Eagerly-supplied document.
+      _validateDiscoveryIssuer();
+      return true;
+    }
+    final uri = discoveryDocumentUri;
+    if (uri == null) {
+      return false;
     }
     final key = uri.toString();
-    final cachedDocument = await store.get(
+    final cached = await _parseCachedDiscovery(
+      key,
+      await store.get(
+        OidcStoreNamespace.discoveryDocument,
+        key: key,
+        managerId: id,
+      ),
+    );
+    if (cached == null) {
+      return false;
+    }
+    currentDiscoveryDocument = _applyMetadataSeed(cached);
+    _validateDiscoveryIssuer();
+    return true;
+  }
+
+  /// Returns `true` when the persisted discovery document is older than
+  /// [OidcUserManagerSettings.discoveryDocumentMaxAge] (or its age is unknown).
+  /// Eagerly-supplied documents (no [discoveryDocumentUri]) are never stale.
+  Future<bool> _isDiscoveryStale() async {
+    final uri = discoveryDocumentUri;
+    if (uri == null) {
+      return false;
+    }
+    final maxAge = settings.discoveryDocumentMaxAge;
+    if (maxAge <= Duration.zero) {
+      return true;
+    }
+    final sidecar = await store.get(
       OidcStoreNamespace.discoveryDocument,
-      key: key,
+      key: '$uri$discoveryFetchedAtSuffix',
       managerId: id,
     );
-    if (cachedDocument != null) {
-      try {
-        ///try loading the document
-        currentDiscoveryDocument = OidcProviderMetadata.fromJson(
-          jsonDecode(cachedDocument) as Map<String, dynamic>,
-        );
-      } on Object catch (e, st) {
-        //swallow error.
-        //remove the cached document.
-        logger.warning(
-          "Found a cached discovery document at key: $key, but couldn't parse it.\n"
-          'Removing the bad key now.\n'
-          'cached document: $cachedDocument',
-          e,
-          st,
-        );
-        await store
-            .remove(OidcStoreNamespace.discoveryDocument, key: key)
-            .onError((error, stackTrace) => null);
-      }
+    final ms = sidecar == null ? null : int.tryParse(sidecar);
+    if (ms == null) {
+      return true;
     }
+    final fetchedAt = DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true);
+    return clock.now().toUtc().difference(fetchedAt) > maxAge;
+  }
 
+  /// Background (cache-first) discovery refresh: re-fetches from the network
+  /// only when the persisted document is stale, keeping the cached document as
+  /// an offline fallback on failure.
+  Future<void> _refreshDiscoveryInBackgroundIfStale() async {
+    final uri = discoveryDocumentUri;
+    if (uri == null) {
+      return;
+    }
+    if (!await _isDiscoveryStale()) {
+      return;
+    }
+    await _fetchAndApplyDiscovery(uri);
+    // A refreshed document may advertise a new jwks_uri.
+    setupKeyStore();
+  }
+
+  /// Fetches the discovery document from the network for [uri], verifies signed
+  /// metadata (when enabled), validates the issuer, persists the document with a
+  /// fresh fetched-at timestamp, and applies
+  /// [OidcUserManagerSettings.metadataSeed] in memory.
+  ///
+  /// On a network failure the previously-loaded [currentDiscoveryDocument]
+  /// (cache) is kept as an offline fallback when present; only when there is no
+  /// fallback does this throw.
+  Future<void> _fetchAndApplyDiscovery(Uri uri) async {
+    final key = uri.toString();
+    var fetched = false;
     try {
       currentDiscoveryDocument = await OidcEndpoints.getProviderMetadata(
         uri,
         client: httpClient,
       );
+      fetched = true;
     } catch (e, st) {
       //maybe there is no internet.
       if (currentDiscoveryDocument == null) {
@@ -2659,6 +2750,13 @@ abstract class OidcUserManagerBase {
           },
         );
       }
+      // Keep the cached document as an offline fallback (do NOT re-persist or
+      // refresh its timestamp — it stays as stale as it really is). Still
+      // issuer-validate it: a poisoned cache must never be trusted, even offline
+      // (mirrors the pre-refactor validate-before-use behavior).
+      _validateDiscoveryIssuer();
+      currentDiscoveryDocument = _applyMetadataSeed(currentDiscoveryDocument!);
+      return;
     }
 
     // RFC 8414 §2.1/§3.2: when enabled, verify the document's `signed_metadata`
@@ -2698,16 +2796,87 @@ abstract class OidcUserManagerBase {
       }
     }
 
-    // Validate the final document (cache- or network-sourced) BEFORE persisting,
-    // so a mismatched/poisoned document is never written to the store.
+    // Validate the final document (network-sourced) BEFORE persisting, so a
+    // mismatched/poisoned document is never written to the store.
     _validateDiscoveryIssuer();
 
-    await store.set(
+    // Persist the raw fetched document + a fresh fetched-at timestamp together
+    // (mirrors OidcJwksStoreLoader). Only reached on a successful fetch, so the
+    // TTL timestamp never advances while serving a stale offline copy.
+    if (fetched) {
+      await store.setMany(
+        OidcStoreNamespace.discoveryDocument,
+        values: {
+          key: jsonEncode(currentDiscoveryDocument!.src),
+          '$key$discoveryFetchedAtSuffix': clock
+              .now()
+              .toUtc()
+              .millisecondsSinceEpoch
+              .toString(),
+        },
+        managerId: id,
+      );
+    }
+
+    // Apply the seed in memory AFTER persistence so the seed is never baked
+    // into the cache (fetched/cached values still override it).
+    currentDiscoveryDocument = _applyMetadataSeed(currentDiscoveryDocument!);
+  }
+
+  /// First gets the cached discoveryDocument if any
+  /// (based on discoveryDocumentUri).
+  ///
+  /// Then tries to get it from the network, unless a cached document exists and
+  /// is still within [OidcUserManagerSettings.discoveryDocumentMaxAge] (in which
+  /// case the network fetch is skipped).
+  @protected
+  Future<void> ensureDiscoveryDocument() async {
+    final uri = discoveryDocumentUri;
+
+    if (currentDiscoveryDocument != null) {
+      // An eagerly-supplied discoveryDocument (eager constructor, where
+      // discoveryDocumentUri is null) is still validated against
+      // `settings.expectedIssuer`.
+      _validateDiscoveryIssuer();
+      return;
+    }
+
+    if (uri == null) {
+      logAndThrow(
+        'Impossible case of no discoveryDocument and no discoveryDocumentUri',
+      );
+    }
+    final key = uri.toString();
+    final cachedValues = await store.getMany(
       OidcStoreNamespace.discoveryDocument,
-      key: key,
-      value: jsonEncode(discoveryDocument.src),
+      keys: {key, '$key$discoveryFetchedAtSuffix'},
       managerId: id,
     );
+    final cachedMetadata = await _parseCachedDiscovery(
+      key,
+      cachedValues[key],
+    );
+    // Keep the cached document as the offline fallback for the network fetch.
+    currentDiscoveryDocument = cachedMetadata;
+
+    // TTL cache: within `discoveryDocumentMaxAge`, skip the network fetch and
+    // use the cached document (matching the JWKS loader's timestamp scheme).
+    if (cachedMetadata != null &&
+        settings.discoveryDocumentMaxAge > Duration.zero) {
+      final tsRaw = cachedValues['$key$discoveryFetchedAtSuffix'];
+      final ms = tsRaw == null ? null : int.tryParse(tsRaw);
+      if (ms != null) {
+        final fetchedAt = DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true);
+        final age = clock.now().toUtc().difference(fetchedAt);
+        if (age <= settings.discoveryDocumentMaxAge) {
+          currentDiscoveryDocument = _applyMetadataSeed(cachedMetadata);
+          _validateDiscoveryIssuer();
+          return;
+        }
+      }
+    }
+
+    await _fetchAndApplyDiscovery(uri);
   }
 
   /// OIDC Discovery 1.0 §4.3 / RFC 8414 §3.3: the discovery document's `issuer`
@@ -2779,8 +2948,13 @@ abstract class OidcUserManagerBase {
   }
 
   /// Loads and verifies the tokens.
+  ///
+  /// When [forceRebuild] is `true`, the user is rebuilt from scratch (verifying
+  /// the id_token signature) rather than replacing the token on the current
+  /// user — used by cache-first background revalidation, whose surfaced user was
+  /// restored locally without verification.
   @protected
-  Future<void> loadCachedTokens() async {
+  Future<void> loadCachedTokens({bool forceRebuild = false}) async {
     final usedKeys = <String>{
       OidcConstants_Store.currentToken,
       OidcConstants_Store.currentUserAttributes,
@@ -2799,6 +2973,11 @@ abstract class OidcUserManagerBase {
       return;
     }
 
+    // Captured (when available) so the discard branch can consult
+    // [OidcUserManagerSettings.shouldRemoveInvalidToken] with the same user +
+    // validation errors that were evaluated.
+    OidcUser? policyUser;
+    var policyErrors = const <Exception>[];
     try {
       final decodedAttributes = rawAttributes == null
           ? null
@@ -2817,48 +2996,71 @@ abstract class OidcUserManagerBase {
         userInfo: decodedUserInfo,
         metadata: metadata,
         validateAndSave: false,
+        ignoreCurrentUser: forceRebuild,
       );
       if (loadedUser != null) {
         final validationErrors = validateUser(
           user: loadedUser,
           metadata: metadata,
         );
-        final idTokenNeedsRefresh = validationErrors
-            .whereType<JoseException>()
-            .any((element) => element.message.startsWith('JWT expired'));
+        policyUser = loadedUser;
+        policyErrors = validationErrors;
 
-        if (token.refreshToken != null &&
-            (idTokenNeedsRefresh || token.isAccessTokenExpired())) {
-          // #120: _refreshToken owns the failure signalling and offline
-          // handling for this path now. Passing source: startupLoad makes the
-          // single OidcTokenRefreshFailedEvent it emits carry the correct
-          // source, and its internal handleOfflineEligibleFailure is the single
-          // offline-handling pass. A failure that offline mode absorbs returns
-          // the cached [loadedUser] (so we continue with cached state); a
-          // terminal / offline-disabled failure rethrows to the outer catch
-          // below, which clears the invalid tokens when offline auth is off.
-          // This removes the previous double-signal (two events + two
-          // offline-handling passes) per startup refresh failure.
-          final refreshedUser = await _refreshToken(
-            overrideRefreshToken: token.refreshToken,
-            currentUserOverride: loadedUser,
-            source: OidcTokenRefreshSource.startupLoad,
-          );
-          if (refreshedUser != null) {
-            loadedUser = refreshedUser;
-          }
-        }
-        // [loadedUser] is provably non-null here (we are inside the
-        // `loadedUser != null` guard above and only ever reassign it to a
-        // non-null refreshed user), so it is passed directly to validation.
-        loadedUser = await validateAndSaveUser(
-          user: loadedUser,
-          metadata: metadata,
-          // #302: this validates a resumed (already-established) session, so a
-          // UserInfo 401 from a revoked access token should trigger the
-          // recover-via-refresh + typed-event reaction.
-          reactToUserInfoUnauthorized: true,
+        // Developer control (#205): let callers override whether the loaded
+        // token is acceptable, evaluated with the validation error list BEFORE
+        // the default refresh / discard policy. `null` keeps current behavior.
+        final acceptable = settings.isLoadedTokenAcceptable?.call(
+          loadedUser,
+          validationErrors,
         );
+        if (acceptable == true) {
+          // Explicitly accepted: surface the loaded user as-is, skipping the
+          // refresh / userinfo round-trips.
+          await saveUser(loadedUser);
+          userSubject.add(loadedUser);
+          return;
+        }
+        if (acceptable == false) {
+          // Explicitly rejected: fall through to the discard branch.
+          loadedUser = null;
+        } else {
+          final idTokenNeedsRefresh = validationErrors
+              .whereType<JoseException>()
+              .any((element) => element.message.startsWith('JWT expired'));
+
+          if (token.refreshToken != null &&
+              (idTokenNeedsRefresh || token.isAccessTokenExpired())) {
+            // #120: _refreshToken owns the failure signalling and offline
+            // handling for this path now. Passing source: startupLoad makes the
+            // single OidcTokenRefreshFailedEvent it emits carry the correct
+            // source, and its internal handleOfflineEligibleFailure is the
+            // single offline-handling pass. A failure that offline mode absorbs
+            // returns the cached [loadedUser] (so we continue with cached
+            // state); a terminal / offline-disabled failure rethrows to the
+            // outer catch below, which then consults shouldRemoveInvalidToken
+            // (#205). This removes the previous double-signal (two events + two
+            // offline-handling passes) per startup refresh failure.
+            final refreshedUser = await _refreshToken(
+              overrideRefreshToken: token.refreshToken,
+              currentUserOverride: loadedUser,
+              source: OidcTokenRefreshSource.startupLoad,
+            );
+            if (refreshedUser != null) {
+              loadedUser = refreshedUser;
+            }
+          }
+          // [loadedUser] is provably non-null here (this branch is only entered
+          // with a non-null user and only ever reassigns it to a non-null
+          // refreshed user), so it is passed directly to validation.
+          loadedUser = await validateAndSaveUser(
+            user: loadedUser,
+            metadata: metadata,
+            // #302: this validates a resumed (already-established) session, so a
+            // UserInfo 401 from a revoked access token should trigger the
+            // recover-via-refresh + typed-event reaction.
+            reactToUserInfoUnauthorized: true,
+          );
+        }
       }
 
       if (loadedUser == null) {
@@ -2867,7 +3069,17 @@ abstract class OidcUserManagerBase {
         );
       }
     } on Object catch (_) {
-      if (!settings.supportOfflineAuth) {
+      // Developer control (#205): let callers override the keep/discard
+      // decision. `null` (default) removes the tokens unless offline auth is
+      // enabled — the current behavior, preserved exactly.
+      final shouldRemove = policyUser == null
+          ? !settings.supportOfflineAuth
+          : (settings.shouldRemoveInvalidToken?.call(
+                  policyUser,
+                  policyErrors,
+                ) ??
+                !settings.supportOfflineAuth);
+      if (shouldRemove) {
         // remove invalid tokens, so that they don't get used again.
         await store.removeMany(
           OidcStoreNamespace.secureTokens,
@@ -2988,33 +3200,84 @@ abstract class OidcUserManagerBase {
     );
   }
 
+  /// Registers the id_token verification keys with [keyStore] from the current
+  /// [discoveryDocument]'s `jwks_uri` and (for HS* id_tokens) the client secret.
+  @protected
+  void setupKeyStore() {
+    final jwksUri = currentDiscoveryDocument?.jwksUri;
+    if (jwksUri != null) {
+      keyStore.addKeySetUrl(jwksUri);
+    }
+    final clientSecret = clientCredentials.clientSecret;
+    if (clientSecret != null) {
+      // RFC 7518 §3.2 / OIDC Core §16.19: HS256/384/512 id_tokens are
+      // MAC-signed with the client_secret octets as the key. Register it as an
+      // `oct` key so symmetric id_token signatures can be verified. Without
+      // this, HS*-signed id_tokens were unverifiable. The extra key is inert
+      // for RS*/ES* tokens (those still verify via the jwks_uri keys above).
+      keyStore.addKey(
+        JsonWebKey.fromJson({
+          'kty': 'oct',
+          'k': base64Url.encode(utf8.encode(clientSecret)).replaceAll('=', ''),
+          'use': 'sig',
+        }),
+      );
+    }
+  }
+
+  /// Attaches the manager's lifecycle stream subscriptions (front-channel
+  /// logout, token-refresh scheduling, session monitoring, token-expiry, and
+  /// native browser events). Shared by both `init()` code paths.
+  @protected
+  void attachLifecycleListeners() {
+    final frontChannelLogoutUri = settings.frontChannelLogoutUri;
+    if (frontChannelLogoutUri != null) {
+      toDispose.add(
+        listenToFrontChannelLogoutRequests(
+          frontChannelLogoutUri,
+          settings.frontChannelRequestListeningOptions,
+        ).listen(handleFrontChannelLogoutRequest),
+      );
+    }
+
+    //start listening to token events, if the user enabled them.
+
+    toDispose
+      ..add(
+        userSubject.listen(
+          (value) => listenToTokenRefreshIfSupported(tokenEvents, value),
+        ),
+      )
+      ..add(userSubject.listen(listenToUserSessionIfSupported))
+      ..add(tokenEvents.expiring.listen(handleTokenExpiring))
+      ..add(tokenEvents.expired.listen(handleTokenExpired))
+      // Surface native browser-layer observability through events().
+      ..add(listenToNativeBrowserEvents().listen(emitEvent));
+  }
+
   /// Initializes the user manager, this also gets the [discoveryDocument] if it
   /// wasn't provided.
+  ///
+  /// The restore behavior depends on [OidcUserManagerSettings.initMode]:
+  /// - [OidcInitMode.cacheFirst] (the **default**): a cached user is restored
+  ///   by a pure local deserialize (no network) and `init()` completes
+  ///   immediately, then the user is revalidated in the background. When there
+  ///   is no cached user / cached discovery document, this transparently falls
+  ///   back to the blocking network path below.
+  /// - [OidcInitMode.blockingValidate]: the previous semantics — block until
+  ///   the discovery document is fetched and the cached token fully re-verified.
   Future<void> init() {
     return initMemoizer.runOnce(() async {
       await store.init();
+      if (settings.initMode == OidcInitMode.cacheFirst &&
+          await _tryCacheFirstInit()) {
+        attachLifecycleListeners();
+        return;
+      }
+      // Blocking / network path (the [OidcInitMode.blockingValidate] semantics,
+      // also the fallback when cache-first has nothing to restore).
       await ensureDiscoveryDocument();
-      final jwksUri = discoveryDocument.jwksUri;
-      if (jwksUri != null) {
-        keyStore.addKeySetUrl(jwksUri);
-      }
-      final clientSecret = clientCredentials.clientSecret;
-      if (clientSecret != null) {
-        // RFC 7518 §3.2 / OIDC Core §16.19: HS256/384/512 id_tokens are
-        // MAC-signed with the client_secret octets as the key. Register it as an
-        // `oct` key so symmetric id_token signatures can be verified. Without
-        // this, HS*-signed id_tokens were unverifiable. The extra key is inert
-        // for RS*/ES* tokens (those still verify via the jwks_uri keys above).
-        keyStore.addKey(
-          JsonWebKey.fromJson({
-            'kty': 'oct',
-            'k': base64Url
-                .encode(utf8.encode(clientSecret))
-                .replaceAll('=', ''),
-            'use': 'sig',
-          }),
-        );
-      }
+      setupKeyStore();
       await clearUnusedStates();
       if (!await loadLogoutRequests()) {
         //no logout requests.
@@ -3023,30 +3286,137 @@ abstract class OidcUserManagerBase {
           await loadCachedTokens();
         }
       }
-      final frontChannelLogoutUri = settings.frontChannelLogoutUri;
-      if (frontChannelLogoutUri != null) {
-        toDispose.add(
-          listenToFrontChannelLogoutRequests(
-            frontChannelLogoutUri,
-            settings.frontChannelRequestListeningOptions,
-          ).listen(handleFrontChannelLogoutRequest),
-        );
-      }
-
-      //start listening to token events, if the user enabled them.
-
-      toDispose
-        ..add(
-          userSubject.listen(
-            (value) => listenToTokenRefreshIfSupported(tokenEvents, value),
-          ),
-        )
-        ..add(userSubject.listen(listenToUserSessionIfSupported))
-        ..add(tokenEvents.expiring.listen(handleTokenExpiring))
-        ..add(tokenEvents.expired.listen(handleTokenExpired))
-        // Surface native browser-layer observability through events().
-        ..add(listenToNativeBrowserEvents().listen(emitEvent));
+      attachLifecycleListeners();
     });
+  }
+
+  /// Attempts the [OidcInitMode.cacheFirst] restore: deserialize the cached user
+  /// purely from the [OidcStore] (no network) and schedule background
+  /// revalidation. Returns `false` (leaving state untouched for the blocking
+  /// path) when there is nothing to restore locally, a redirect/logout result
+  /// is pending, or the local restore fails.
+  Future<bool> _tryCacheFirstInit() async {
+    // No cached token → nothing to restore; use the network path.
+    final rawToken = await store.get(
+      OidcStoreNamespace.secureTokens,
+      key: OidcConstants_Store.currentToken,
+      managerId: id,
+    );
+    if (rawToken == null) {
+      return false;
+    }
+    // A pending redirect result or front-channel logout is the interactive
+    // path (it needs the network); defer to the blocking path.
+    if ((await store.getStatesWithResponses()).isNotEmpty) {
+      return false;
+    }
+    if (await store.getCurrentFrontChannelLogoutRequest() != null) {
+      return false;
+    }
+    // Need a locally-available discovery document (no network) to build the
+    // user; otherwise fall back to the network path.
+    if (!await _loadDiscoveryFromCacheOnly()) {
+      return false;
+    }
+    setupKeyStore();
+    await clearUnusedStates();
+    final restored = await _restoreCachedUserLocally();
+    if (restored == null) {
+      // Couldn't restore locally; reset the (cache-only) discovery document so
+      // the network path re-fetches it. Keep an eagerly-supplied document.
+      if (discoveryDocumentUri != null) {
+        currentDiscoveryDocument = null;
+      }
+      return false;
+    }
+    unawaited(_scheduleBackgroundRevalidation(restored));
+    return true;
+  }
+
+  /// Deserializes and surfaces the cached user WITHOUT any network access
+  /// (no signature verification, no refresh, no userinfo). Returns the restored
+  /// user, or `null` when there is no usable cached token.
+  Future<OidcUser?> _restoreCachedUserLocally() async {
+    final tokens = await store.getMany(
+      OidcStoreNamespace.secureTokens,
+      keys: {
+        OidcConstants_Store.currentToken,
+        OidcConstants_Store.currentUserAttributes,
+        OidcConstants_Store.currentUserInfo,
+      },
+      managerId: id,
+    );
+    final rawToken = tokens[OidcConstants_Store.currentToken];
+    if (rawToken == null) {
+      return null;
+    }
+    try {
+      final rawUserInfo = tokens[OidcConstants_Store.currentUserInfo];
+      final rawAttributes = tokens[OidcConstants_Store.currentUserAttributes];
+      final decodedAttributes = rawAttributes == null
+          ? null
+          : jsonDecode(rawAttributes) as Map<String, dynamic>;
+      final decodedUserInfo = rawUserInfo == null
+          ? null
+          : jsonDecode(rawUserInfo) as Map<String, dynamic>;
+      final token = OidcToken.fromJson(
+        jsonDecode(rawToken) as Map<String, dynamic>,
+      );
+      // Pure-local restore: pass `keystore: null` so `OidcUser.fromIdToken`
+      // parses the id_token unverified (`JsonWebToken.unverified`) instead of
+      // fetching the JWKS. The token was already verified when it was saved;
+      // the scheduled background revalidation re-verifies it against the network.
+      final user = await OidcUser.fromIdToken(
+        token: token,
+        attributes: decodedAttributes,
+        userInfo: decodedUserInfo,
+      );
+      userSubject.add(user);
+      return user;
+    } on Object catch (e, st) {
+      logger.warning(
+        'cache-first init: failed to restore the cached user locally; '
+        'falling back to the network path.',
+        e,
+        st,
+      );
+      return null;
+    }
+  }
+
+  /// Runs the cache-first background revalidation after `init()` has completed.
+  ///
+  /// Refreshes the discovery document if it is stale, then re-runs the full
+  /// [loadCachedTokens] validation (re-verify, refresh-if-expired, userinfo,
+  /// save) so the outcome is surfaced through [userChanges]/[events]. If the
+  /// token is discarded as invalid (and offline auth is not keeping it), the
+  /// stale restored user is forgotten.
+  Future<void> _scheduleBackgroundRevalidation(OidcUser restoredUser) async {
+    // Wait until init() has fully returned (didInit == true) before touching
+    // init-guarded getters.
+    await initFuture;
+    try {
+      await _refreshDiscoveryInBackgroundIfStale();
+      await loadCachedTokens(forceRebuild: true);
+      // If loadCachedTokens discarded the tokens as invalid without replacing
+      // the surfaced user, reconcile by forgetting the stale restored user.
+      if (identical(currentUser, restoredUser)) {
+        final raw = await store.get(
+          OidcStoreNamespace.secureTokens,
+          key: OidcConstants_Store.currentToken,
+          managerId: id,
+        );
+        if (raw == null) {
+          await forgetUser();
+        }
+      }
+    } on Object catch (e, st) {
+      logger.warning(
+        'cache-first init: background revalidation failed.',
+        e,
+        st,
+      );
+    }
   }
 
   /// Disposes the resources used by this class.

--- a/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
+++ b/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
@@ -61,12 +61,30 @@ enum OidcInitMode {
   /// This makes cold-start `init()` fast and offline-friendly at the cost of a
   /// brief window where the surfaced user has not yet been re-verified against
   /// the network.
+  ///
+  /// **Note — [OidcUserManagerBase.userChanges] emits TWICE on a cold start:**
+  /// once for the locally-restored (unverified) user, then again for the
+  /// background-rebuilt user once revalidation completes. The second object is
+  /// distinct even when its claims are unchanged — its id_token is now VERIFIED
+  /// (`parsedIdToken.isVerified == true`) and/or its token was refreshed — so
+  /// this second emission is intentional and must not be deduplicated: it is how
+  /// the verified/refreshed state is surfaced. Listeners that need a single
+  /// settled value should key off `parsedIdToken.isVerified` (or use
+  /// [blockingValidate]).
   cacheFirst,
 
   /// The pre-existing semantics (opt-in escape hatch): `init()` blocks until
   /// the discovery document is fetched/validated and the cached token is fully
   /// re-verified (and refreshed/userinfo-fetched) before completing. Choose
   /// this when callers must not observe an unverified user after `init()`.
+  ///
+  /// **Not a byte-for-byte replica of the pre-1.0 `init()` network behavior.**
+  /// The discovery document is now served from the shared TTL cache
+  /// (see [OidcUserManagerSettings.discoveryDocumentMaxAge], default 1 day), so
+  /// a cached `.well-known` document within that window is NOT re-fetched — the
+  /// old code fetched it on every `init()`. To reproduce the exact previous
+  /// network behavior (a discovery fetch on every `init()`), also set
+  /// `discoveryDocumentMaxAge: Duration.zero`.
   blockingValidate,
 }
 
@@ -430,6 +448,12 @@ class OidcUserManagerSettings {
   /// revalidate in the background. Set to [OidcInitMode.blockingValidate] to
   /// keep the previous behavior (block on the network until the cached token is
   /// fully re-verified before `init()` completes).
+  ///
+  /// [OidcInitMode.blockingValidate] is close to but NOT a byte-for-byte replica
+  /// of the pre-1.0 `init()`: the discovery document is now served from the
+  /// [discoveryDocumentMaxAge] TTL cache, so a `.well-known` fetch within that
+  /// window is skipped. Combine it with `discoveryDocumentMaxAge: Duration.zero`
+  /// to also restore the previous fetch-on-every-`init()` network behavior.
   final OidcInitMode initMode;
 
   /// An optional base discovery document whose members are merged UNDER the

--- a/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
+++ b/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
@@ -8,6 +8,68 @@ Duration? defaultRefreshBefore(OidcToken token) {
   return const Duration(minutes: 1);
 }
 
+/// The callback used by [OidcUserManagerSettings.isLoadedTokenAcceptable] to
+/// decide, when tokens are restored from the [OidcStore] during `init()`,
+/// whether the loaded token should be treated as acceptable despite (or in the
+/// absence of) validation errors.
+///
+/// [validationErrors] is the exact list produced by the manager's internal
+/// `validateUser` for the loaded id_token (empty when the token validated
+/// cleanly).
+///
+/// Return:
+/// - `true`  → accept the loaded token as-is and surface the user immediately,
+///   skipping the refresh / userinfo round-trips.
+/// - `false` → reject the loaded token (proceed to the discard branch, see
+///   [OidcShouldRemoveInvalidTokenCallback]).
+/// - `null`  → apply the default policy (the current, unchanged behavior:
+///   refresh when expired, then re-validate).
+typedef OidcIsLoadedTokenAcceptableCallback =
+    bool? Function(OidcUser user, List<Exception> validationErrors);
+
+/// The callback used by [OidcUserManagerSettings.shouldRemoveInvalidToken] to
+/// decide whether a loaded-but-invalid token is removed from the [OidcStore].
+///
+/// Invoked in the discard branch of cached-token loading with the loaded
+/// [user] and its [validationErrors].
+///
+/// Return:
+/// - `true`  → remove the cached tokens from the store.
+/// - `false` → keep the cached tokens (e.g. for a bespoke offline policy).
+/// - `null`  → apply the default policy, which removes the tokens unless
+///   [OidcUserManagerSettings.supportOfflineAuth] is enabled.
+typedef OidcShouldRemoveInvalidTokenCallback =
+    bool? Function(OidcUser user, List<Exception> validationErrors);
+
+/// Controls how [OidcUserManagerBase.init] restores a previously-cached user.
+///
+/// **This changes the DEFAULT `init()` semantics** (see [OidcInitMode.cacheFirst]
+/// vs [OidcInitMode.blockingValidate]).
+enum OidcInitMode {
+  /// **The new default.** `init()` restores the cached user by a PURE local
+  /// deserialize (no network) and completes immediately, then revalidates in
+  /// the background — refreshing the discovery document if it is stale
+  /// (see [OidcUserManagerSettings.discoveryDocumentMaxAge]), refreshing the
+  /// token if it is expired, and calling the userinfo endpoint when enabled.
+  ///
+  /// Background outcomes are surfaced through the existing channels:
+  /// [OidcUserManagerBase.userChanges] emits when the user object changes and
+  /// [OidcUserManagerBase.events] emits on failures. When there is no cached
+  /// user (or no locally-cached discovery document), `init()` transparently
+  /// falls back to the [blockingValidate] network path.
+  ///
+  /// This makes cold-start `init()` fast and offline-friendly at the cost of a
+  /// brief window where the surfaced user has not yet been re-verified against
+  /// the network.
+  cacheFirst,
+
+  /// The pre-existing semantics (opt-in escape hatch): `init()` blocks until
+  /// the discovery document is fetched/validated and the cached token is fully
+  /// re-verified (and refreshed/userinfo-fetched) before completing. Choose
+  /// this when callers must not observe an unverified user after `init()`.
+  blockingValidate,
+}
+
 /// The callback used to determine the retry delay for offline mode refresh attempts.
 typedef OidcOfflineRefreshRetryDelayCallback =
     Duration Function(
@@ -65,6 +127,11 @@ class OidcUserManagerSettings {
     this.extraAuthenticationParameters,
     this.expiryTolerance = const Duration(minutes: 1),
     this.jwksCacheMaxAge = const Duration(days: 1),
+    this.discoveryDocumentMaxAge = const Duration(days: 1),
+    this.initMode = OidcInitMode.cacheFirst,
+    this.metadataSeed,
+    this.isLoadedTokenAcceptable,
+    this.shouldRemoveInvalidToken,
     this.extraTokenParameters,
     this.postLogoutRedirectUri,
     this.options,
@@ -335,6 +402,60 @@ class OidcUserManagerSettings {
   /// (Rotation of Asymmetric Signing Keys), an RP must obtain rotated keys and
   /// must not pin a stale/retired key set indefinitely.
   final Duration jwksCacheMaxAge;
+
+  /// How long a persisted discovery document may be served from the
+  /// [OidcStore] before it is treated as stale and re-fetched from the network.
+  ///
+  /// The document is persisted alongside a sidecar epoch-millis fetched-at
+  /// timestamp (mirroring [OidcJwksStoreLoader]'s `::oidc_jwks_fetched_at`
+  /// pattern, under the `::oidc_discovery_fetched_at` key). Within this window
+  /// the manager skips the network `.well-known` fetch and uses the cached
+  /// document; beyond it the document is refreshed (in the background under
+  /// [OidcInitMode.cacheFirst], blocking under [OidcInitMode.blockingValidate]).
+  /// If the refresh fails (e.g. offline), the stale cached document is still
+  /// served (mirroring the JWKS loader's offline-fallback behavior).
+  ///
+  /// [Duration.zero]/negative disables the TTL cache — every `init()` re-fetches
+  /// the document (the cached copy remains only as an offline fallback).
+  ///
+  /// Defaults to `const Duration(days: 1)`, matching [jwksCacheMaxAge] and the
+  /// ~24h OP-metadata TTL used by MSAL. (oidc-client-ts caches OP metadata
+  /// only in-memory for the session; this persists it across restarts.)
+  final Duration discoveryDocumentMaxAge;
+
+  /// Controls how [OidcUserManagerBase.init] restores a cached user.
+  ///
+  /// Defaults to [OidcInitMode.cacheFirst] — **this changes the default
+  /// `init()` semantics** to restore the cached user locally (no network) and
+  /// revalidate in the background. Set to [OidcInitMode.blockingValidate] to
+  /// keep the previous behavior (block on the network until the cached token is
+  /// fully re-verified before `init()` completes).
+  final OidcInitMode initMode;
+
+  /// An optional base discovery document whose members are merged UNDER the
+  /// fetched (or cached) document — the fetched/cached values override the seed
+  /// (matching oidc-client-ts `metadataSeed` semantics).
+  ///
+  /// Use this to supply endpoints an OP omits from its `.well-known` document,
+  /// or to prime the manager before the first network fetch. The seed does not
+  /// affect the eagerly-supplied [OidcUserManagerBase] (non-`.lazy`) constructor
+  /// path, which is a full override and stays untouched. The seed is applied
+  /// in-memory on every load and is never persisted.
+  final OidcProviderMetadata? metadataSeed;
+
+  /// Optional developer control over whether a token restored from the store
+  /// during `init()` is accepted despite (or in the absence of) validation
+  /// errors. See [OidcIsLoadedTokenAcceptableCallback].
+  ///
+  /// Defaults to `null` — the current behavior is preserved exactly.
+  final OidcIsLoadedTokenAcceptableCallback? isLoadedTokenAcceptable;
+
+  /// Optional developer control over whether a loaded-but-invalid token is
+  /// removed from the store. See [OidcShouldRemoveInvalidTokenCallback].
+  ///
+  /// Defaults to `null` — the current behavior is preserved exactly (removed
+  /// unless [supportOfflineAuth] is enabled).
+  final OidcShouldRemoveInvalidTokenCallback? shouldRemoveInvalidToken;
 
   /// Settings related to the session management spec.
   final OidcSessionManagementSettings sessionManagementSettings;

--- a/packages/oidc_core/test/audit_p0_regression_test.dart
+++ b/packages/oidc_core/test/audit_p0_regression_test.dart
@@ -590,6 +590,96 @@ void main() {
     );
 
     test(
+      't7b (#201): the SAME startup cached-load refresh failure under the '
+      'DEFAULT cacheFirst mode ALSO emits EXACTLY ONE failure event '
+      '(source=startupLoad) — the restored-user expiry timers do NOT race a '
+      'second refresh, and the terminal failure forgets the user',
+      () async {
+        final store = OidcMemoryStore();
+
+        // Seed an expired-but-refreshable user (same shape as t7).
+        final seeder = _TestManager(
+          discoveryDocument: _metadataNoGrantTypes(),
+          clientCredentials: const OidcClientAuthentication.none(
+            clientId: 'client-1',
+          ),
+          store: store,
+          httpClient: MockClient((req) async => http.Response('{}', 404)),
+          settings: OidcUserManagerSettings(
+            redirectUri: Uri.parse('com.example.app://cb'),
+          ),
+        );
+        await seeder.init();
+        await seeder.saveUserTest(
+          await OidcUser.fromIdToken(
+            token: OidcToken(
+              creationTime: clock.now().subtract(const Duration(hours: 2)),
+              idToken: _signIdToken({
+                'exp':
+                    clock
+                        .now()
+                        .subtract(const Duration(hours: 1))
+                        .millisecondsSinceEpoch ~/
+                    1000,
+              }),
+              accessToken: 'at-old',
+              refreshToken: 'rt-old',
+              tokenType: 'Bearer',
+              expiresIn: const Duration(hours: 1),
+            ),
+          ),
+        );
+        await seeder.dispose();
+
+        // A fresh manager over the SAME store; /token rejects the refresh with
+        // invalid_grant. NO initMode override => the new default (cacheFirst):
+        // the expired cached user is surfaced first, arming the expiry timers,
+        // WHILE the background revalidation refreshes. Both must resolve to a
+        // SINGLE refresh + SINGLE failure event (#201 BLOCKER 1 — the previous
+        // masking that pinned t7 to blockingValidate is undone here).
+        final manager = _TestManager(
+          discoveryDocument: _metadataNoGrantTypes(),
+          clientCredentials: const OidcClientAuthentication.none(
+            clientId: 'client-1',
+          ),
+          store: store,
+          httpClient: MockClient((req) async {
+            if (req.url.path.endsWith('/jwks')) return _jwks();
+            if (req.url.path.endsWith('/token')) return _invalidGrant();
+            return http.Response('{}', 404);
+          }),
+          settings: OidcUserManagerSettings(
+            redirectUri: Uri.parse('com.example.app://cb'),
+          ),
+        );
+        addTearDown(manager.dispose);
+        final events = <OidcEvent>[];
+        final sub = manager.events().listen(events.add);
+
+        await manager.init();
+        await pumpEventQueue();
+
+        final failures = events
+            .whereType<OidcTokenRefreshFailedEvent>()
+            .toList();
+        expect(
+          failures,
+          hasLength(1),
+          reason:
+              'the DEFAULT (cacheFirst) mode must emit exactly ONE failure '
+              'event — the restored-user expiry timers must not race the '
+              'background refresh into a second /token exchange',
+        );
+        expect(failures.single.source, OidcTokenRefreshSource.startupLoad);
+        expect(failures.single.kind, OidcTokenRefreshFailureKind.terminal);
+        expect(failures.single.oauthErrorCode, 'invalid_grant');
+        // Terminal failure => the optimistically-restored user is retracted.
+        expect(manager.currentUser, isNull);
+        await sub.cancel();
+      },
+    );
+
+    test(
       't8 (#154): resume race — an expired refreshable token whose refresh '
       'SUCCEEDS retains and REPLACES the user, emits no null userChange, and '
       'refreshes exactly once (no double refresh)',

--- a/packages/oidc_core/test/audit_p0_regression_test.dart
+++ b/packages/oidc_core/test/audit_p0_regression_test.dart
@@ -555,6 +555,13 @@ void main() {
           }),
           settings: OidcUserManagerSettings(
             redirectUri: Uri.parse('com.example.app://cb'),
+            // #201 rebase: the new default (OidcInitMode.cacheFirst) surfaces
+            // the expired cached user first, so the expiry listener AND the
+            // background revalidation each attempt a refresh — two failure
+            // events. This probe targets the blocking startup cached-load
+            // catch specifically (that it does not itself re-emit), so it pins
+            // the pre-existing blocking semantics it was written against.
+            initMode: OidcInitMode.blockingValidate,
           ),
         );
         addTearDown(manager.dispose);

--- a/packages/oidc_core/test/cache_first_init_test.dart
+++ b/packages/oidc_core/test/cache_first_init_test.dart
@@ -1,0 +1,592 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+const _issuer = 'https://op.example.com';
+final Uri _wellKnown = Uri.parse(
+  '$_issuer/.well-known/openid-configuration',
+);
+final JsonWebKey _signingKey = JsonWebKey.generate('RS256');
+
+String _signIdToken({
+  String subject = 'user-1',
+  String issuer = _issuer,
+  Duration expiresIn = const Duration(hours: 1),
+}) {
+  final now = clock.now().millisecondsSinceEpoch ~/ 1000;
+  return (JsonWebSignatureBuilder()
+        ..jsonContent = {
+          'iss': issuer,
+          'sub': subject,
+          'aud': 'client-1',
+          'exp': now + expiresIn.inSeconds,
+          'iat': now,
+        }
+        ..addRecipient(_signingKey, algorithm: 'RS256'))
+      .build()
+      .toCompactSerialization();
+}
+
+Map<String, dynamic> _metadataJson({
+  String issuer = _issuer,
+  bool includeUserinfo = true,
+  Map<String, dynamic> extra = const {},
+}) => {
+  'issuer': issuer,
+  'authorization_endpoint': '$_issuer/authorize',
+  'token_endpoint': '$_issuer/token',
+  if (includeUserinfo) 'userinfo_endpoint': '$_issuer/userinfo',
+  // No `jwks_uri`: the tests inject the signing key into the manager keyStore
+  // directly, so id_token verification never needs a network JWKS fetch.
+  'id_token_signing_alg_values_supported': ['RS256'],
+  ...extra,
+};
+
+/// A concrete manager built via the `.lazy` constructor so the tests can drive
+/// `init()` end-to-end against a discovery URL.
+class _Manager extends OidcUserManagerBase {
+  _Manager.lazy({
+    required super.discoveryDocumentUri,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    super.httpClient,
+    super.keyStore,
+  }) : super.lazy();
+
+  @override
+  bool get isWeb => false;
+
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+/// A MockClient that records every request path and answers the standard
+/// discovery / userinfo / token endpoints.
+http.Client _client(
+  List<String> log, {
+  bool failDiscovery = false,
+  Map<String, dynamic>? metadata,
+}) => MockClient((req) async {
+  log.add(req.url.path);
+  final path = req.url.path;
+  if (path.endsWith('openid-configuration')) {
+    if (failDiscovery) {
+      throw const SocketException('offline');
+    }
+    return http.Response(
+      jsonEncode(metadata ?? _metadataJson()),
+      200,
+      headers: const {'content-type': 'application/json'},
+    );
+  }
+  if (path.endsWith('/userinfo')) {
+    return http.Response(
+      jsonEncode({'sub': 'user-1'}),
+      200,
+      headers: const {'content-type': 'application/json'},
+    );
+  }
+  if (path.endsWith('/token')) {
+    return http.Response(
+      jsonEncode({
+        'access_token': 'at-refreshed',
+        'token_type': 'Bearer',
+        'expires_in': 3600,
+        'id_token': _signIdToken(),
+      }),
+      200,
+      headers: const {'content-type': 'application/json'},
+    );
+  }
+  return http.Response('{}', 404);
+});
+
+String _tokenJson({
+  String? idToken,
+  String accessToken = 'at-cached',
+  String? refreshToken,
+  Duration expiresIn = const Duration(hours: 1),
+  DateTime? creationTime,
+}) => jsonEncode(
+  OidcToken(
+    creationTime: creationTime ?? clock.now().toUtc(),
+    idToken: idToken ?? _signIdToken(),
+    accessToken: accessToken,
+    tokenType: 'Bearer',
+    expiresIn: expiresIn,
+    refreshToken: refreshToken,
+  ).toJson(),
+);
+
+Future<OidcMemoryStore> _seededStore({
+  String? discoveryMetadata,
+  int? discoveryTimestampMs,
+  String? tokenJson,
+}) async {
+  final store = OidcMemoryStore();
+  await store.init();
+  if (discoveryMetadata != null) {
+    await store.setMany(
+      OidcStoreNamespace.discoveryDocument,
+      values: {
+        _wellKnown.toString(): discoveryMetadata,
+        if (discoveryTimestampMs != null)
+          '$_wellKnown::oidc_discovery_fetched_at': discoveryTimestampMs
+              .toString(),
+      },
+    );
+  }
+  if (tokenJson != null) {
+    await store.setMany(
+      OidcStoreNamespace.secureTokens,
+      values: {OidcConstants_Store.currentToken: tokenJson},
+    );
+  }
+  return store;
+}
+
+_Manager _lazyManager({
+  required OidcStore store,
+  required http.Client client,
+  OidcUserManagerSettings? settings,
+}) => _Manager.lazy(
+  discoveryDocumentUri: _wellKnown,
+  clientCredentials: const OidcClientAuthentication.none(clientId: 'client-1'),
+  store: store,
+  httpClient: client,
+  keyStore: JsonWebKeyStore()..addKey(_signingKey),
+  settings:
+      settings ?? OidcUserManagerSettings(redirectUri: Uri.parse('app://cb')),
+);
+
+void main() {
+  group('cacheFirst init (new default)', () {
+    test(
+      'restores the cached user with ZERO network calls, then '
+      'revalidates in the background',
+      () async {
+        final net = <String>[];
+        final verifiedSeq = <bool?>[];
+
+        // Seed a fresh cached discovery document + a valid cached token.
+        final store = await _seededStore(
+          discoveryMetadata: jsonEncode(_metadataJson()),
+          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+          tokenJson: _tokenJson(),
+        );
+        final manager = _lazyManager(store: store, client: _client(net));
+        manager.userChanges().listen((u) {
+          if (u != null) {
+            verifiedSeq.add(u.parsedIdToken.isVerified);
+          }
+        });
+
+        await manager.init();
+
+        // init() itself performed NO network I/O: the cached user was restored
+        // by a pure local deserialize. The background revalidation is gated on
+        // the completed initFuture and has only read the store so far.
+        expect(net, isEmpty);
+        expect(manager.currentUser, isNotNull);
+        // The restored user is not yet verified against the network.
+        expect(manager.currentUser!.parsedIdToken.isVerified, isNull);
+
+        // Drive the background revalidation to completion.
+        await pumpEventQueue();
+
+        // The first surfaced user was the local (unverified => isVerified null)
+        // restore; the background pass replaced it with a verified user.
+        expect(verifiedSeq.first, isNull);
+        expect(verifiedSeq.last, isTrue);
+        expect(manager.currentUser!.parsedIdToken.isVerified, isTrue);
+        // Fresh discovery => no discovery fetch; the only network call the
+        // background made was the userinfo request.
+        expect(net.where((p) => p.endsWith('openid-configuration')), isEmpty);
+        expect(net.where((p) => p.endsWith('/userinfo')).length, 1);
+        await manager.dispose();
+      },
+    );
+
+    test('with no cached user, falls back to the network path', () async {
+      final net = <String>[];
+      // No cached discovery, no cached token.
+      final store = await _seededStore();
+      final manager = _lazyManager(store: store, client: _client(net));
+
+      await manager.init();
+
+      // The blocking network path fetched the discovery document.
+      expect(net.where((p) => p.endsWith('openid-configuration')).length, 1);
+      expect(manager.currentUser, isNull);
+      await manager.dispose();
+    });
+
+    test(
+      'a locally-restored (unverified) user is available immediately after '
+      'init() returns, before any network I/O',
+      () async {
+        final net = <String>[];
+        final store = await _seededStore(
+          discoveryMetadata: jsonEncode(_metadataJson()),
+          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+          tokenJson: _tokenJson(),
+        );
+        final manager = _lazyManager(store: store, client: _client(net));
+
+        await manager.init();
+
+        // Right after init() resolves, the background revalidation has not yet
+        // performed any network request (it is gated on the completed
+        // initFuture and only reads the store first).
+        expect(net, isEmpty);
+        expect(manager.currentUser, isNotNull);
+        // Locally restored, not yet verified against the network.
+        expect(manager.currentUser!.parsedIdToken.isVerified, isNull);
+        await manager.dispose();
+      },
+    );
+  });
+
+  group('blockingValidate init (escape hatch)', () {
+    test('fully verifies the cached user before init() completes', () async {
+      final net = <String>[];
+      final store = await _seededStore(
+        discoveryMetadata: jsonEncode(_metadataJson()),
+        discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+        tokenJson: _tokenJson(),
+      );
+      final manager = _lazyManager(
+        store: store,
+        client: _client(net),
+        settings: OidcUserManagerSettings(
+          redirectUri: Uri.parse('app://cb'),
+          initMode: OidcInitMode.blockingValidate,
+        ),
+      );
+
+      await manager.init();
+
+      // The user is already verified when init() returns (no background pass),
+      // and userinfo was called synchronously as part of init().
+      expect(manager.currentUser, isNotNull);
+      expect(manager.currentUser!.parsedIdToken.isVerified, isTrue);
+      expect(net.where((p) => p.endsWith('/userinfo')).length, 1);
+      await manager.dispose();
+    });
+  });
+
+  group('discovery document TTL cache', () {
+    final t0 = DateTime.utc(2026, 1, 1, 12);
+
+    test('within TTL skips the network fetch', () async {
+      await withClock(Clock.fixed(t0), () async {
+        final net = <String>[];
+        final store = await _seededStore(
+          discoveryMetadata: jsonEncode(_metadataJson()),
+          discoveryTimestampMs: t0.millisecondsSinceEpoch,
+        );
+        final manager = _lazyManager(
+          store: store,
+          client: _client(net),
+          settings: OidcUserManagerSettings(
+            redirectUri: Uri.parse('app://cb'),
+            initMode: OidcInitMode.blockingValidate,
+          ),
+        );
+
+        await manager.init();
+
+        expect(net.where((p) => p.endsWith('openid-configuration')), isEmpty);
+        expect(manager.discoveryDocument.issuer.toString(), _issuer);
+        await manager.dispose();
+      });
+    });
+
+    test('beyond TTL re-fetches and refreshes the timestamp', () async {
+      final net = <String>[];
+      final store = await _seededStore(
+        discoveryMetadata: jsonEncode(_metadataJson()),
+        // Seeded 2 days ago -> stale against the 1-day default.
+        discoveryTimestampMs: t0
+            .subtract(const Duration(days: 2))
+            .millisecondsSinceEpoch,
+      );
+      await withClock(Clock.fixed(t0), () async {
+        final manager = _lazyManager(
+          store: store,
+          client: _client(net),
+          settings: OidcUserManagerSettings(
+            redirectUri: Uri.parse('app://cb'),
+            initMode: OidcInitMode.blockingValidate,
+          ),
+        );
+
+        await manager.init();
+
+        expect(
+          net.where((p) => p.endsWith('openid-configuration')).length,
+          1,
+        );
+        await manager.dispose();
+      });
+      // The sidecar timestamp was refreshed to "now".
+      final sidecar = await store.get(
+        OidcStoreNamespace.discoveryDocument,
+        key: '$_wellKnown::oidc_discovery_fetched_at',
+      );
+      expect(sidecar, t0.millisecondsSinceEpoch.toString());
+    });
+
+    test('beyond TTL but offline serves the stale cached document', () async {
+      final net = <String>[];
+      final store = await _seededStore(
+        discoveryMetadata: jsonEncode(_metadataJson()),
+        discoveryTimestampMs: t0
+            .subtract(const Duration(days: 2))
+            .millisecondsSinceEpoch,
+      );
+      await withClock(Clock.fixed(t0), () async {
+        final manager = _lazyManager(
+          store: store,
+          client: _client(net, failDiscovery: true),
+          settings: OidcUserManagerSettings(
+            redirectUri: Uri.parse('app://cb'),
+            initMode: OidcInitMode.blockingValidate,
+          ),
+        );
+
+        // A failing refresh does not throw: the stale cache is served.
+        await manager.init();
+
+        expect(
+          net.where((p) => p.endsWith('openid-configuration')).length,
+          1,
+        );
+        expect(manager.discoveryDocument.issuer.toString(), _issuer);
+        await manager.dispose();
+      });
+    });
+  });
+
+  group('loaded-token validity callbacks (#205)', () {
+    OidcUserManagerSettings settings({
+      OidcIsLoadedTokenAcceptableCallback? isAcceptable,
+      OidcShouldRemoveInvalidTokenCallback? shouldRemove,
+    }) => OidcUserManagerSettings(
+      redirectUri: Uri.parse('app://cb'),
+      initMode: OidcInitMode.blockingValidate,
+      userInfoSettings: const OidcUserInfoSettings(sendUserInfoRequest: false),
+      isLoadedTokenAcceptable: isAcceptable,
+      shouldRemoveInvalidToken: shouldRemove,
+    );
+
+    test(
+      'isLoadedTokenAcceptable=true accepts an expired token without '
+      'refreshing',
+      () async {
+        final net = <String>[];
+        // Expired id_token WITH a refresh token: default policy would refresh.
+        final store = await _seededStore(
+          discoveryMetadata: jsonEncode(_metadataJson()),
+          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+          tokenJson: _tokenJson(
+            idToken: _signIdToken(expiresIn: const Duration(hours: -1)),
+            refreshToken: 'rt-cached',
+          ),
+        );
+        List<Exception>? seenErrors;
+        final manager = _lazyManager(
+          store: store,
+          client: _client(net),
+          settings: settings(
+            isAcceptable: (user, errors) {
+              seenErrors = errors;
+              return true;
+            },
+          ),
+        );
+
+        await manager.init();
+
+        expect(manager.currentUser, isNotNull);
+        // The callback saw the expiry error...
+        expect(seenErrors, isNotNull);
+        expect(seenErrors, isNotEmpty);
+        // ...and accepting short-circuited the refresh (no /token call).
+        expect(net.where((p) => p.endsWith('/token')), isEmpty);
+        await manager.dispose();
+      },
+    );
+
+    test(
+      'isLoadedTokenAcceptable=false discards and (by default) removes the '
+      'tokens',
+      () async {
+        final net = <String>[];
+        final store = await _seededStore(
+          discoveryMetadata: jsonEncode(_metadataJson()),
+          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+          tokenJson: _tokenJson(),
+        );
+        final manager = _lazyManager(
+          store: store,
+          client: _client(net),
+          settings: settings(isAcceptable: (user, errors) => false),
+        );
+
+        await manager.init();
+
+        expect(manager.currentUser, isNull);
+        final remaining = await store.get(
+          OidcStoreNamespace.secureTokens,
+          key: OidcConstants_Store.currentToken,
+        );
+        expect(remaining, isNull);
+        await manager.dispose();
+      },
+    );
+
+    test(
+      'shouldRemoveInvalidToken=false keeps the discarded tokens',
+      () async {
+        final net = <String>[];
+        final store = await _seededStore(
+          discoveryMetadata: jsonEncode(_metadataJson()),
+          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+          tokenJson: _tokenJson(),
+        );
+        final manager = _lazyManager(
+          store: store,
+          client: _client(net),
+          settings: settings(
+            isAcceptable: (user, errors) => false,
+            shouldRemove: (user, errors) => false,
+          ),
+        );
+
+        await manager.init();
+
+        expect(manager.currentUser, isNull);
+        // The developer kept the tokens despite the rejection.
+        final remaining = await store.get(
+          OidcStoreNamespace.secureTokens,
+          key: OidcConstants_Store.currentToken,
+        );
+        expect(remaining, isNotNull);
+        await manager.dispose();
+      },
+    );
+
+    test(
+      'null callbacks preserve the default behavior (invalid token removed)',
+      () async {
+        final net = <String>[];
+        // A wrong-issuer id_token fails validation; default policy removes it.
+        final store = await _seededStore(
+          discoveryMetadata: jsonEncode(_metadataJson()),
+          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+          tokenJson: _tokenJson(
+            idToken: _signIdToken(issuer: 'https://evil.example.com'),
+          ),
+        );
+        final manager = _lazyManager(
+          store: store,
+          client: _client(net),
+          settings: settings(),
+        );
+
+        await manager.init();
+
+        expect(manager.currentUser, isNull);
+        final remaining = await store.get(
+          OidcStoreNamespace.secureTokens,
+          key: OidcConstants_Store.currentToken,
+        );
+        expect(remaining, isNull);
+        await manager.dispose();
+      },
+    );
+  });
+
+  group('metadataSeed merge order', () {
+    test(
+      'fetched values override the seed; seed-only members survive',
+      () async {
+        final net = <String>[];
+        // Fetched document has NO end_session_endpoint and a different issuer.
+        final store = await _seededStore();
+        final seed = OidcProviderMetadata.fromJson({
+          'issuer': 'https://seed.example.com',
+          'end_session_endpoint': '$_issuer/logout',
+        });
+        final manager = _lazyManager(
+          store: store,
+          client: _client(net, metadata: _metadataJson()),
+          settings: OidcUserManagerSettings(
+            redirectUri: Uri.parse('app://cb'),
+            initMode: OidcInitMode.blockingValidate,
+            metadataSeed: seed,
+          ),
+        );
+
+        await manager.init();
+
+        // Fetched issuer overrides the seed's issuer.
+        expect(manager.discoveryDocument.issuer.toString(), _issuer);
+        // Seed-only member is preserved (fetched doc omitted it).
+        expect(
+          manager.discoveryDocument.endSessionEndpoint.toString(),
+          '$_issuer/logout',
+        );
+        // A fetched-only member is present too.
+        expect(
+          manager.discoveryDocument.tokenEndpoint.toString(),
+          '$_issuer/token',
+        );
+        await manager.dispose();
+      },
+    );
+  });
+}

--- a/packages/oidc_core/test/cache_first_init_test.dart
+++ b/packages/oidc_core/test/cache_first_init_test.dart
@@ -107,6 +107,7 @@ class _Manager extends OidcUserManagerBase {
 http.Client _client(
   List<String> log, {
   bool failDiscovery = false,
+  bool failTokenInvalidGrant = false,
   Map<String, dynamic>? metadata,
 }) => MockClient((req) async {
   log.add(req.url.path);
@@ -129,6 +130,17 @@ http.Client _client(
     );
   }
   if (path.endsWith('/token')) {
+    if (failTokenInvalidGrant) {
+      // RFC 6749 §5.2 terminal error: a revoked/rotated refresh token.
+      return http.Response(
+        jsonEncode({
+          'error': 'invalid_grant',
+          'error_description': 'refresh token revoked',
+        }),
+        400,
+        headers: const {'content-type': 'application/json'},
+      );
+    }
     return http.Response(
       jsonEncode({
         'access_token': 'at-refreshed',
@@ -287,6 +299,109 @@ void main() {
         await manager.dispose();
       },
     );
+
+    // #201 BLOCKER 1: on a cache-first cold start with an EXPIRED-but-refreshable
+    // cached token, the restored expired user arms the expiry timers (path A)
+    // while the background revalidation also refreshes (path B, source
+    // startupLoad). Both must NOT hit `/token` — two concurrent refresh-token
+    // exchanges can trip an OP's RFC 9700 rotation-reuse detection and revoke the
+    // family. The expiry-driven auto-refresh is suppressed until the background
+    // pass settles, so the DEFAULT mode performs EXACTLY ONE refresh.
+    test(
+      'cacheFirst DEFAULT cold start (expired+refreshable): refresh SUCCESS '
+      'does exactly ONE /token call, replaces the user (verified), no failure '
+      'event',
+      () async {
+        final net = <String>[];
+        final store = await _seededStore(
+          discoveryMetadata: jsonEncode(_metadataJson()),
+          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+          // Expired access token (created 2h ago, 1h lifetime) + expired
+          // id_token + a refresh token: BOTH the expiry timers and the
+          // background pass want to refresh.
+          tokenJson: _tokenJson(
+            idToken: _signIdToken(expiresIn: const Duration(hours: -1)),
+            accessToken: 'at-expired',
+            refreshToken: 'rt-cached',
+            creationTime: clock
+                .now()
+                .subtract(const Duration(hours: 2))
+                .toUtc(),
+          ),
+        );
+        final manager = _lazyManager(store: store, client: _client(net));
+        final failures = <OidcTokenRefreshFailedEvent>[];
+        final sub = manager.events().listen((e) {
+          if (e is OidcTokenRefreshFailedEvent) failures.add(e);
+        });
+
+        await manager.init();
+        // Drive both the (gated) expiry timers and the background revalidation.
+        await pumpEventQueue();
+
+        // Exactly ONE token exchange across BOTH paths.
+        expect(net.where((p) => p.endsWith('/token')).length, 1);
+        // The background refresh replaced the restored user with a verified one.
+        expect(manager.currentUser, isNotNull);
+        expect(manager.currentUser!.parsedIdToken.isVerified, isTrue);
+        expect(manager.currentUser!.token.accessToken, 'at-refreshed');
+        // A successful refresh emits NO failure event.
+        expect(failures, isEmpty);
+        await sub.cancel();
+        await manager.dispose();
+      },
+    );
+
+    test(
+      'cacheFirst DEFAULT cold start (expired+refreshable): refresh TERMINAL '
+      'failure emits EXACTLY ONE failure event (source=startupLoad) and forgets '
+      'the user',
+      () async {
+        final net = <String>[];
+        final store = await _seededStore(
+          discoveryMetadata: jsonEncode(_metadataJson()),
+          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+          tokenJson: _tokenJson(
+            idToken: _signIdToken(expiresIn: const Duration(hours: -1)),
+            accessToken: 'at-expired',
+            refreshToken: 'rt-cached',
+            creationTime: clock
+                .now()
+                .subtract(const Duration(hours: 2))
+                .toUtc(),
+          ),
+        );
+        final manager = _lazyManager(
+          store: store,
+          client: _client(net, failTokenInvalidGrant: true),
+        );
+        final failures = <OidcTokenRefreshFailedEvent>[];
+        final offlineEntered = <OidcOfflineModeEnteredEvent>[];
+        final sub = manager.events().listen((e) {
+          if (e is OidcTokenRefreshFailedEvent) failures.add(e);
+          if (e is OidcOfflineModeEnteredEvent) offlineEntered.add(e);
+        });
+
+        await manager.init();
+        await pumpEventQueue();
+
+        // Exactly ONE token exchange (the background-owned refresh); the
+        // expiry-driven path did not race a second one.
+        expect(net.where((p) => p.endsWith('/token')).length, 1);
+        // Exactly ONE failure event, honestly sourced to the background refresh.
+        expect(failures, hasLength(1));
+        expect(failures.single.source, OidcTokenRefreshSource.startupLoad);
+        expect(failures.single.kind, OidcTokenRefreshFailureKind.terminal);
+        expect(failures.single.oauthErrorCode, 'invalid_grant');
+        // Offline handling ran at most once (a terminal failure at the default
+        // supportOfflineAuth=false enters no offline mode).
+        expect(offlineEntered, isEmpty);
+        // The stale restored user is retracted (terminal failure => forgotten).
+        expect(manager.currentUser, isNull);
+        await sub.cancel();
+        await manager.dispose();
+      },
+    );
   });
 
   group('blockingValidate init (escape hatch)', () {
@@ -410,145 +525,168 @@ void main() {
     });
   });
 
-  group('loaded-token validity callbacks (#205)', () {
-    OidcUserManagerSettings settings({
-      OidcIsLoadedTokenAcceptableCallback? isAcceptable,
-      OidcShouldRemoveInvalidTokenCallback? shouldRemove,
-    }) => OidcUserManagerSettings(
-      redirectUri: Uri.parse('app://cb'),
-      initMode: OidcInitMode.blockingValidate,
-      userInfoSettings: const OidcUserInfoSettings(sendUserInfoRequest: false),
-      isLoadedTokenAcceptable: isAcceptable,
-      shouldRemoveInvalidToken: shouldRemove,
-    );
+  // #205 validity-callback matrix, run under BOTH init modes. The cacheFirst
+  // DEFAULT must converge on exactly what blockingValidate surfaces: a
+  // policy-REJECTED loaded token must never leave the optimistically-restored
+  // user logged in, even when the removal policy KEEPS the token on disk
+  // (reject-but-keep). Previously cacheFirst only retracted the surfaced user
+  // when the on-disk token had been removed, leaking a rejected user under a
+  // keep policy (BLOCKER 2).
+  for (final mode in OidcInitMode.values) {
+    group('loaded-token validity callbacks (#205) [$mode]', () {
+      OidcUserManagerSettings settings({
+        OidcIsLoadedTokenAcceptableCallback? isAcceptable,
+        OidcShouldRemoveInvalidTokenCallback? shouldRemove,
+      }) => OidcUserManagerSettings(
+        redirectUri: Uri.parse('app://cb'),
+        initMode: mode,
+        userInfoSettings: const OidcUserInfoSettings(
+          sendUserInfoRequest: false,
+        ),
+        isLoadedTokenAcceptable: isAcceptable,
+        shouldRemoveInvalidToken: shouldRemove,
+      );
 
-    test(
-      'isLoadedTokenAcceptable=true accepts an expired token without '
-      'refreshing',
-      () async {
-        final net = <String>[];
-        // Expired id_token WITH a refresh token: default policy would refresh.
-        final store = await _seededStore(
-          discoveryMetadata: jsonEncode(_metadataJson()),
-          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
-          tokenJson: _tokenJson(
-            idToken: _signIdToken(expiresIn: const Duration(hours: -1)),
-            refreshToken: 'rt-cached',
-          ),
-        );
-        List<Exception>? seenErrors;
-        final manager = _lazyManager(
-          store: store,
-          client: _client(net),
-          settings: settings(
-            isAcceptable: (user, errors) {
-              seenErrors = errors;
-              return true;
-            },
-          ),
-        );
+      test(
+        'isLoadedTokenAcceptable=true accepts an expired token without '
+        'refreshing',
+        () async {
+          final net = <String>[];
+          // Expired id_token WITH a refresh token, but a still-valid access
+          // token lifetime (so the expiry timers do not themselves fire): the
+          // default policy would refresh on the expired id_token.
+          final store = await _seededStore(
+            discoveryMetadata: jsonEncode(_metadataJson()),
+            discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+            tokenJson: _tokenJson(
+              idToken: _signIdToken(expiresIn: const Duration(hours: -1)),
+              refreshToken: 'rt-cached',
+            ),
+          );
+          List<Exception>? seenErrors;
+          final manager = _lazyManager(
+            store: store,
+            client: _client(net),
+            settings: settings(
+              isAcceptable: (user, errors) {
+                seenErrors = errors;
+                return true;
+              },
+            ),
+          );
 
-        await manager.init();
+          await manager.init();
+          // Under cacheFirst the callback runs in the background pass, so drain
+          // it before asserting; harmless (no pending work) under blocking.
+          await pumpEventQueue();
 
-        expect(manager.currentUser, isNotNull);
-        // The callback saw the expiry error...
-        expect(seenErrors, isNotNull);
-        expect(seenErrors, isNotEmpty);
-        // ...and accepting short-circuited the refresh (no /token call).
-        expect(net.where((p) => p.endsWith('/token')), isEmpty);
-        await manager.dispose();
-      },
-    );
+          expect(manager.currentUser, isNotNull);
+          // The callback saw the expiry error...
+          expect(seenErrors, isNotNull);
+          expect(seenErrors, isNotEmpty);
+          // ...and accepting short-circuited the refresh (no /token call).
+          expect(net.where((p) => p.endsWith('/token')), isEmpty);
+          await manager.dispose();
+        },
+      );
 
-    test(
-      'isLoadedTokenAcceptable=false discards and (by default) removes the '
-      'tokens',
-      () async {
-        final net = <String>[];
-        final store = await _seededStore(
-          discoveryMetadata: jsonEncode(_metadataJson()),
-          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
-          tokenJson: _tokenJson(),
-        );
-        final manager = _lazyManager(
-          store: store,
-          client: _client(net),
-          settings: settings(isAcceptable: (user, errors) => false),
-        );
+      test(
+        'isLoadedTokenAcceptable=false discards and (by default) removes the '
+        'tokens',
+        () async {
+          final net = <String>[];
+          final store = await _seededStore(
+            discoveryMetadata: jsonEncode(_metadataJson()),
+            discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+            tokenJson: _tokenJson(),
+          );
+          final manager = _lazyManager(
+            store: store,
+            client: _client(net),
+            settings: settings(isAcceptable: (user, errors) => false),
+          );
 
-        await manager.init();
+          await manager.init();
+          await pumpEventQueue();
 
-        expect(manager.currentUser, isNull);
-        final remaining = await store.get(
-          OidcStoreNamespace.secureTokens,
-          key: OidcConstants_Store.currentToken,
-        );
-        expect(remaining, isNull);
-        await manager.dispose();
-      },
-    );
+          expect(manager.currentUser, isNull);
+          final remaining = await store.get(
+            OidcStoreNamespace.secureTokens,
+            key: OidcConstants_Store.currentToken,
+          );
+          expect(remaining, isNull);
+          await manager.dispose();
+        },
+      );
 
-    test(
-      'shouldRemoveInvalidToken=false keeps the discarded tokens',
-      () async {
-        final net = <String>[];
-        final store = await _seededStore(
-          discoveryMetadata: jsonEncode(_metadataJson()),
-          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
-          tokenJson: _tokenJson(),
-        );
-        final manager = _lazyManager(
-          store: store,
-          client: _client(net),
-          settings: settings(
-            isAcceptable: (user, errors) => false,
-            shouldRemove: (user, errors) => false,
-          ),
-        );
+      test(
+        'shouldRemoveInvalidToken=false keeps the discarded tokens '
+        '(reject-but-keep) yet surfaces NO user',
+        () async {
+          final net = <String>[];
+          final store = await _seededStore(
+            discoveryMetadata: jsonEncode(_metadataJson()),
+            discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+            tokenJson: _tokenJson(),
+          );
+          final manager = _lazyManager(
+            store: store,
+            client: _client(net),
+            settings: settings(
+              isAcceptable: (user, errors) => false,
+              shouldRemove: (user, errors) => false,
+            ),
+          );
 
-        await manager.init();
+          await manager.init();
+          await pumpEventQueue();
 
-        expect(manager.currentUser, isNull);
-        // The developer kept the tokens despite the rejection.
-        final remaining = await store.get(
-          OidcStoreNamespace.secureTokens,
-          key: OidcConstants_Store.currentToken,
-        );
-        expect(remaining, isNotNull);
-        await manager.dispose();
-      },
-    );
+          // Reject-but-keep: no user in EITHER mode (BLOCKER 2 — cacheFirst must
+          // not leak the rejected restored user just because the token stayed on
+          // disk).
+          expect(manager.currentUser, isNull);
+          // The developer kept the tokens despite the rejection.
+          final remaining = await store.get(
+            OidcStoreNamespace.secureTokens,
+            key: OidcConstants_Store.currentToken,
+          );
+          expect(remaining, isNotNull);
+          await manager.dispose();
+        },
+      );
 
-    test(
-      'null callbacks preserve the default behavior (invalid token removed)',
-      () async {
-        final net = <String>[];
-        // A wrong-issuer id_token fails validation; default policy removes it.
-        final store = await _seededStore(
-          discoveryMetadata: jsonEncode(_metadataJson()),
-          discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
-          tokenJson: _tokenJson(
-            idToken: _signIdToken(issuer: 'https://evil.example.com'),
-          ),
-        );
-        final manager = _lazyManager(
-          store: store,
-          client: _client(net),
-          settings: settings(),
-        );
+      test(
+        'null callbacks preserve the default behavior (invalid token removed)',
+        () async {
+          final net = <String>[];
+          // A wrong-issuer id_token fails validation; default policy removes it.
+          final store = await _seededStore(
+            discoveryMetadata: jsonEncode(_metadataJson()),
+            discoveryTimestampMs: clock.now().millisecondsSinceEpoch,
+            tokenJson: _tokenJson(
+              idToken: _signIdToken(issuer: 'https://evil.example.com'),
+            ),
+          );
+          final manager = _lazyManager(
+            store: store,
+            client: _client(net),
+            settings: settings(),
+          );
 
-        await manager.init();
+          await manager.init();
+          await pumpEventQueue();
 
-        expect(manager.currentUser, isNull);
-        final remaining = await store.get(
-          OidcStoreNamespace.secureTokens,
-          key: OidcConstants_Store.currentToken,
-        );
-        expect(remaining, isNull);
-        await manager.dispose();
-      },
-    );
-  });
+          expect(manager.currentUser, isNull);
+          final remaining = await store.get(
+            OidcStoreNamespace.secureTokens,
+            key: OidcConstants_Store.currentToken,
+          );
+          expect(remaining, isNull);
+          await manager.dispose();
+        },
+      );
+    });
+  }
 
   group('metadataSeed merge order', () {
     test(
@@ -585,6 +723,47 @@ void main() {
           manager.discoveryDocument.tokenEndpoint.toString(),
           '$_issuer/token',
         );
+        await manager.dispose();
+      },
+    );
+
+    test(
+      'the seed is in-memory only: the PERSISTED discovery copy contains none '
+      'of the seed values',
+      () async {
+        final net = <String>[];
+        final store = await _seededStore();
+        final seed = OidcProviderMetadata.fromJson({
+          'issuer': 'https://seed.example.com',
+          'end_session_endpoint': '$_issuer/logout',
+        });
+        final manager = _lazyManager(
+          store: store,
+          client: _client(net, metadata: _metadataJson()),
+          settings: OidcUserManagerSettings(
+            redirectUri: Uri.parse('app://cb'),
+            initMode: OidcInitMode.blockingValidate,
+            metadataSeed: seed,
+          ),
+        );
+
+        await manager.init();
+
+        // The on-disk discovery document is the FETCHED document verbatim — the
+        // seed is merged only into the in-memory `discoveryDocument` getter, so
+        // a later run that skips the seed (or changes it) never inherits stale
+        // seed values off disk.
+        final persistedRaw = await store.get(
+          OidcStoreNamespace.discoveryDocument,
+          key: _wellKnown.toString(),
+        );
+        expect(persistedRaw, isNotNull);
+        final persisted = jsonDecode(persistedRaw!) as Map<String, dynamic>;
+        // Seed-only member is NOT persisted...
+        expect(persisted.containsKey('end_session_endpoint'), isFalse);
+        // ...and the persisted issuer is the FETCHED one, not the seed's.
+        expect(persisted['issuer'], _issuer);
+        expect(persisted['issuer'], isNot('https://seed.example.com'));
         await manager.dispose();
       },
     );

--- a/packages/oidc_core/test/user_manager_flows_coverage_test.dart
+++ b/packages/oidc_core/test/user_manager_flows_coverage_test.dart
@@ -135,6 +135,9 @@ Future<_FlowManager> _build({
         settings ??
         OidcUserManagerSettings(
           redirectUri: Uri.parse('com.example.app://cb'),
+          // These coverage tests pin the pre-existing blocking init semantics
+          // (cache validated/refreshed before init() completes).
+          initMode: OidcInitMode.blockingValidate,
           userInfoSettings: const OidcUserInfoSettings(
             sendUserInfoRequest: false,
           ),


### PR DESCRIPTION
Implements #201 + #205 in oidc_core, changing the DEFAULT `init()` semantics (USER-DECIDED).

**New default — cache-first init.** `OidcUserManagerSettings.initMode` (new, `OidcInitMode { cacheFirst (default), blockingValidate }`). Under `cacheFirst`, `init()` restores a cached user by a PURE local deserialize — `OidcUser.fromIdToken(keystore: null)`, no network — and completes immediately, then revalidates in the background: refreshes discovery if stale, re-verifies + refreshes the token if expired, and calls userinfo when enabled. Background outcomes surface through the EXISTING channels — `userChanges()` when the user object changes, `events()` for failures. With no cached user (or no locally-cached discovery document, or a pending redirect/logout result) it transparently falls back to the blocking network path. `blockingValidate` reproduces the exact previous semantics as an escape hatch.

**Discovery TTL cache.** The fetched discovery document is now persisted with a sidecar epoch-millis timestamp under `'<key>::oidc_discovery_fetched_at'` (mirrors `OidcJwksStoreLoader`'s `::oidc_jwks_fetched_at`). New `discoveryDocumentMaxAge` (Duration, default `const Duration(days: 1)` — matches `jwksCacheMaxAge` and MSAL's ~24h OP-metadata TTL; oidc-client-ts only caches in-memory per session). Within the TTL the `.well-known` fetch is skipped; beyond it the document is refreshed (background under `cacheFirst`, blocking under `blockingValidate`) and the stale cached copy is still served on refresh failure. The timestamp advances only on a successful fetch, never while serving a stale offline copy. Offline-served/stale documents are still issuer-validated before use (poisoned-cache protection preserved).

**#205 loaded-token validity controls.** Two `refreshBefore`-style typedef callbacks on settings: `isLoadedTokenAcceptable(OidcUser, List<Exception>) -> bool?` (invoked in `loadCachedTokens` after `validateUser` produces its error list, before the keep/discard branch: `true` surfaces the loaded user as-is skipping refresh/userinfo, `false` rejects, `null` = default policy) and `shouldRemoveInvalidToken(OidcUser, List<Exception>) -> bool?` (overrides the discard decision; `null` = remove unless `supportOfflineAuth`). Both default to `null` and preserve current behavior exactly.

**metadataSeed.** Optional `OidcProviderMetadata metadataSeed` merged UNDER the fetched/cached document (fetched values override the seed — oidc-client-ts semantics), applied in-memory only (never persisted); the eager full-override constructor path is untouched.

MIGRATION NOTE for the changelog: cold-start `init()` is now cache-first by default, so immediately after `init()` a restored user may not yet be re-verified against the network (verification/refresh completes in a background pass). Callers that require a fully-verified user before `init()` returns must set `initMode: OidcInitMode.blockingValidate`.

### Test evidence
- `packages/oidc_core/test/cache_first_init_test.dart — 12 tests: cacheFirst zero-network restore + background revalidation; cacheFirst no-cache fallback to network path; locally-restored-user-available-immediately; blockingValidate synchronous verify; discovery TTL within/beyond/offline-serves-stale; isLoadedTokenAcceptable=true/false; shouldRemoveInvalidToken=false keeps tokens; null-callbacks default; metadataSeed merge order`

Gates re-ran green after rebasing onto post-1.0.0 main (full oidc_core/oidc_cli/oidc/oidc_default_store set plus package-specific suites; see commits).

Closes #201
Closes #205

Behavior change: init() now completes from the local cache and revalidates in the background by default; `initMode: OidcInitMode.blockingValidate` restores the previous semantics. The changelog entry must carry this prominently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cache-first initialization, restoring cached users immediately while revalidating in the background.
  - Added blocking validation mode for applications that require verification before initialization completes.
  - Added configuration for discovery-document cache lifetime and metadata seeding.
  - Added callbacks to control acceptance and removal of invalid cached tokens.
- **Improvements**
  - Prevented duplicate token refreshes and inconsistent sign-out behavior during startup.
  - Improved offline support by retaining usable cached discovery data when the network is unavailable.
- **Tests**
  - Added coverage for initialization modes, token refresh failures, discovery caching, and token-policy callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->