### PR TITLE
ci: run oidc_web's chrome-tagged suite in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -203,6 +203,19 @@ jobs:
           for f in test/*_test.dart; do
             dart test "$f" --suite-load-timeout 4m --platform chrome --coverage=coverage/chrome --chain-stack-traces
           done
+      # oidc_web (#370): the only Flutter *plugin* package with browser-only
+      # lib code. Must run on BOTH pull_request and push -- unlike the
+      # Dart-package browser sweeps above, this isn't split into a
+      # PR-scoped subset vs a main-only full sweep: oidc_web has exactly one
+      # browser-tagged suite file today (test/library_surface_test.dart,
+      # @TestOn('chrome'), 3 trivial tests), so a single invocation covers
+      # both scopes -- no per-file loop needed. See pubspec.yaml's
+      # test:oidc_web:chrome script for why plain `flutter test` and
+      # `flutter test -d chrome` both silently skip this suite, and why the
+      # deprecated `--platform chrome` flag is used anyway.
+      - name: "[Verify step] Test oidc_web [Chrome]"
+        timeout-minutes: 10
+        run: melos run test:oidc_web:chrome
       - name: Remove dart_test.yaml Files
         run: melos run remove_dart_test_yaml
       - name: "[Verify step] Test Flutter packages"

--- a/packages/oidc_web/test/library_surface_test.dart
+++ b/packages/oidc_web/test/library_surface_test.dart
@@ -4,11 +4,17 @@ library;
 // `oidc_web.dart` (the real `OidcWeb` plugin class, the KNOWN gap this test
 // closes) imports `oidc_web_core`, which unconditionally depends on
 // `package:web` (`dart:js_interop`) -- so this suite only compiles for a
-// browser compile target and must be run with `flutter test -d chrome`
-// (equivalent to `dart test -p chrome` for a pure-Dart package). This
-// package's other "test" file is only a placeholder pointing at
-// `integration_test`, so `oidc_web.dart` was never loaded by any unit test
-// before this file.
+// browser compile target and must be run with `flutter test --platform
+// chrome` (NOT `flutter test -d chrome`: `-d`/`--device-id` is ignored by
+// `flutter test`, which still runs on the VM ("tester") harness regardless
+// of the device given, so this suite would stay silently excluded -- 0
+// tests loaded, no failure. `--platform chrome` is deprecated/hidden but is
+// the only invocation that threads a browser Runtime through suite-load
+// filtering; see pubspec.yaml's test:oidc_web:chrome script for the full
+// story). This package's other "test" file is only a placeholder pointing
+// at `integration_test`, so before this file, `oidc_web.dart` was never
+// loaded by any unit test; CI now wires this suite in via
+// test:oidc_web:chrome (#370).
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oidc_core/oidc_core.dart';
 import 'package:oidc_platform_interface/oidc_platform_interface.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -255,6 +255,46 @@ melos:
         dirExists: test
         ignore:
           - "*example*"
+    test:oidc_web:chrome:
+      name: oidc_web browser-platform suite (Chrome)
+      # #370: lib/oidc_web.dart (the real OidcWeb plugin class) imports
+      # oidc_web_core -> package:web (dart:js_interop), so it only compiles
+      # for a browser target. Plain `flutter test` (test:flutter above) runs
+      # on the VM ("tester") platform by default, so
+      # test/library_surface_test.dart's `@TestOn('chrome')` suite is
+      # silently skipped there (0 tests loaded, no failure) and
+      # oidc_web.dart has never appeared in any CI unit report.
+      # `flutter test -d chrome` does NOT fix this -- verified empirically:
+      # `-d`/`--device-id` is ignored by `flutter test`, which still spawns
+      # the native `flutter_tester` process (confirmed via `-v`: it launches
+      # `flutter_tester.exe`, never a browser) regardless of the device
+      # given, so the chrome-tagged file stays excluded exactly as before.
+      # `--platform chrome` is the only invocation that actually threads a
+      # browser Runtime through suite-load filtering (flutter_tools'
+      # FlutterWebPlatform registers `SuitePlatform(Runtime.chrome)`) --
+      # confirmed locally: with this flag, library_surface_test.dart reaches
+      # "loading ...", which it never does under `-d chrome`. `flutter test
+      # --help -v` marks the flag "(deprecated) ... intended for testing the
+      # Flutter framework itself and may be removed at any time", but there
+      # is no non-deprecated alternative today.
+      # On a Windows dev machine this flag can hang after launching Chrome --
+      # a long-standing, Windows-only flutter_tools bug (flutter/flutter
+      # #162798, #44583, #118778; reproducible with a bare `flutter create`
+      # app, no project code involved). This job runs on ubuntu-latest, not
+      # the affected platform.
+      # flutter_tools' web test Chrome launcher (web/chrome.dart) adds its
+      # own `--no-sandbox --headless` flags automatically, so (unlike the
+      # `dart test --platform chrome` steps elsewhere in this workflow) no
+      # CHROME_FLAGS wiring is needed here.
+      # One suite file today (library_surface_test.dart); the package's
+      # other test file (oidc_web_test.dart) has no @TestOn restriction and
+      # loads fine alongside it under Runtime.chrome, so a single
+      # non-per-file invocation covers the package -- no jose_plus/
+      # oidc_web_core-style per-file loop needed.
+      exec: flutter test --platform chrome
+      packageFilters:
+        scope:
+          - oidc_web
     integration_test:android:
       name: Flutter Android Integration tests
       exec: flutter test integration_test --coverage --coverage-package oidc* --branch-coverage -d android --coverage-path coverage/android-coverage.info --dart-define=CI=true


### PR DESCRIPTION
oidc_web's only browser-only lib code (`lib/oidc_web.dart`, the real `OidcWeb` plugin class) has never run under any CI unit test: `packages/oidc_web/test/library_surface_test.dart` is tagged `@TestOn('chrome')`, but CI's Flutter unit step (`flutter test`, no platform flag) always runs on the VM ("tester") harness, so the file is silently excluded (0 tests loaded, no failure) — verified issue #370.

The test file's own header comment claimed the fix was `flutter test -d chrome`. That's wrong: `-d`/`--device-id` is a no-op for `flutter test`, which still launches the native `flutter_tester` VM process regardless of the device given (confirmed via `-v` logs). The only invocation that actually threads a browser `Runtime` through suite-load filtering is the hidden/deprecated `--platform chrome` flag (`flutter test --help -v`: "intended for testing the Flutter framework itself and may be removed at any time") — confirmed locally: only under `--platform chrome` does the suite reach `loading .../library_surface_test.dart`.

This PR:
- adds a `test:oidc_web:chrome` melos script (`flutter test --platform chrome`, scoped to `oidc_web`) with the invocation-correctness rationale documented inline
- adds an unconditional CI step (`[Verify step] Test oidc_web [Chrome]`, `timeout-minutes: 10`) that runs it on both `push` and `pull_request` — unlike the Dart-package browser sweeps elsewhere in this workflow, oidc_web has exactly one browser-tagged suite file today (3 trivial tests), so a single invocation covers both scopes with no per-file loop
- fixes the stale `-d chrome` claim in `library_surface_test.dart`'s header comment

Scope is intentionally limited to `oidc_web`, the sole Flutter *plugin* package with browser-only lib code; no other package needs this treatment.

### Test evidence
- `No new .dart test file added -- the fix wires the EXISTING packages/oidc_web/test/library_surface_test.dart (@TestOn('chrome')) into CI. New melos script pubspec.yaml:test:oidc_web:chrome (exec: `flutter test --platform chrome`, packageFilters.scope: [oidc_web]). New CI step '.github/workflows/tests.yaml:[Verify step] Test oidc_web [Chrome]' (unconditional -- runs on both push and pull_request, timeout-minutes: 10), invoking `melos run test:oidc_web:chrome`.`

Gates re-ran green after rebasing onto post-1.0.0 main (full oidc_core/oidc_cli/oidc/oidc_default_store set plus package-specific suites; see commits).

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS
