### PR TITLE
feat(oidc_core): react to userinfo 401 — one refresh retry, typed event, step-up challenge parsing

### DIFF
--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -2321,12 +2321,21 @@ abstract class OidcUserManagerBase {
       error is JoseException && error.message.startsWith('JWT expired');
 
   /// This function validates that a user claims
+  ///
+  /// When [reactToUserInfoUnauthorized] is `true`, a UserInfo `401` (RFC 6750
+  /// §3) triggers the #302 recovery reaction: one refresh-token grant + a single
+  /// UserInfo retry when a refresh token is available, and — failing that — an
+  /// [OidcUserInfoFailedEvent] on [events]. It is enabled only when validating
+  /// an already-established session (e.g. resuming a cached user), never during
+  /// initial login or immediately after a refresh (where the access token is
+  /// freshly issued and a re-refresh would be pointless / could loop).
   @protected
   Future<OidcUser?> validateAndSaveUser({
     required OidcUser user,
     required OidcProviderMetadata metadata,
     String? authorizationCode,
     Duration? maxAge,
+    bool reactToUserInfoUnauthorized = false,
   }) async {
     var actualUser = user;
     final errors = validateUser(
@@ -2415,6 +2424,54 @@ abstract class OidcUserManagerBase {
                 error: e,
               );
             }
+          }
+
+          // #302: a UserInfo `401` while re-validating an established session
+          // means the resource server rejected the access token (revoked or
+          // expired) per RFC 6750 §3. The OAuth error rides the
+          // `WWW-Authenticate` header, not a JSON body, so it slips past the
+          // offline categorization above (which classifies it `unknown`). React
+          // only when the caller opted in — a session resume, not an initial
+          // login or a just-refreshed token.
+          final isUnauthorized =
+              e is OidcException && e.rawResponse?.statusCode == 401;
+          if (reactToUserInfoUnauthorized && isUnauthorized) {
+            // A revoked access token paired with a still-valid refresh token is
+            // recoverable without re-authentication: attempt exactly ONE
+            // refresh (reusing the #120 machinery, which also emits
+            // OidcTokenRefreshFailedEvent on failure). That refresh's own
+            // validate-and-save performs the single UserInfo retry with the
+            // fresh access token (this method is re-entered with
+            // reactToUserInfoUnauthorized defaulting to false, so it cannot
+            // loop).
+            if (actualUser.token.refreshToken != null) {
+              OidcUser? recovered;
+              try {
+                recovered = await _refreshToken(
+                  currentUserOverride: actualUser,
+                );
+              } on Object {
+                // The refresh failed; #120 already surfaced the terminal
+                // OidcTokenRefreshFailedEvent. Fall through to emit the
+                // UserInfo failure and retain the cached user.
+                recovered = null;
+              }
+              if (recovered != null) {
+                // The refresh succeeded and its validate-and-save already
+                // retried UserInfo, persisted and published the refreshed user.
+                // Nothing failed to surface, so emit no failure event.
+                return recovered;
+              }
+            }
+
+            // No refresh token, or the refresh did not recover the session:
+            // surface the rejection (with any RFC 9470 step-up hints from the
+            // `WWW-Authenticate` header) so the app can decide to sign out or
+            // step up. Consistent with the #120 terminal-retention default, the
+            // cached user is NOT forgotten here.
+            emitEvent(
+              OidcUserInfoFailedEvent.fromError(error: e, stackTrace: st),
+            );
           }
         }
       }
@@ -2778,6 +2835,10 @@ abstract class OidcUserManagerBase {
         loadedUser = await validateAndSaveUser(
           user: loadedUser,
           metadata: metadata,
+          // #302: this validates a resumed (already-established) session, so a
+          // UserInfo 401 from a revoked access token should trigger the
+          // recover-via-refresh + typed-event reaction.
+          reactToUserInfoUnauthorized: true,
         );
       }
 

--- a/packages/oidc_core/lib/src/models/events/_exports.dart
+++ b/packages/oidc_core/lib/src/models/events/_exports.dart
@@ -6,3 +6,4 @@ export 'pre_logout_event.dart';
 export 'token_expired_event.dart';
 export 'token_expiring_event.dart';
 export 'token_refresh_failed_event.dart';
+export 'userinfo_failed_event.dart';

--- a/packages/oidc_core/lib/src/models/events/userinfo_failed_event.dart
+++ b/packages/oidc_core/lib/src/models/events/userinfo_failed_event.dart
@@ -1,0 +1,158 @@
+import 'package:oidc_core/oidc_core.dart';
+
+/// An event raised when a UserInfo request (OpenID Connect Core §5.3) made
+/// while re-validating an already-authenticated session is rejected by the
+/// resource server with an HTTP `401 Unauthorized`.
+///
+/// ## Why this is a sibling of [OidcTokenRefreshFailedEvent], not an extension
+///
+/// A refresh failure (RFC 6749 §5.2/§6) and a UserInfo `401` are two distinct
+/// protocol surfaces, and conflating them would blur the taxonomy:
+///
+/// * A refresh failure originates at the **token endpoint** and carries its
+///   OAuth error in a **JSON body** (`{"error":"invalid_grant", ...}`).
+/// * A UserInfo `401` originates at a **protected resource** and carries its
+///   OAuth error in the **`WWW-Authenticate` response header** per RFC 6750 §3
+///   (`Bearer error="invalid_token"`), optionally with the RFC 9470 step-up
+///   hints (`error="insufficient_user_authentication"`, `acr_values`,
+///   `max_age`).
+///
+/// Modelling this as a first-class sibling under [OidcEvent] keeps each event's
+/// fields honest to its own wire format while mirroring the [OidcEvent]
+/// conventions established by [OidcTokenRefreshFailedEvent]
+/// (`httpStatusCode` / `oauthErrorCode` / `errorDescription`, plus a typed
+/// [challenge]).
+///
+/// ## Why this rides [OidcUserManagerBase.events], not
+/// [OidcUserManagerBase.userChanges]
+///
+/// Same rationale as [OidcTokenRefreshFailedEvent]: `userChanges()` is a value
+/// stream of the current [OidcUser] (or `null`); pushing a failure through it
+/// would break existing `onData`-only listeners. Failures are surfaced as
+/// first-class events on `events()` instead, leaving the value stream clean.
+///
+/// ## What the manager does before emitting this
+///
+/// When the failing UserInfo request happens while resuming/validating a live
+/// session and a refresh token is available, the manager first attempts **one**
+/// refresh-token grant (reusing the same machinery that powers
+/// [OidcTokenRefreshFailedEvent]) and retries UserInfo once — a revoked access
+/// token paired with a still-valid refresh token is recoverable without
+/// re-authentication. This event is emitted only when that recovery is not
+/// possible or does not succeed; on a successful recovery no failure event is
+/// emitted. When the recovery refresh itself fails, an
+/// [OidcTokenRefreshFailedEvent] is also emitted (by the refresh path).
+///
+/// The manager deliberately does **not** call `forgetUser` in reaction to this
+/// event (mirroring the terminal-retention default for refresh failures): the
+/// cached session is retained and the decision — sign the user out, launch an
+/// RFC 9470 step-up, or ignore a transient blip — is left to the application.
+///
+/// ### Recommended application recipe
+///
+/// ```dart
+/// manager.events().whereType<OidcUserInfoFailedEvent>().listen((event) {
+///   if (event.isStepUpChallenge) {
+///     // RFC 9470: re-authenticate at the challenged acr / max_age.
+///     manager.loginAuthorizationCodeFlow(
+///       extraParameters: {
+///         if (event.challenge?.acrValues case final acrs?)
+///           'acr_values': acrs.join(' '),
+///         if (event.challenge?.maxAge case final maxAge?)
+///           'max_age': '${maxAge.inSeconds}',
+///       },
+///     );
+///   } else {
+///     // The access token was rejected and could not be recovered.
+///     manager.forgetUser();
+///   }
+/// });
+/// ```
+class OidcUserInfoFailedEvent extends OidcEvent {
+  ///
+  const OidcUserInfoFailedEvent({
+    required this.error,
+    required super.at,
+    this.stackTrace,
+    this.httpStatusCode,
+    this.oauthErrorCode,
+    this.errorDescription,
+    this.challenge,
+    super.additionalInfo,
+  });
+
+  ///
+  OidcUserInfoFailedEvent.now({
+    required this.error,
+    this.stackTrace,
+    this.httpStatusCode,
+    this.oauthErrorCode,
+    this.errorDescription,
+    this.challenge,
+    super.additionalInfo,
+  }) : super.now();
+
+  /// Builds an event from a caught [error], extracting the HTTP status from an
+  /// [OidcException]'s raw response and parsing its `WWW-Authenticate` header
+  /// (RFC 6750 §3 / RFC 9470) into a typed [OidcStepUpChallenge].
+  factory OidcUserInfoFailedEvent.fromError({
+    required Object error,
+    StackTrace? stackTrace,
+    Map<String, dynamic>? additionalInfo,
+  }) {
+    int? httpStatusCode;
+    OidcStepUpChallenge? challenge;
+    if (error is OidcException) {
+      final rawResponse = error.rawResponse;
+      httpStatusCode = rawResponse?.statusCode;
+      challenge = OidcStepUpChallenge.parse(
+        rawResponse?.headers[_wwwAuthenticateHeaderKey],
+      );
+    }
+    return OidcUserInfoFailedEvent.now(
+      error: error,
+      stackTrace: stackTrace,
+      httpStatusCode: httpStatusCode,
+      // For a protected-resource 401 the OAuth error lives in the
+      // `WWW-Authenticate` header (RFC 6750 §3), not a JSON body.
+      oauthErrorCode: challenge?.error,
+      errorDescription: challenge?.errorDescription,
+      challenge: challenge,
+      additionalInfo: additionalInfo,
+    );
+  }
+
+  /// The response header key that carries the RFC 6750 §3 bearer-token
+  /// challenge. `package:http` lowercases all response header keys, so the
+  /// lookup MUST use the lowercase form.
+  static const _wwwAuthenticateHeaderKey = 'www-authenticate';
+
+  /// The raw error that caused the UserInfo request to fail.
+  final Object error;
+
+  /// The stack trace captured with [error], if available.
+  final StackTrace? stackTrace;
+
+  /// The HTTP status code of the UserInfo response, when available (typically
+  /// `401`).
+  final int? httpStatusCode;
+
+  /// The RFC 6750 §3 `error` code parsed from the `WWW-Authenticate` header
+  /// (e.g. `invalid_token`, `insufficient_scope`, or the RFC 9470
+  /// `insufficient_user_authentication`), when present.
+  final String? oauthErrorCode;
+
+  /// The RFC 6750 §3 `error_description` parsed from the `WWW-Authenticate`
+  /// header, when the resource server provided one.
+  final String? errorDescription;
+
+  /// The parsed `WWW-Authenticate` challenge (RFC 6750 §3), including any
+  /// RFC 9470 step-up hints (`acr_values` / `max_age`), when the response
+  /// carried one.
+  final OidcStepUpChallenge? challenge;
+
+  /// Whether the resource server asked for RFC 9470 step-up authentication
+  /// (`error="insufficient_user_authentication"`).
+  bool get isStepUpChallenge =>
+      challenge?.isInsufficientUserAuthentication ?? false;
+}

--- a/packages/oidc_core/test/userinfo_401_reaction_test.dart
+++ b/packages/oidc_core/test/userinfo_401_reaction_test.dart
@@ -1,0 +1,476 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+const _issuer = 'https://op.example.com';
+final _signingKey = JsonWebKey.generate('RS256');
+
+String _signIdToken({
+  String subject = 'user-1',
+  Duration expiresIn = const Duration(hours: 1),
+  String issuer = _issuer,
+}) {
+  final now = clock.now().millisecondsSinceEpoch ~/ 1000;
+  return (JsonWebSignatureBuilder()
+        ..jsonContent = {
+          'iss': issuer,
+          'sub': subject,
+          'aud': 'client-1',
+          'exp': now + expiresIn.inSeconds,
+          'iat': now,
+        }
+        ..addRecipient(_signingKey, algorithm: 'RS256'))
+      .build()
+      .toCompactSerialization();
+}
+
+/// A concrete manager exposing the `@protected` re-validation surface so the
+/// #302 UserInfo-401 reaction can be driven directly from a VM test.
+class _M extends OidcUserManagerBase {
+  _M({
+    required super.discoveryDocument,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    super.httpClient,
+    super.keyStore,
+  });
+
+  void seed(OidcUser user) => userSubject.add(user);
+  Future<void> saveUserRaw(OidcUser user) => saveUser(user);
+
+  /// Re-validates an already-established session (the #302 opt-in): a UserInfo
+  /// 401 triggers the recover-via-refresh + typed-event reaction.
+  Future<OidcUser?> validateResumedSession(OidcUser user) =>
+      validateAndSaveUser(
+        user: user,
+        metadata: discoveryDocument,
+        reactToUserInfoUnauthorized: true,
+      );
+
+  /// Validates a freshly-issued login token (no #302 reaction), used as the
+  /// "not a session resume" contrast.
+  Future<OidcUser?> validateFreshLogin(OidcUser user) =>
+      validateAndSaveUser(user: user, metadata: discoveryDocument);
+
+  @override
+  bool get isWeb => false;
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+OidcProviderMetadata _metadata() => OidcProviderMetadata.fromJson({
+  'issuer': _issuer,
+  'authorization_endpoint': '$_issuer/authorize',
+  'token_endpoint': '$_issuer/token',
+  'userinfo_endpoint': '$_issuer/userinfo',
+});
+
+OidcToken _token({
+  String accessToken = 'at-seed',
+  String? refreshToken = 'rt-seed',
+}) => OidcToken(
+  creationTime: clock.now(),
+  idToken: _signIdToken(),
+  accessToken: accessToken,
+  refreshToken: refreshToken,
+  tokenType: 'Bearer',
+  expiresIn: const Duration(hours: 1),
+);
+
+Future<OidcUser> _seedUser({String? refreshToken = 'rt-seed'}) =>
+    OidcUser.fromIdToken(token: _token(refreshToken: refreshToken));
+
+_M _make({
+  required http.Client client,
+  OidcUserManagerSettings? settings,
+  OidcStore? store,
+}) => _M(
+  discoveryDocument: _metadata(),
+  clientCredentials: const OidcClientAuthentication.none(clientId: 'client-1'),
+  store: store ?? OidcMemoryStore(),
+  httpClient: client,
+  keyStore: JsonWebKeyStore()..addKey(_signingKey),
+  settings:
+      settings ??
+      OidcUserManagerSettings(redirectUri: Uri.parse('com.example.app://cb')),
+);
+
+/// A `WWW-Authenticate` bearer challenge (RFC 6750 §3) rejecting a revoked
+/// access token.
+const _invalidTokenChallenge =
+    'Bearer error="invalid_token", '
+    'error_description="The access token was revoked"';
+
+void main() {
+  group('OidcUserInfoFailedEvent.fromError (WWW-Authenticate parsing)', () {
+    test('extracts the RFC 6750 §3 error and description from the header', () {
+      final event = OidcUserInfoFailedEvent.fromError(
+        error: OidcException(
+          'UserInfo rejected',
+          rawResponse: http.Response(
+            '',
+            401,
+            headers: const {'www-authenticate': _invalidTokenChallenge},
+          ),
+        ),
+      );
+
+      expect(event.httpStatusCode, 401);
+      expect(event.oauthErrorCode, 'invalid_token');
+      expect(event.errorDescription, 'The access token was revoked');
+      expect(event.challenge, isNotNull);
+      expect(event.isStepUpChallenge, isFalse);
+    });
+
+    test('surfaces RFC 9470 step-up hints (acr_values / max_age)', () {
+      final event = OidcUserInfoFailedEvent.fromError(
+        error: OidcException(
+          'step-up required',
+          rawResponse: http.Response(
+            '',
+            401,
+            headers: const {
+              'www-authenticate':
+                  'Bearer error="insufficient_user_authentication", '
+                  'acr_values="urn:mace:incommon:iap:silver", max_age="0"',
+            },
+          ),
+        ),
+      );
+
+      expect(event.oauthErrorCode, 'insufficient_user_authentication');
+      expect(event.isStepUpChallenge, isTrue);
+      expect(
+        event.challenge?.acrValues,
+        contains('urn:mace:incommon:iap:silver'),
+      );
+      expect(event.challenge?.maxAge, Duration.zero);
+    });
+
+    test('carries no HTTP fields for a non-OidcException error', () {
+      final event = OidcUserInfoFailedEvent.fromError(
+        error: const SocketException('offline'),
+      );
+      expect(event.httpStatusCode, isNull);
+      expect(event.oauthErrorCode, isNull);
+      expect(event.challenge, isNull);
+      expect(event.isStepUpChallenge, isFalse);
+    });
+  });
+
+  group('UserInfo 401 session reaction (#302)', () {
+    test(
+      'a live refresh token recovers: refresh + one UserInfo retry, no failure '
+      'event',
+      () async {
+        var userInfoCalls = 0;
+        var tokenCalls = 0;
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/userinfo')) {
+            userInfoCalls++;
+            if (userInfoCalls == 1) {
+              return http.Response(
+                '',
+                401,
+                headers: const {'www-authenticate': _invalidTokenChallenge},
+              );
+            }
+            return http.Response(
+              jsonEncode({'sub': 'user-1', 'email': 'a@b.com'}),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          if (req.url.path.endsWith('/token')) {
+            tokenCalls++;
+            return http.Response(
+              jsonEncode({
+                'access_token': 'at-refreshed',
+                'token_type': 'Bearer',
+                'expires_in': 3600,
+                'refresh_token': 'rt-2',
+                'id_token': _signIdToken(),
+              }),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        });
+        final manager = _make(client: client);
+        await manager.init();
+        final events = <OidcEvent>[];
+        final sub = manager.events().listen(events.add);
+
+        final result = await manager.validateResumedSession(await _seedUser());
+        await pumpEventQueue();
+
+        // Exactly one refresh, and UserInfo retried exactly once after it.
+        expect(tokenCalls, 1);
+        expect(userInfoCalls, 2);
+        // The recovered session carries the refreshed access token + UserInfo.
+        expect(result?.token.accessToken, 'at-refreshed');
+        expect(result?.userInfo['email'], 'a@b.com');
+        // A successful recovery surfaces no failure of any kind.
+        expect(events.whereType<OidcUserInfoFailedEvent>(), isEmpty);
+        expect(events.whereType<OidcTokenRefreshFailedEvent>(), isEmpty);
+
+        await sub.cancel();
+        await manager.dispose();
+      },
+    );
+
+    test(
+      'a dead refresh token emits the UserInfo-failed event and the #120 '
+      'terminal event, retaining the user',
+      () async {
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/userinfo')) {
+            return http.Response(
+              '',
+              401,
+              headers: const {'www-authenticate': _invalidTokenChallenge},
+            );
+          }
+          if (req.url.path.endsWith('/token')) {
+            // The refresh token is revoked too — RFC 6749 §5.2 invalid_grant.
+            return http.Response(
+              jsonEncode({'error': 'invalid_grant'}),
+              400,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        });
+        final manager = _make(client: client);
+        await manager.init();
+        final events = <OidcEvent>[];
+        final sub = manager.events().listen(events.add);
+
+        final result = await manager.validateResumedSession(await _seedUser());
+        await pumpEventQueue();
+
+        // The user is retained (no automatic forgetUser).
+        expect(result, isNotNull);
+        expect(result?.token.accessToken, 'at-seed');
+
+        final userInfoFailure = events
+            .whereType<OidcUserInfoFailedEvent>()
+            .single;
+        expect(userInfoFailure.httpStatusCode, 401);
+        expect(userInfoFailure.oauthErrorCode, 'invalid_token');
+        expect(userInfoFailure.challenge, isNotNull);
+
+        final refreshFailure = events
+            .whereType<OidcTokenRefreshFailedEvent>()
+            .single;
+        expect(refreshFailure.kind, OidcTokenRefreshFailureKind.terminal);
+        expect(refreshFailure.oauthErrorCode, 'invalid_grant');
+
+        await sub.cancel();
+        await manager.dispose();
+      },
+    );
+
+    test(
+      'no refresh token: the UserInfo-failed event is surfaced, user retained',
+      () async {
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/userinfo')) {
+            return http.Response(
+              '',
+              401,
+              headers: const {'www-authenticate': _invalidTokenChallenge},
+            );
+          }
+          return http.Response('{}', 404);
+        });
+        final manager = _make(client: client);
+        await manager.init();
+        final events = <OidcEvent>[];
+        final sub = manager.events().listen(events.add);
+
+        final result = await manager.validateResumedSession(
+          await _seedUser(refreshToken: null),
+        );
+        await pumpEventQueue();
+
+        expect(result, isNotNull, reason: 'user retained');
+        expect(events.whereType<OidcUserInfoFailedEvent>().single, isNotNull);
+        // No refresh path is fired when there is no refresh token.
+        expect(events.whereType<OidcTokenRefreshFailedEvent>(), isEmpty);
+
+        await sub.cancel();
+        await manager.dispose();
+      },
+    );
+
+    test(
+      'a non-401 UserInfo failure does not react (no refresh, no event)',
+      () async {
+        var tokenCalls = 0;
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/userinfo')) {
+            // A 5xx is a server error, not a token rejection.
+            return http.Response('{}', 500);
+          }
+          if (req.url.path.endsWith('/token')) {
+            tokenCalls++;
+            return http.Response('{}', 200);
+          }
+          return http.Response('{}', 404);
+        });
+        final manager = _make(client: client);
+        await manager.init();
+        final events = <OidcEvent>[];
+        final sub = manager.events().listen(events.add);
+
+        final result = await manager.validateResumedSession(await _seedUser());
+        await pumpEventQueue();
+
+        // Unchanged behaviour: no recovery refresh, no #302 event, user kept.
+        expect(tokenCalls, 0);
+        expect(events.whereType<OidcUserInfoFailedEvent>(), isEmpty);
+        expect(result?.token.accessToken, 'at-seed');
+
+        await sub.cancel();
+        await manager.dispose();
+      },
+    );
+
+    test(
+      'a UserInfo 401 during initial login does not react (not a session '
+      'resume)',
+      () async {
+        var tokenCalls = 0;
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/userinfo')) {
+            return http.Response(
+              '',
+              401,
+              headers: const {'www-authenticate': _invalidTokenChallenge},
+            );
+          }
+          if (req.url.path.endsWith('/token')) {
+            tokenCalls++;
+            return http.Response('{}', 200);
+          }
+          return http.Response('{}', 404);
+        });
+        final manager = _make(client: client);
+        await manager.init();
+        final events = <OidcEvent>[];
+        final sub = manager.events().listen(events.add);
+
+        final result = await manager.validateFreshLogin(await _seedUser());
+        await pumpEventQueue();
+
+        // The login-context path is unchanged: the 401 is not reacted to.
+        expect(tokenCalls, 0);
+        expect(events.whereType<OidcUserInfoFailedEvent>(), isEmpty);
+        expect(result, isNotNull);
+
+        await sub.cancel();
+        await manager.dispose();
+      },
+    );
+
+    test(
+      'the cached-session resume path (init) recovers a revoked access token',
+      () async {
+        final store = OidcMemoryStore();
+        var userInfoCalls = 0;
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/userinfo')) {
+            userInfoCalls++;
+            if (userInfoCalls == 1) {
+              return http.Response(
+                '',
+                401,
+                headers: const {'www-authenticate': _invalidTokenChallenge},
+              );
+            }
+            return http.Response(
+              jsonEncode({'sub': 'user-1', 'email': 'a@b.com'}),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          if (req.url.path.endsWith('/token')) {
+            return http.Response(
+              jsonEncode({
+                'access_token': 'at-refreshed',
+                'token_type': 'Bearer',
+                'expires_in': 3600,
+                'refresh_token': 'rt-2',
+                'id_token': _signIdToken(),
+              }),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        });
+
+        // Persist a cached (un-expired, but server-side revoked) session, then
+        // resume it in a fresh manager over the same store — the reporter's
+        // app-restart scenario.
+        final seeder = _make(client: client, store: store);
+        await seeder.saveUserRaw(await _seedUser());
+        await seeder.dispose();
+
+        final manager = _make(client: client, store: store);
+        final events = <OidcEvent>[];
+        final sub = manager.events().listen(events.add);
+        await manager.init();
+        await pumpEventQueue();
+
+        expect(manager.currentUser?.token.accessToken, 'at-refreshed');
+        expect(manager.currentUser?.userInfo['email'], 'a@b.com');
+        expect(events.whereType<OidcUserInfoFailedEvent>(), isEmpty);
+        expect(events.whereType<OidcTokenRefreshFailedEvent>(), isEmpty);
+
+        await sub.cancel();
+        await manager.dispose();
+      },
+    );
+  });
+}


### PR DESCRIPTION
Fixes #302: a UserInfo request that a resource server rejected with `401` while resuming an established session used to be swallowed — the cached id_token still validated, so the user was saved without UserInfo and no signal reached the app ("nothing happens").

`validateAndSaveUser` now takes an opt-in `reactToUserInfoUnauthorized` flag, wired `true` only on the cached-session resume path (`loadCachedTokens`), never on initial login or a just-refreshed token. On a UserInfo `401` it:

1. Parses the `WWW-Authenticate` challenge — RFC 6750 §3 error codes (`invalid_token`, …) and RFC 9470 step-up hints (`acr_values` / `max_age`) — reusing the existing `OidcStepUpChallenge.parse`.
2. Attempts exactly one refresh-token grant when a refresh token exists, reusing the #120 refresh machinery. On refresh success the refresh path's own validate-and-save performs the single UserInfo retry with the fresh access token; a revoked access token paired with a live refresh token is thus recovered transparently, emitting no failure event.
3. Emits a new typed `OidcUserInfoFailedEvent` on `events()` only when recovery is not possible or does not succeed. When the recovery refresh itself fails, the #120 `OidcTokenRefreshFailedEvent` (terminal) also fires.

There is no automatic `forgetUser` (consistent with the #120 terminal-retention default): the cached user is retained and the app listens for `OidcUserInfoFailedEvent` to decide between logout and an RFC 9470 step-up (recipe documented on the event's doc comment, including `isStepUpChallenge`).

`OidcUserInfoFailedEvent` is a new sibling of `OidcTokenRefreshFailedEvent` under `OidcEvent`, carrying `error`/`stackTrace`/`httpStatusCode`/`oauthErrorCode`/`errorDescription`/`challenge`, with a `fromError` factory that extracts the status and parses the header.

### Test evidence
- `OidcUserInfoFailedEvent.fromError extracts the RFC 6750 §3 error and description from the header`
- `OidcUserInfoFailedEvent.fromError surfaces RFC 9470 step-up hints (acr_values / max_age)`
- `OidcUserInfoFailedEvent.fromError carries no HTTP fields for a non-OidcException error`
- `UserInfo 401 session reaction: a live refresh token recovers (refresh + one UserInfo retry, no failure event)`
- `UserInfo 401 session reaction: a dead refresh token emits the UserInfo-failed event and the #120 terminal event, retaining the user`
- `UserInfo 401 session reaction: no refresh token surfaces the UserInfo-failed event, user retained`
- `UserInfo 401 session reaction: a non-401 UserInfo failure does not react (no refresh, no event) [regression pin]`
- `UserInfo 401 session reaction: a UserInfo 401 during initial login does not react (not a session resume)`

Gates re-ran green after rebasing onto post-1.0.0 main (full oidc_core/oidc_cli/oidc/oidc_default_store set plus package-specific suites; see commits).

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS
