### PR TITLE
fix(oidc_core): deleteClientConfiguration requires 204 and surfaces typed errors (RFC 7592 §2.3)

### DIFF
--- a/packages/oidc_core/lib/src/endpoints/facade.dart
+++ b/packages/oidc_core/lib/src/endpoints/facade.dart
@@ -26,23 +26,38 @@ class OidcEndpoints {
     return mapper(body);
   }
 
+  /// Decodes a response's JSON body, throwing a typed
+  /// [OidcException.serverError] (with a parsed [OidcErrorResponse]) when the
+  /// body carries an RFC 6749 `error` field. Does not consider the HTTP
+  /// status code; callers apply their own success/failure status semantics.
+  static Map<String, dynamic> _decodeJsonBodyOrThrowTypedError({
+    required http.Request request,
+    required http.Response response,
+  }) {
+    final rawBody = utf8.decode(response.bodyBytes).trim();
+    final body = rawBody.isNotEmpty
+        ? jsonDecode(rawBody) as Map<String, dynamic>
+        : <String, dynamic>{};
+    if (body.containsKey(OidcConstants_AuthParameters.error)) {
+      final resp = OidcErrorResponse.fromJson(body);
+      throw OidcException.serverError(
+        errorResponse: resp,
+        rawRequest: request,
+        rawResponse: response,
+      );
+    }
+    return body;
+  }
+
   static Map<String, dynamic> _handleResponseRaw({
     required http.Request request,
     required http.Response response,
   }) {
     try {
-      final rawBody = utf8.decode(response.bodyBytes).trim();
-      final body = rawBody.isNotEmpty
-          ? jsonDecode(rawBody) as Map<String, dynamic>
-          : <String, dynamic>{};
-      if (body.containsKey(OidcConstants_AuthParameters.error)) {
-        final resp = OidcErrorResponse.fromJson(body);
-        throw OidcException.serverError(
-          errorResponse: resp,
-          rawRequest: request,
-          rawResponse: response,
-        );
-      }
+      final body = _decodeJsonBodyOrThrowTypedError(
+        request: request,
+        response: response,
+      );
       if (!(response.statusCode >= 200 && response.statusCode < 400)) {
         throw OidcException(
           'Failed to handle the response from endpoint (status code ${response.statusCode}): ${request.url}',
@@ -1457,7 +1472,14 @@ class OidcEndpoints {
   }
 
   /// Deletes (deprovisions) a client (RFC 7592 §2.3) at its
-  /// [registrationClientUri]. A successful deletion returns HTTP 204.
+  /// [registrationClientUri]. Per the spec, a successful deletion returns
+  /// HTTP 204 (No Content); HTTP 200 is also accepted leniently, since some
+  /// authorization servers respond with it instead. Any other status
+  /// (including 3xx redirects, which RFC 7592 does not define as success
+  /// here) is an error and is routed through the same typed error parsing
+  /// used by [registerClient], [readClientConfiguration], and
+  /// [updateClientConfiguration], so an RFC 6749-shaped error body surfaces
+  /// as a typed [OidcException.serverError].
   static Future<void> deleteClientConfiguration({
     required Uri registrationClientUri,
     required String registrationAccessToken,
@@ -1476,13 +1498,30 @@ class OidcEndpoints {
       client: client,
       request: req,
     );
-    if (!(resp.statusCode >= 200 && resp.statusCode < 400)) {
+    try {
+      _decodeJsonBodyOrThrowTypedError(
+        request: req,
+        response: resp,
+      );
+    } on OidcException {
+      rethrow;
+    } catch (e, st) {
       throw OidcException(
-        'Failed to delete client configuration '
-        '(status ${resp.statusCode}): ${req.url}',
+        'Failed to handle the response from endpoint: ${req.url}',
+        internalException: e,
+        internalStackTrace: st,
         rawRequest: req,
         rawResponse: resp,
       );
     }
+    if (resp.statusCode == 204 || resp.statusCode == 200) {
+      return;
+    }
+    throw OidcException(
+      'Failed to delete client configuration '
+      '(status ${resp.statusCode}): ${req.url}',
+      rawRequest: req,
+      rawResponse: resp,
+    );
   }
 }

--- a/packages/oidc_core/test/dynamic_client_registration_test.dart
+++ b/packages/oidc_core/test/dynamic_client_registration_test.dart
@@ -115,5 +115,115 @@ void main() {
       expect(captured!.method, 'DELETE');
       expect(captured!.headers['authorization'], 'Bearer rat-1');
     });
+
+    test(
+      'deleteClientConfiguration accepts 200 leniently as success',
+      () async {
+        final client = MockClient((req) async {
+          return http.Response('', 200);
+        });
+        await OidcEndpoints.deleteClientConfiguration(
+          registrationClientUri: Uri.parse(
+            'https://op.example.com/register/generated-id',
+          ),
+          registrationAccessToken: 'rat-1',
+          client: client,
+        );
+      },
+    );
+
+    test(
+      'deleteClientConfiguration throws on a 302 redirect '
+      '(not a defined success status per RFC 7592 2.3)',
+      () async {
+        final client = MockClient((req) async {
+          return http.Response(
+            '',
+            302,
+            headers: const {'location': 'https://op.example.com/login'},
+          );
+        });
+        await expectLater(
+          OidcEndpoints.deleteClientConfiguration(
+            registrationClientUri: Uri.parse(
+              'https://op.example.com/register/generated-id',
+            ),
+            registrationAccessToken: 'rat-1',
+            client: client,
+          ),
+          throwsA(isA<OidcException>()),
+        );
+      },
+    );
+
+    test(
+      'deleteClientConfiguration surfaces a 401 RFC 6749-shaped error body '
+      'as a typed OidcException',
+      () async {
+        final client = MockClient((req) async {
+          return http.Response(
+            jsonEncode({
+              'error': 'invalid_token',
+              'error_description': 'The access token expired',
+            }),
+            401,
+            headers: const {'content-type': 'application/json'},
+          );
+        });
+        try {
+          await OidcEndpoints.deleteClientConfiguration(
+            registrationClientUri: Uri.parse(
+              'https://op.example.com/register/generated-id',
+            ),
+            registrationAccessToken: 'rat-1',
+            client: client,
+          );
+          fail('should have thrown');
+        } on OidcException catch (e) {
+          expect(e.errorResponse, isNotNull);
+          expect(e.errorResponse!.error, 'invalid_token');
+          expect(
+            e.errorResponse!.errorDescription,
+            'The access token expired',
+          );
+          expect(e.rawResponse?.statusCode, 401);
+        }
+      },
+    );
+
+    test(
+      'deleteClientConfiguration surfaces a 405 error body as a typed '
+      'OidcException',
+      () async {
+        final client = MockClient((req) async {
+          return http.Response(
+            jsonEncode({
+              'error': 'invalid_request',
+              'error_description': 'DELETE is not supported',
+            }),
+            405,
+            headers: const {'content-type': 'application/json'},
+          );
+        });
+        try {
+          await OidcEndpoints.deleteClientConfiguration(
+            registrationClientUri: Uri.parse(
+              'https://op.example.com/register/generated-id',
+            ),
+            registrationAccessToken: 'rat-1',
+            client: client,
+          );
+          fail('should have thrown');
+        } on OidcException catch (e) {
+          expect(e.errorResponse, isNotNull);
+          expect(e.errorResponse!.error, 'invalid_request');
+          expect(
+            e.errorResponse!.errorDescription,
+            'DELETE is not supported',
+          );
+          expect(e.rawResponse?.statusCode, 405);
+        }
+      },
+    );
   });
 }


### PR DESCRIPTION
Fixes #387: `OidcEndpoints.deleteClientConfiguration` (RFC 7592 §2.3) previously accepted any status in `[200, 400)` as success — including 3xx redirects — and on failure threw a bare `OidcException` with no parsed error body, unlike `registerClient`/`readClientConfiguration`/`updateClientConfiguration`, which all route through `_handleResponseRaw` for typed `OidcErrorResponse` parsing.

Extracted the RFC 6749 error-body decoding out of `_handleResponseRaw` into a new `_decodeJsonBodyOrThrowTypedError` helper (status-agnostic: throws `OidcException.serverError` with a parsed `OidcErrorResponse` whenever the body has an `error` field). `_handleResponseRaw` now calls this helper and keeps its existing `[200,400)` status check for the other three registration endpoints — unchanged behavior there.

`deleteClientConfiguration` now: decodes the body through the same helper first (so any RFC 6749-shaped error body — 401, 403, 405, etc. — surfaces as a typed exception regardless of status); then applies its own success predicate per RFC 7592 §2.3 — HTTP 204 is success, HTTP 200 is accepted leniently since some servers use it instead; every other status (including 3xx redirects, which are not a defined success case here) falls through to a descriptive `OidcException`.

Added 4 tests to `dynamic_client_registration_test.dart` pinning: 200 accepted leniently, 302 now throws (regression pin for the original bug), 401 with an RFC 6749 error body populates typed `errorResponse` fields, and 405 likewise. The existing 204-success test is untouched.

### Test evidence
- `dynamic_client_registration_test.dart: deleteClientConfiguration accepts 200 leniently as success`
- `dynamic_client_registration_test.dart: deleteClientConfiguration throws on a 302 redirect (not a defined success status per RFC 7592 2.3)`
- `dynamic_client_registration_test.dart: deleteClientConfiguration surfaces a 401 RFC 6749-shaped error body as a typed OidcException`
- `dynamic_client_registration_test.dart: deleteClientConfiguration surfaces a 405 error body as a typed OidcException`

Gates re-ran green after rebasing onto post-1.0.0 main (full oidc_core/oidc_cli/oidc/oidc_default_store set plus package-specific suites; see commits).

Closes #387
Part of #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS
