### PR TITLE
fix(oidc_core): protect the PKCE code_verifier at rest

### DIFF
--- a/packages/oidc_core/lib/src/endpoints/facade.dart
+++ b/packages/oidc_core/lib/src/endpoints/facade.dart
@@ -190,6 +190,20 @@ class OidcEndpoints {
     );
     //store the state
     if (store != null) {
+      // #324 item 20: the PKCE `code_verifier` is secret-grade — whoever holds
+      // it together with the authorization `code` can complete the token
+      // exchange (RFC 7636 §1) — so it must not sit in the plaintext `state`
+      // namespace. Persist it in the `secureTokens` namespace (encrypted at
+      // rest on web, secure-storage-backed on mobile/desktop) keyed by the
+      // state id, and strip it from the state payload before persisting.
+      // `handleSuccessfulAuthResponse` reads it back from there, falling back
+      // to the in-payload value for one release so any flow already in flight
+      // across an app upgrade still completes.
+      await store.setStateCodeVerifier(
+        state: stateData.id,
+        codeVerifier: codeVerifier,
+      );
+      stateData.codeVerifier = null;
       await store.setStateData(
         state: stateData.id,
         stateData: stateData.toStorageString(),

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -1184,6 +1184,16 @@ abstract class OidcUserManagerBase {
         );
       }
 
+      // #324 item 20: the PKCE `code_verifier` now lives in the `secureTokens`
+      // namespace (encrypted / secure-storage-backed) keyed by the state id,
+      // not in the plaintext `state` payload. Fall back to the value embedded
+      // in the payload for a flow that was started by a version which still
+      // wrote it there — a one-release compatibility window so in-flight logins
+      // survive an app upgrade.
+      final storedCodeVerifier = await store.getStateCodeVerifier(
+        receivedStateKey,
+      );
+
       //request the token.
       final tokenResp = await (settings.hooks?.token).execute(
         request: OidcTokenHookRequest(
@@ -1193,7 +1203,10 @@ abstract class OidcUserManagerBase {
           headers: stateData.extraTokenHeaders,
           request: OidcTokenRequest.authorizationCode(
             redirectUri: response.redirectUri ?? stateData.redirectUri,
-            codeVerifier: response.codeVerifier ?? stateData.codeVerifier,
+            codeVerifier:
+                response.codeVerifier ??
+                storedCodeVerifier ??
+                stateData.codeVerifier,
             extra: stateData.extraTokenParams,
             clientId: clientCredentials.clientId,
             code: code,
@@ -1234,6 +1247,12 @@ abstract class OidcUserManagerBase {
         stateData: null,
       );
       await store.setStateData(state: receivedStateKey, stateData: null);
+      // #324 item 20: drop the secureTokens `code_verifier` for this state too,
+      // so the secret does not outlive the flow that consumed it.
+      await store.setStateCodeVerifier(
+        state: receivedStateKey,
+        codeVerifier: null,
+      );
     }
   }
 

--- a/packages/oidc_core/lib/src/models/state/state.dart
+++ b/packages/oidc_core/lib/src/models/state/state.dart
@@ -101,6 +101,10 @@ class OidcState {
         //no need to await
         unawaited(store.remove(OidcStoreNamespace.state, key: key));
         unawaited(store.remove(OidcStoreNamespace.stateResponse, key: key));
+        // #324 item 20: also drop the secureTokens `code_verifier` keyed by
+        // this stale state, so an abandoned flow doesn't leave the secret
+        // behind.
+        unawaited(store.setStateCodeVerifier(state: key, codeVerifier: null));
       }
     }
   }

--- a/packages/oidc_core/lib/src/state_store.dart
+++ b/packages/oidc_core/lib/src/state_store.dart
@@ -104,6 +104,19 @@ extension OidcReadOnlyStoreExt on OidcReadOnlyStore {
     key: state,
   );
 
+  /// Gets the PKCE `code_verifier` for an in-flight authorization [state] from
+  /// the [OidcStoreNamespace.secureTokens] namespace.
+  ///
+  /// Returns null when absent — e.g. for a flow that was started by a version
+  /// which still embedded the `code_verifier` inside the (plaintext)
+  /// [OidcStoreNamespace.state] payload. Callers must fall back to that
+  /// embedded value for one release; see [OidcStoreExt.setStateCodeVerifier]
+  /// for the rationale and the compatibility window.
+  Future<String?> getStateCodeVerifier(String state) => get(
+    OidcStoreNamespace.secureTokens,
+    key: _stateCodeVerifierKey(state),
+  );
+
   /// Gets the stateData (value) of a [state] (key).
   Future<String?> getStateResponseData(String state) => get(
     OidcStoreNamespace.stateResponse,
@@ -205,6 +218,34 @@ extension OidcStoreExt on OidcStore {
           value: stateData,
         );
 
+  /// Persists the PKCE `code_verifier` for an in-flight authorization [state]
+  /// in the [OidcStoreNamespace.secureTokens] namespace, keyed by the state id.
+  ///
+  /// The `code_verifier` is secret-grade: an attacker who captures it together
+  /// with the authorization `code` can complete the token exchange (RFC 7636
+  /// §1). Persisting it in `secureTokens` (encrypted at rest on web via
+  /// `OidcWebStore`, secure-storage-backed on mobile/desktop via
+  /// `OidcDefaultStore`) instead of the plaintext [OidcStoreNamespace.state]
+  /// payload closes that at-rest exposure on every platform — the same posture
+  /// the nonce already gets via [setCurrentNonce].
+  ///
+  /// if [codeVerifier] (value) is null, the entry is removed; call this after a
+  /// flow completes (or when clearing a stale state) so the secret does not
+  /// outlive the short-lived flow.
+  Future<void> setStateCodeVerifier({
+    required String state,
+    required String? codeVerifier,
+  }) => codeVerifier == null
+      ? remove(
+          OidcStoreNamespace.secureTokens,
+          key: _stateCodeVerifierKey(state),
+        )
+      : set(
+          OidcStoreNamespace.secureTokens,
+          key: _stateCodeVerifierKey(state),
+          value: codeVerifier,
+        );
+
   /// Sets the [stateData] (value) of a [state] (key).
   ///
   /// if [stateData] (value) is null, the [state] (key) will be removed.
@@ -242,3 +283,12 @@ extension OidcStoreExt on OidcStore {
           value: value,
         );
 }
+
+/// The [OidcStoreNamespace.secureTokens] key under which the PKCE
+/// `code_verifier` for an in-flight authorization [state] is persisted.
+///
+/// The state id (a UUID) namespaces the entry so concurrent authorization
+/// flows never collide, and the `code_verifier.` prefix keeps it distinct from
+/// the token/nonce entries that share the namespace.
+String _stateCodeVerifierKey(String state) =>
+    '${OidcConstants_AuthParameters.codeVerifier}.$state';

--- a/packages/oidc_core/test/code_verifier_at_rest_test.dart
+++ b/packages/oidc_core/test/code_verifier_at_rest_test.dart
@@ -1,0 +1,282 @@
+@TestOn('vm')
+library;
+
+// Audit #324 item 20: the PKCE `code_verifier` must not be persisted in the
+// plaintext `state` namespace. It now lives in the `secureTokens` namespace
+// (encrypted at rest on web, secure-storage-backed on mobile/desktop) keyed by
+// the state id, with a one-release read fallback to the (legacy) in-payload
+// value so flows already in flight across an app upgrade still complete.
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+/// Drives a `code` -> token exchange so the `code_verifier` the token request
+/// carries can be observed. `getAuthorizationResponse` echoes the request's own
+/// state back with a code, so the success handler reaches the token POST. User
+/// creation then fails (the minimal token response has no id_token), but the
+/// token POST — and its `code_verifier` — has already happened.
+class _CodeFlowManager extends OidcUserManagerBase {
+  _CodeFlowManager({
+    required super.discoveryDocument,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    super.httpClient,
+  });
+
+  OidcAuthorizeRequest? lastAuthRequest;
+
+  @override
+  bool get isWeb => false;
+
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async {
+    lastAuthRequest = request;
+    return OidcAuthorizeResponse.fromJson({
+      'code': 'auth-code-1',
+      'state': request.state,
+    });
+  }
+
+  /// Exposes the `@protected` success handler so the compatibility test can
+  /// drive it against a pre-seeded (legacy-format) state.
+  Future<OidcUser?> exposeHandleSuccess(
+    OidcAuthorizeResponse response,
+    OidcProviderMetadata metadata,
+  ) => handleSuccessfulAuthResponse(
+    response: response,
+    grantType: OidcConstants_GrantType.authorizationCode,
+    metadata: metadata,
+  );
+
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+OidcProviderMetadata _metadata() => OidcProviderMetadata.fromJson({
+  'issuer': 'https://op.example.com',
+  'authorization_endpoint': 'https://op.example.com/authorize',
+  'token_endpoint': 'https://op.example.com/token',
+  'scopes_supported': ['openid'],
+});
+
+void main() {
+  group('prepareAuthorizationCodeFlowRequest (write side)', () {
+    late OidcMemoryStore store;
+    setUp(() async {
+      store = OidcMemoryStore();
+      await store.init();
+    });
+
+    test(
+      'persists the code_verifier in secureTokens, not the state payload',
+      () async {
+        final container =
+            await OidcEndpoints.prepareAuthorizationCodeFlowRequest(
+              metadata: _metadata(),
+              store: store,
+              input: OidcSimpleAuthorizationCodeFlowRequest(
+                clientId: 'client-1',
+                redirectUri: Uri.parse('com.example.app://cb'),
+                scope: const ['openid'],
+              ),
+            );
+        final stateId = container.request.state!;
+
+        // The plaintext state payload must NOT carry the code_verifier.
+        final rawState = await store.getStateData(stateId);
+        expect(rawState, isNotNull);
+        final decodedState = jsonDecode(rawState!) as Map<String, dynamic>;
+        expect(decodedState['code_verifier'], isNull);
+        // ...but it keeps the (public) code_challenge that went into the URL.
+        expect(decodedState['code_challenge'], container.request.codeChallenge);
+
+        // The code_verifier lives in secureTokens, keyed by the state id, and
+        // matches the challenge that was sent on the authorization request.
+        final storedVerifier = await store.getStateCodeVerifier(stateId);
+        expect(storedVerifier, isNotNull);
+        expect(
+          OidcPkcePair.generateS256Challenge(storedVerifier!),
+          container.request.codeChallenge,
+        );
+      },
+    );
+  });
+
+  group('authorize -> redirect round-trip (new location)', () {
+    Future<_CodeFlowManager> build(List<http.Request> tokenPosts) async {
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/token')) {
+          tokenPosts.add(req);
+          return http.Response(
+            jsonEncode({'access_token': 'at', 'token_type': 'Bearer'}),
+            200,
+            headers: const {'content-type': 'application/json'},
+          );
+        }
+        return http.Response('{}', 404);
+      });
+      final manager = _CodeFlowManager(
+        discoveryDocument: _metadata(),
+        clientCredentials: const OidcClientAuthentication.none(
+          clientId: 'client-1',
+        ),
+        store: OidcMemoryStore(),
+        httpClient: client,
+        settings: OidcUserManagerSettings(
+          redirectUri: Uri.parse('com.example.app://cb'),
+        ),
+      );
+      await manager.init();
+      return manager;
+    }
+
+    test(
+      'the token request carries the code_verifier read back from secureTokens',
+      () async {
+        final posts = <http.Request>[];
+        final manager = await build(posts);
+        try {
+          await manager.loginAuthorizationCodeFlow();
+        } on Object {
+          // User creation fails (no id_token); irrelevant to this assertion,
+          // which is about the token request that already happened.
+        }
+
+        expect(posts, hasLength(1));
+        final body = Uri.splitQueryString(posts.single.body);
+        // Had the reader relied only on the now-stripped state payload, this
+        // would be absent (the token model omits a null code_verifier).
+        expect(body['code_verifier'], isNotNull);
+        // The verifier that reached the token endpoint is the one behind the
+        // challenge that went out on the authorization request.
+        expect(
+          OidcPkcePair.generateS256Challenge(body['code_verifier']!),
+          manager.lastAuthRequest!.codeChallenge,
+        );
+      },
+    );
+
+    test(
+      'the secureTokens code_verifier is cleared once the flow is handled',
+      () async {
+        final posts = <http.Request>[];
+        final manager = await build(posts);
+        try {
+          await manager.loginAuthorizationCodeFlow();
+        } on Object {
+          // See above.
+        }
+
+        final stateId = manager.lastAuthRequest!.state!;
+        expect(await manager.store.getStateCodeVerifier(stateId), isNull);
+        // The state payload is cleared too (unchanged behavior).
+        expect(await manager.store.getStateData(stateId), isNull);
+      },
+    );
+  });
+
+  group('backward compatibility (legacy in-payload code_verifier)', () {
+    test(
+      'a flow whose code_verifier is still embedded in the state payload '
+      '(no secureTokens entry) completes via the fallback',
+      () async {
+        final posts = <http.Request>[];
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            posts.add(req);
+            return http.Response(
+              jsonEncode({'access_token': 'at', 'token_type': 'Bearer'}),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        });
+        final store = OidcMemoryStore();
+        final manager = _CodeFlowManager(
+          discoveryDocument: _metadata(),
+          clientCredentials: const OidcClientAuthentication.none(
+            clientId: 'client-1',
+          ),
+          store: store,
+          httpClient: client,
+          settings: OidcUserManagerSettings(
+            redirectUri: Uri.parse('com.example.app://cb'),
+          ),
+        );
+        await manager.init();
+
+        // Simulate a state written by a version that still embedded the
+        // code_verifier in the (plaintext) state payload, with nothing in
+        // secureTokens — an in-flight flow captured mid app-upgrade.
+        final legacyState = OidcAuthorizeState(
+          id: 'legacy-state-1',
+          codeVerifier: 'legacy-verifier',
+          codeChallenge: OidcPkcePair.generateS256Challenge('legacy-verifier'),
+          redirectUri: Uri.parse('com.example.app://cb'),
+          clientId: 'client-1',
+          nonce: 'hashed-nonce',
+          originalUri: null,
+          extraTokenParams: null,
+          extraTokenHeaders: null,
+          options: null,
+        );
+        await store.setStateData(
+          state: legacyState.id,
+          stateData: legacyState.toStorageString(),
+        );
+        expect(await store.getStateCodeVerifier(legacyState.id), isNull);
+
+        try {
+          await manager.exposeHandleSuccess(
+            OidcAuthorizeResponse.fromJson({
+              'code': 'auth-code-1',
+              'state': legacyState.id,
+            }),
+            _metadata(),
+          );
+        } on Object {
+          // User creation fails (no id_token); the token POST already happened.
+        }
+
+        expect(posts, hasLength(1));
+        final body = Uri.splitQueryString(posts.single.body);
+        // The token exchange used the embedded (legacy) verifier.
+        expect(body['code_verifier'], 'legacy-verifier');
+      },
+    );
+  });
+}

--- a/packages/oidc_core/test/store_extensions_test.dart
+++ b/packages/oidc_core/test/store_extensions_test.dart
@@ -26,6 +26,52 @@ void main() {
     });
   });
 
+  group('state code_verifier helpers (secureTokens namespace)', () {
+    test(
+      'setStateCodeVerifier then getStateCodeVerifier round-trips',
+      () async {
+        await store.setStateCodeVerifier(
+          state: 'state-1',
+          codeVerifier: 'the-verifier',
+        );
+        expect(await store.getStateCodeVerifier('state-1'), 'the-verifier');
+      },
+    );
+
+    test('setStateCodeVerifier(null) removes the stored verifier', () async {
+      await store.setStateCodeVerifier(
+        state: 'state-1',
+        codeVerifier: 'the-verifier',
+      );
+      await store.setStateCodeVerifier(state: 'state-1', codeVerifier: null);
+      expect(await store.getStateCodeVerifier('state-1'), isNull);
+    });
+
+    test('an absent verifier reads as null', () async {
+      expect(await store.getStateCodeVerifier('nope'), isNull);
+    });
+
+    test('is keyed per state id (concurrent flows do not collide)', () async {
+      await store.setStateCodeVerifier(state: 's1', codeVerifier: 'v1');
+      await store.setStateCodeVerifier(state: 's2', codeVerifier: 'v2');
+      expect(await store.getStateCodeVerifier('s1'), 'v1');
+      expect(await store.getStateCodeVerifier('s2'), 'v2');
+    });
+
+    test('lives in secureTokens, not the plaintext state namespace', () async {
+      await store.setStateCodeVerifier(
+        state: 'state-1',
+        codeVerifier: 'the-verifier',
+      );
+      // The state namespace (plaintext on every backend) must not hold it.
+      expect(await store.getStateData('state-1'), isNull);
+      expect(
+        await store.getMany(OidcStoreNamespace.state, keys: {'state-1'}),
+        isEmpty,
+      );
+    });
+  });
+
   group('front-channel logout request helpers (request namespace)', () {
     test('set then get round-trips the request', () async {
       await store.setCurrentFrontChannelLogoutRequest('sid=abc');

--- a/packages/oidc_web_core/test/oidc_web_store_test.dart
+++ b/packages/oidc_web_core/test/oidc_web_store_test.dart
@@ -69,6 +69,32 @@ void main() {
       },
     );
 
+    test(
+      'a state code_verifier (audit #324 item 20) is persisted as ciphertext',
+      () async {
+        const store = OidcWebStore(storagePrefix: 'cv');
+        await store.init();
+        const verifier = 'super-secret-code-verifier';
+
+        await store.setStateCodeVerifier(
+          state: 'state-1',
+          codeVerifier: verifier,
+        );
+
+        // setStateCodeVerifier routes through the secureTokens namespace, so
+        // the raw localStorage value is an encrypted envelope, not plaintext.
+        final raw = web.window.localStorage.getItem(
+          'cv.secureTokens.code_verifier.state-1',
+        );
+        expect(raw, isNotNull);
+        expect(raw, startsWith(oidcWebCryptoEnvelopePrefixV1));
+        expect(raw, isNot(contains(verifier)));
+
+        // ...and it decrypts back to the original on the read path.
+        expect(await store.getStateCodeVerifier('state-1'), verifier);
+      },
+    );
+
     test('uses a fresh random IV per write', () async {
       const store = OidcWebStore(storagePrefix: 'ivunique');
       await store.init();


### PR DESCRIPTION
Fixes #324 item 20: the PKCE `code_verifier` was persisted in the `state` namespace, which is plaintext on every backend (localStorage on web, SharedPreferences on mobile/desktop). An attacker who scrapes that store together with the intercepted authorization code can complete the token exchange (RFC 7636 §1).

Design decision — chose option (a): move the secret out of `state` into the `secureTokens` namespace, keyed by the state id, rather than option (b) (extend the web store's AES-GCM to the `state` namespace). Rationale: `secureTokens` is already protected on ALL platforms (AES-GCM via OidcWebStore on web; flutter_secure_storage / Keychain / Keystore via OidcDefaultStore on mobile/desktop), whereas (b) would only harden web and leave the code_verifier plaintext on mobile/desktop. This is also the posture the OIDC nonce already uses (setCurrentNonce writes to secureTokens at authorize, read at redirect), and OidcDefaultStore's own fallback-warning docs already describe the code_verifier as belonging in secureTokens — so this closes an existing gap rather than inventing a new mechanism.

Secret-grade audit of the state payload: only `code_verifier` is secret-grade. `code_challenge` is the public S256 hash that already travels in the authorization URL. The `nonce` field in the state payload is the *hashed* nonce (also sent in the URL); the raw nonce is already stored separately in secureTokens. So only `code_verifier` moves.

What changed: `prepareAuthorizationCodeFlowRequest` now writes the code_verifier via the new `setStateCodeVerifier` helper and nulls it out of the state payload before persisting. `handleSuccessfulAuthResponse` reads it back with `getStateCodeVerifier` and, for the compatibility window, falls back to the (now legacy) in-payload value. It is deleted in the redirect handler's `finally` and in `OidcState.clearStaleState`, so the secret never outlives the short-lived flow.

Migration safety / compat window: the reader accepts the OLD location for one release — a login started by a pre-fix version (code_verifier embedded in the state payload, nothing in secureTokens) still completes after an app upgrade. The migration is forward-only, matching the convention already documented for the web at-rest-encryption feature. On web with `OidcWebStoreEncryption.required` plus unavailable WebCrypto, the write throws before the state is persisted (fail-loud, consistent with `required`); on `preferred` it degrades to the same plaintext posture as before (no regression).

Tests pin every behavioral change: the write location (verifier absent from the state payload, present in secureTokens, and its S256 matches the challenge on the request), the full authorize→redirect round-trip through the new location, cleanup after completion, the legacy-payload fallback, and — on Chrome — that the web store persists the value as an `oidcenc.v1.` ciphertext envelope and decrypts it back.

### Test evidence
- `oidc_core/test/code_verifier_at_rest_test.dart :: prepareAuthorizationCodeFlowRequest (write side) persists the code_verifier in secureTokens, not the state payload`
- `oidc_core/test/code_verifier_at_rest_test.dart :: authorize -> redirect round-trip: the token request carries the code_verifier read back from secureTokens`
- `oidc_core/test/code_verifier_at_rest_test.dart :: the secureTokens code_verifier is cleared once the flow is handled`
- `oidc_core/test/code_verifier_at_rest_test.dart :: backward compatibility: a legacy in-payload code_verifier (no secureTokens entry) completes via the fallback`
- `oidc_core/test/store_extensions_test.dart :: setStateCodeVerifier/getStateCodeVerifier round-trip, null-removes, absent-null, per-state keying, and secureTokens-not-state isolation (5 tests)`
- `oidc_web_core/test/oidc_web_store_test.dart :: a state code_verifier (audit #324 item 20) is persisted as ciphertext and decrypts back`

Gates re-ran green after rebasing onto post-1.0.0 main (full oidc_core/oidc_cli/oidc/oidc_default_store set plus package-specific suites; see commits).

Part of #324 (item 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS
