### PR TITLE
build(melos): regenerate build_version files during `melos version` (fixes #416)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,7 @@ melos:
     # `cmd.exe /C %MELOS_SCRIPT%` on Windows, and cmd truncates the command at
     # the first embedded newline -- a `|` block would silently run only
     # generate:dart and drop the `git add`, making the fix inert on Windows
-    # (verified empirically against melos 7.8.2). `&&` keeps it one line and
+    # (verified empirically against melos 7.8.0). `&&` keeps it one line and
     # cross-platform, and short-circuits the add if generation fails.
     version:
       hooks:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,24 @@ melos:
           rm -rf coverage &&
           rm -rf pubspec.lock &&
           melos exec --dir-exists coverage -- "rm -rf coverage"
+    # `melos version` bumps each package's pubspec.yaml but never runs
+    # build_runner, so oidc_cli's build_version-generated lib/src/version.dart
+    # lags behind the new version until the next manual generate (issue #416).
+    # This preCommit hook regenerates it and stages it INTO the release commit.
+    # The explicit `git add` is REQUIRED: melos's _gitStageChanges only stages
+    # the changelogs and pubspecs it edits itself, never files a preCommit hook
+    # regenerates -- without it the fresh version.dart is left unstaged and the
+    # release commit ships a stale version, defeating the whole fix.
+    # Single line joined with `&&` (NOT a multi-line `|` block) on purpose:
+    # melos runs hooks via `sh -c 'eval "$MELOS_SCRIPT"'` on POSIX but
+    # `cmd.exe /C %MELOS_SCRIPT%` on Windows, and cmd truncates the command at
+    # the first embedded newline -- a `|` block would silently run only
+    # generate:dart and drop the `git add`, making the fix inert on Windows
+    # (verified empirically against melos 7.8.2). `&&` keeps it one line and
+    # cross-platform, and short-circuits the add if generation fails.
+    version:
+      hooks:
+        preCommit: melos run generate:dart && git add packages/oidc_cli/lib/src/version.dart
   scripts:
     pana:
       run: melos exec -c 1 "pana"


### PR DESCRIPTION
Fixes #416.

`melos version` bumps each package's pubspec but never runs build_runner, so oidc_cli's `build_version`-generated `lib/src/version.dart` lags every release — failing `ensure_build_test` and shipping a CLI that misreports its version (hand-patched on #415; this is the permanent fix).

Adds a `version` command `preCommit` hook to the root melos config:

```
version:
  hooks:
    preCommit: melos run generate:dart && git add packages/oidc_cli/lib/src/version.dart
```

Two non-obvious details, both verified against melos 7.8.x source and empirically:

- **The explicit `git add` is required.** melos's `_gitStageChanges` (`commands/version.dart`) only stages the changelogs and pubspecs it edits itself — never files a `preCommit` hook regenerates. Without the `git add`, the fresh `version.dart` is left unstaged and the release commit still ships the stale version.
- **Single-line `&&`, not a multi-line `|` block.** melos runs hooks via `sh -c 'eval "$MELOS_SCRIPT"'` on POSIX but `cmd.exe /C %MELOS_SCRIPT%` on Windows, and `cmd` truncates the command at the first embedded newline — a multi-line block silently runs only `generate:dart` and drops the `git add`, making the fix inert on Windows. Confirmed empirically: the multi-line form left `version.dart` unstaged; the `&&` form stages it. `&&` also short-circuits the add if generation fails.

Validated end-to-end: a scratch `melos version -V oidc_cli:1.0.2 --no-git-tag-version --no-git-commit-version` fired the hook and `git diff --cached` showed the regenerated `version.dart` staged at 1.0.2 (scratch bump then discarded). Diff is exactly the 18-line pubspec addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpgK7W6YsJsFVGQH5Yy6cS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Improved versioning workflow to automatically regenerate and include version information in release commits.
  * Added clearer guidance for handling version updates across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->