### PR TITLE
feat(oidc_core): DCR integration — fromRegistrationResponse, typed OIDC-Reg metadata, update-request converter

### DIFF
--- a/packages/oidc_core/lib/src/endpoints/registration/request.dart
+++ b/packages/oidc_core/lib/src/endpoints/registration/request.dart
@@ -34,6 +34,11 @@ class OidcClientRegistrationRequest extends JsonBasedRequest {
     this.subjectType,
     this.tokenEndpointAuthMethod,
     this.idTokenSignedResponseAlg,
+    this.defaultMaxAge,
+    this.requireAuthTime,
+    this.defaultAcrValues,
+    this.initiateLoginUri,
+    this.requestUris,
     this.scope,
     this.softwareId,
     this.softwareVersion,
@@ -104,6 +109,34 @@ class OidcClientRegistrationRequest extends JsonBasedRequest {
   /// JWS `alg` the client requires for its id_tokens.
   @JsonKey(name: 'id_token_signed_response_alg')
   String? idTokenSignedResponseAlg;
+
+  /// Default Maximum Authentication Age (OpenID Connect Dynamic Client
+  /// Registration 1.0 §2): if the End-User was authenticated longer ago than
+  /// this, they MUST be actively re-authenticated. Serialized as a number of
+  /// seconds.
+  @JsonKey(name: 'default_max_age')
+  Duration? defaultMaxAge;
+
+  /// Whether the `auth_time` claim in the id_token is REQUIRED (OpenID Connect
+  /// Dynamic Client Registration 1.0 §2).
+  @JsonKey(name: 'require_auth_time')
+  bool? requireAuthTime;
+
+  /// Default `acr` values the OP is requested to use for this client (OpenID
+  /// Connect Dynamic Client Registration 1.0 §2), as a JSON array of strings.
+  @JsonKey(name: 'default_acr_values')
+  List<String>? defaultAcrValues;
+
+  /// URI (https) a third party can use to initiate a login for this client
+  /// (OpenID Connect Dynamic Client Registration 1.0 §2).
+  @JsonKey(name: 'initiate_login_uri')
+  Uri? initiateLoginUri;
+
+  /// `request_uri` values pre-registered by the client for use at the OP
+  /// (OpenID Connect Dynamic Client Registration 1.0 §2). These URIs MUST use
+  /// the https scheme.
+  @JsonKey(name: 'request_uris')
+  List<Uri>? requestUris;
 
   /// Space-separated list of scope values the client may request.
   @JsonKey(

--- a/packages/oidc_core/lib/src/endpoints/registration/request.g.dart
+++ b/packages/oidc_core/lib/src/endpoints/registration/request.g.dart
@@ -25,8 +25,21 @@ Map<String, dynamic> _$OidcClientRegistrationRequestToJson(
   'subject_type': ?instance.subjectType,
   'token_endpoint_auth_method': ?instance.tokenEndpointAuthMethod,
   'id_token_signed_response_alg': ?instance.idTokenSignedResponseAlg,
+  'default_max_age': ?_$JsonConverterToJson<int, Duration>(
+    instance.defaultMaxAge,
+    const OidcDurationSecondsConverter().toJson,
+  ),
+  'require_auth_time': ?instance.requireAuthTime,
+  'default_acr_values': ?instance.defaultAcrValues,
+  'initiate_login_uri': ?instance.initiateLoginUri?.toString(),
+  'request_uris': ?instance.requestUris?.map((e) => e.toString()).toList(),
   'scope': ?OidcInternalUtilities.joinSpaceDelimitedList(instance.scope),
   'software_id': ?instance.softwareId,
   'software_version': ?instance.softwareVersion,
   'software_statement': ?instance.softwareStatement,
 };
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) => value == null ? null : toJson(value);

--- a/packages/oidc_core/lib/src/endpoints/registration/response.dart
+++ b/packages/oidc_core/lib/src/endpoints/registration/response.dart
@@ -75,6 +75,41 @@ class OidcClientRegistrationResponse extends JsonBasedResponse {
   /// Registered human-readable client name.
   String? get clientName => src['client_name'] as String?;
 
+  /// Server-managed members that a client MUST NOT send back in an RFC 7592
+  /// §2.2 update request.
+  static const _updateExcludedKeys = {
+    'registration_access_token',
+    'registration_client_uri',
+    'client_id_issued_at',
+    'client_secret_expires_at',
+  };
+
+  /// Builds the full-metadata body for an RFC 7592 §2.2 client update (PUT to
+  /// [registrationClientUri]).
+  ///
+  /// Per RFC 7592 §2.2 the update MUST carry the complete set of client
+  /// metadata as returned by the server — values replace, not augment, the
+  /// prior registration — so this echoes every member of [src] except the
+  /// server-managed fields (`registration_access_token`,
+  /// `registration_client_uri`, `client_id_issued_at`,
+  /// `client_secret_expires_at`). `client_id`, and `client_secret` when it was
+  /// issued, are retained (the spec requires `client_id`, and a returned
+  /// `client_secret` MUST match the currently-issued secret).
+  ///
+  /// Note on rotation: the update *response* MAY return a new `client_secret`
+  /// and/or a new `registration_access_token` (RFC 7592 §2.2 / §3). Those
+  /// rotated credentials supersede the previous ones — read them from the
+  /// returned [OidcClientRegistrationResponse] (via [clientSecret] /
+  /// [registrationAccessToken]) and use them for subsequent requests; the old
+  /// values may no longer be valid.
+  OidcClientRegistrationRequest toUpdateRequest() {
+    final extra = <String, dynamic>{
+      for (final entry in src.entries)
+        if (!_updateExcludedKeys.contains(entry.key)) entry.key: entry.value,
+    };
+    return OidcClientRegistrationRequest(extra: extra);
+  }
+
   List<String>? _stringList(String key) {
     final value = src[key];
     return value is List ? value.map((e) => e.toString()).toList() : null;

--- a/packages/oidc_core/lib/src/models/client_auth.dart
+++ b/packages/oidc_core/lib/src/models/client_auth.dart
@@ -103,6 +103,86 @@ class OidcClientAuthentication {
        _signingAlgorithm = algorithm,
        _assertionLifetime = assertionLifetime;
 
+  /// Derives a ready-to-use client authentication from a Dynamic Client
+  /// Registration response (RFC 7591 §3.2.1 / RFC 7592).
+  ///
+  /// The method is taken from [preferredMethod] when supplied, otherwise from
+  /// the response's `token_endpoint_auth_method`, otherwise it defaults to
+  /// `client_secret_basic` (RFC 7591 §2). The response's `client_secret` (when
+  /// present) supplies the credential:
+  ///
+  /// - `none` → [OidcClientAuthentication.none].
+  /// - `client_secret_basic` → [OidcClientAuthentication.clientSecretBasic].
+  /// - `client_secret_post` → [OidcClientAuthentication.clientSecretPost].
+  /// - `client_secret_jwt` → [OidcClientAuthentication.clientSecretJwtGenerated]
+  ///   (assertions are minted per request from the issued secret).
+  ///
+  /// Throws an [OidcException] when the response carries no `client_id`, when a
+  /// secret-based method is selected but no `client_secret` was issued, when
+  /// the method is `private_key_jwt` (whose signing key is held by the client
+  /// out of band and is never part of a registration response — construct
+  /// [OidcClientAuthentication.privateKeyJwtGenerated] directly with that key),
+  /// or when the method is otherwise unsupported/unknown.
+  factory OidcClientAuthentication.fromRegistrationResponse(
+    OidcClientRegistrationResponse response, {
+    String? preferredMethod,
+  }) {
+    final clientId = response.clientId;
+    if (clientId == null) {
+      throw const OidcException(
+        'Cannot derive client authentication: the registration response has '
+        'no client_id.',
+      );
+    }
+    final method =
+        preferredMethod ??
+        response.tokenEndpointAuthMethod ??
+        OidcConstants_ClientAuthenticationMethods.clientSecretBasic;
+    final secret = response.clientSecret;
+
+    String requireSecret() {
+      if (secret == null) {
+        throw OidcException(
+          'The registration response selected token_endpoint_auth_method '
+          '"$method" but did not issue a client_secret.',
+        );
+      }
+      return secret;
+    }
+
+    switch (method) {
+      case OidcConstants_ClientAuthenticationMethods.none:
+        return OidcClientAuthentication.none(clientId: clientId);
+      case OidcConstants_ClientAuthenticationMethods.clientSecretBasic:
+        return OidcClientAuthentication.clientSecretBasic(
+          clientId: clientId,
+          clientSecret: requireSecret(),
+        );
+      case OidcConstants_ClientAuthenticationMethods.clientSecretPost:
+        return OidcClientAuthentication.clientSecretPost(
+          clientId: clientId,
+          clientSecret: requireSecret(),
+        );
+      case OidcConstants_ClientAuthenticationMethods.clientSecretJwt:
+        return OidcClientAuthentication.clientSecretJwtGenerated(
+          clientId: clientId,
+          clientSecret: requireSecret(),
+        );
+      case OidcConstants_ClientAuthenticationMethods.privateKeyJwt:
+        throw const OidcException(
+          'token_endpoint_auth_method "private_key_jwt" cannot be derived from '
+          'a registration response: the signing key is held by the client and '
+          'is never returned by the server. Construct '
+          'OidcClientAuthentication.privateKeyJwtGenerated directly with your '
+          'private key.',
+        );
+      default:
+        throw OidcException(
+          'Unsupported token_endpoint_auth_method "$method".',
+        );
+    }
+  }
+
   @JsonKey(includeToJson: false)
   final String location;
   @JsonKey(name: OidcConstants_AuthParameters.clientId)

--- a/packages/oidc_core/test/client_auth_from_registration_test.dart
+++ b/packages/oidc_core/test/client_auth_from_registration_test.dart
@@ -1,0 +1,161 @@
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+OidcClientRegistrationResponse _resp({
+  String? clientId = 'reg-client',
+  String? clientSecret,
+  String? method,
+}) => OidcClientRegistrationResponse.fromJson({
+  'client_id': ?clientId,
+  'client_secret': ?clientSecret,
+  'token_endpoint_auth_method': ?method,
+});
+
+void main() {
+  group('OidcClientAuthentication.fromRegistrationResponse', () {
+    test('none → OidcClientAuthentication.none', () {
+      final auth = OidcClientAuthentication.fromRegistrationResponse(
+        _resp(method: OidcConstants_ClientAuthenticationMethods.none),
+      );
+      expect(
+        auth.location,
+        OidcConstants_ClientAuthenticationMethods.none,
+      );
+      expect(auth.clientId, 'reg-client');
+      expect(auth.clientSecret, isNull);
+    });
+
+    test('client_secret_basic maps to clientSecretBasic with the secret', () {
+      final auth = OidcClientAuthentication.fromRegistrationResponse(
+        _resp(
+          clientSecret: 's3cr3t',
+          method: OidcConstants_ClientAuthenticationMethods.clientSecretBasic,
+        ),
+      );
+      expect(
+        auth.location,
+        OidcConstants_ClientAuthenticationMethods.clientSecretBasic,
+      );
+      expect(auth.clientSecret, 's3cr3t');
+      expect(auth.getAuthorizationHeader(), startsWith('Basic '));
+    });
+
+    test('client_secret_post maps to clientSecretPost with the secret', () {
+      final auth = OidcClientAuthentication.fromRegistrationResponse(
+        _resp(
+          clientSecret: 's3cr3t',
+          method: OidcConstants_ClientAuthenticationMethods.clientSecretPost,
+        ),
+      );
+      expect(
+        auth.location,
+        OidcConstants_ClientAuthenticationMethods.clientSecretPost,
+      );
+      expect(auth.clientSecret, 's3cr3t');
+      // client_secret_post carries the secret in the body, not a header.
+      expect(auth.getAuthorizationHeader(), isNull);
+      expect(auth.getBodyParameters()['client_secret'], 's3cr3t');
+    });
+
+    test(
+      'client_secret_jwt maps to the generated variant that mints assertions',
+      () {
+        final auth = OidcClientAuthentication.fromRegistrationResponse(
+          _resp(
+            clientSecret: 's3cr3t',
+            method: OidcConstants_ClientAuthenticationMethods.clientSecretJwt,
+          ),
+        );
+        expect(
+          auth.location,
+          OidcConstants_ClientAuthenticationMethods.clientSecretJwt,
+        );
+        // The generated variant holds the secret internally (never on the
+        // wire) and mints a fresh assertion per request.
+        expect(auth.clientSecret, isNull);
+        expect(auth.clientAssertion, isNull);
+        final resolved = auth.resolveForRequest(
+          Uri.parse('https://op.example.com/token'),
+        );
+        expect(resolved.clientAssertion, isNotNull);
+        expect(
+          resolved.clientAssertionType,
+          OidcConstants_ClientAssertionTypes.jwtBearer,
+        );
+      },
+    );
+
+    test('defaults to client_secret_basic when the method is absent '
+        '(RFC 7591 §2)', () {
+      final auth = OidcClientAuthentication.fromRegistrationResponse(
+        _resp(clientSecret: 's3cr3t'),
+      );
+      expect(
+        auth.location,
+        OidcConstants_ClientAuthenticationMethods.clientSecretBasic,
+      );
+      expect(auth.clientSecret, 's3cr3t');
+    });
+
+    test(
+      'preferredMethod overrides the response token_endpoint_auth_method',
+      () {
+        final auth = OidcClientAuthentication.fromRegistrationResponse(
+          _resp(
+            clientSecret: 's3cr3t',
+            method: OidcConstants_ClientAuthenticationMethods.clientSecretBasic,
+          ),
+          preferredMethod:
+              OidcConstants_ClientAuthenticationMethods.clientSecretPost,
+        );
+        expect(
+          auth.location,
+          OidcConstants_ClientAuthenticationMethods.clientSecretPost,
+        );
+      },
+    );
+
+    test('throws when a secret-based method has no client_secret', () {
+      expect(
+        () => OidcClientAuthentication.fromRegistrationResponse(
+          _resp(
+            method: OidcConstants_ClientAuthenticationMethods.clientSecretBasic,
+          ),
+        ),
+        throwsA(isA<OidcException>()),
+      );
+    });
+
+    test('throws when the response has no client_id', () {
+      expect(
+        () => OidcClientAuthentication.fromRegistrationResponse(
+          _resp(
+            clientId: null,
+            method: OidcConstants_ClientAuthenticationMethods.none,
+          ),
+        ),
+        throwsA(isA<OidcException>()),
+      );
+    });
+
+    test('throws for private_key_jwt (key is never in the response)', () {
+      expect(
+        () => OidcClientAuthentication.fromRegistrationResponse(
+          _resp(
+            method: OidcConstants_ClientAuthenticationMethods.privateKeyJwt,
+          ),
+        ),
+        throwsA(isA<OidcException>()),
+      );
+    });
+
+    test('throws for an unknown/unsupported method', () {
+      expect(
+        () => OidcClientAuthentication.fromRegistrationResponse(
+          _resp(method: 'tls_client_auth'),
+        ),
+        throwsA(isA<OidcException>()),
+      );
+    });
+  });
+}

--- a/packages/oidc_core/test/dynamic_client_registration_test.dart
+++ b/packages/oidc_core/test/dynamic_client_registration_test.dart
@@ -226,4 +226,94 @@ void main() {
       },
     );
   });
+
+  group('OidcClientRegistrationRequest OIDC-Reg-1.0 typed metadata', () {
+    test('serializes the OpenID Connect DCR §2 fields with correct types', () {
+      final body = OidcClientRegistrationRequest(
+        defaultMaxAge: const Duration(seconds: 3600),
+        requireAuthTime: true,
+        defaultAcrValues: const ['urn:mace:incommon:iap:silver', 'phr'],
+        initiateLoginUri: Uri.parse('https://app.example.com/initiate'),
+        requestUris: [
+          Uri.parse('https://app.example.com/request/1'),
+          Uri.parse('https://app.example.com/request/2'),
+        ],
+      ).toMap();
+
+      // default_max_age is a Number of seconds.
+      expect(body['default_max_age'], 3600);
+      // require_auth_time is a Boolean.
+      expect(body['require_auth_time'], true);
+      // default_acr_values is a JSON array of strings (NOT space-joined).
+      expect(body['default_acr_values'], [
+        'urn:mace:incommon:iap:silver',
+        'phr',
+      ]);
+      // initiate_login_uri is a URI string.
+      expect(body['initiate_login_uri'], 'https://app.example.com/initiate');
+      // request_uris is a JSON array of URI strings.
+      expect(body['request_uris'], [
+        'https://app.example.com/request/1',
+        'https://app.example.com/request/2',
+      ]);
+    });
+
+    test('omits the typed metadata fields entirely when unset', () {
+      final body = OidcClientRegistrationRequest(clientName: 'x').toMap();
+      expect(body.containsKey('default_max_age'), isFalse);
+      expect(body.containsKey('require_auth_time'), isFalse);
+      expect(body.containsKey('default_acr_values'), isFalse);
+      expect(body.containsKey('initiate_login_uri'), isFalse);
+      expect(body.containsKey('request_uris'), isFalse);
+    });
+  });
+
+  group('OidcClientRegistrationResponse.toUpdateRequest (RFC 7592 §2.2)', () {
+    test('echoes full metadata and drops server-managed fields', () {
+      final resp = OidcClientRegistrationResponse.fromJson({
+        'client_id': 'generated-id',
+        'client_secret': 's3cr3t',
+        'client_id_issued_at': 1672531200,
+        'client_secret_expires_at': 0,
+        'registration_access_token': 'rat-1',
+        'registration_client_uri':
+            'https://op.example.com/register/generated-id',
+        'redirect_uris': ['com.example.app://cb'],
+        'grant_types': ['authorization_code'],
+        'token_endpoint_auth_method': 'client_secret_basic',
+        'client_name': 'Example App',
+        'scope': 'openid profile',
+      });
+
+      final body = resp.toUpdateRequest().toMap();
+
+      // client_id (required) and client_secret (must match) are retained.
+      expect(body['client_id'], 'generated-id');
+      expect(body['client_secret'], 's3cr3t');
+      // Full metadata is echoed back.
+      expect(body['redirect_uris'], ['com.example.app://cb']);
+      expect(body['grant_types'], ['authorization_code']);
+      expect(body['token_endpoint_auth_method'], 'client_secret_basic');
+      expect(body['client_name'], 'Example App');
+      expect(body['scope'], 'openid profile');
+      // Server-managed fields MUST NOT be sent back.
+      expect(body.containsKey('registration_access_token'), isFalse);
+      expect(body.containsKey('registration_client_uri'), isFalse);
+      expect(body.containsKey('client_id_issued_at'), isFalse);
+      expect(body.containsKey('client_secret_expires_at'), isFalse);
+    });
+
+    test('rotation: a new secret/registration token in the update response '
+        'supersedes the old one', () {
+      // Simulate the PUT response rotating both credentials.
+      final updated = OidcClientRegistrationResponse.fromJson({
+        'client_id': 'generated-id',
+        'client_secret': 'rotated-secret',
+        'registration_access_token': 'rotated-rat',
+        'client_name': 'Example App v2',
+      });
+      expect(updated.clientSecret, 'rotated-secret');
+      expect(updated.registrationAccessToken, 'rotated-rat');
+    });
+  });
 }


### PR DESCRIPTION
Delivered the three tractable #385 DCR integration checklist items in oidc_core only. (1) Added the OidcClientAuthentication.fromRegistrationResponse(resp, {preferredMethod}) factory mapping token_endpoint_auth_method + credential presence to the right auth variant, defaulting to client_secret_basic (RFC 7591 §2), throwing OidcException on missing client_id, missing secret for a secret-based method, private_key_jwt, and unknown methods. (2) Added the five truly-absent typed OpenID Connect Dynamic Client Registration 1.0 §2 metadata fields to OidcClientRegistrationRequest (default_max_age as Duration, require_auth_time as bool, default_acr_values as List<String>, initiate_login_uri as Uri, request_uris as List<Uri>) and regenerated request.g.dart via build_runner. (3) Added OidcClientRegistrationResponse.toUpdateRequest() producing the full-metadata RFC 7592 §2.2 PUT body (dropping the four server-managed fields) with documented client_secret/registration_access_token rotation semantics.

### Test evidence
- `packages/oidc_core/test/client_auth_from_registration_test.dart (10 tests: none/basic/post/secret_jwt mappings, default-to-basic, preferredMethod override, and throws for missing-secret / missing-client_id / private_key_jwt / unknown method)`
- `packages/oidc_core/test/dynamic_client_registration_test.dart (4 added tests: typed OIDC-Reg-1.0 metadata serialization + omit-when-unset; toUpdateRequest full-metadata echo + server-managed-field exclusion; and credential-rotation supersession)`

Gates: PASS. `dart test packages/oidc_core`: All tests passed (654 tests, +4 groups from this change). `dart analyze packages/oidc_core`: 23 issues, all baseline (pre-existing in authorize/resp.dart, user_manager_base.dart, utils.dart, event_manager_test.dart); the 3 new lints my test helper introduced were fixed, so no NEW issues (pre-fix count was 26). `dart format --set-exit-if-changed` on all 6 chang

Part of #385.

Lands three integration items: `OidcClientAuthentication.fromRegistrationResponse`, the five typed OpenID Connect Dynamic Client Registration 1.0 §2 metadata fields, and `OidcClientRegistrationResponse.toUpdateRequest()` (RFC 7592 §2.2 full-metadata PUT with rotation semantics). The register→manager bootstrap and a dedicated registration-credential store namespace remain open on #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS
