### PR TITLE
feat(oidc_core): silent-acquisition API at the manager/app boundary (#421, #422, #423, #424)

### DIFF
--- a/docs/oidc-usage-accesstoken.md
+++ b/docs/oidc-usage-accesstoken.md
@@ -1,29 +1,73 @@
 # Using the access token
 
-`package:oidc`'s role ends once you get the `access_token`/`id_token`, and what you do with it is outside the scope of the package.
+`package:oidc` hands you an `access_token`; what you do with it against your own API is outside the scope of the package.
 
 However here are common best practices on how you can get and use the `access_token` in different libraries.
 
 ## Getting the access token
 
-You can get the access token from the `OidcToken` object, that you can get from the `OidcUser` object.
+Use `OidcUserManager.getAccessToken()`. It returns an access token that is guaranteed to stay valid for at least `minValidity` (30 seconds by default), refreshing it first only when it would not be:
 
-You can get the `OidcUser` in 2 ways:
+```dart
+final accessToken = await userManager.getAccessToken();
+```
 
-1. Reactive way: listening on the `OidcUserManager.userChanges()` stream.
-2. Non-Reactive way: `OidcUserManager.currentUser` property.
+Three things it does that reading the token yourself does not:
 
-So the general idea is that when you are sending a request, you would first get the access token, then add it as a header `Authorization: Bearer access_token`.
+* **it refreshes only when needed** — a still-fresh token is returned without any network call;
+* **it coalesces concurrent callers** — N parallel requests that all find a stale token share ONE refresh-token exchange. This matters against a provider that rotates refresh tokens, which [RFC 9700 §2.2.2](https://www.rfc-editor.org/rfc/rfc9700.html#section-2.2.2) requires for public clients ("Refresh tokens for public clients MUST be sender-constrained or use refresh token rotation"): rotation invalidates the previous refresh token on every exchange, so a second concurrent exchange presents an invalidated token and the server "will revoke the active refresh token" ([§4.14.2](https://www.rfc-editor.org/rfc/rfc9700.html#section-4.14.2)) — logging the user out;
+* **it tells you when a login is genuinely required** — via a typed exception rather than an OAuth error string you have to match on.
+
+```dart
+try {
+  final accessToken = await userManager.getAccessToken();
+  // ... send the request
+} on OidcInteractionRequiredException {
+  // The session cannot be renewed silently — start an interactive login.
+  await userManager.loginAuthorizationCodeFlow();
+}
+```
+
+| Situation | Result |
+| --- | --- |
+| No signed-in user | returns `null` (a state, not an error) |
+| Token still valid for `minValidity` | returns it unchanged, no network call |
+| Token stale, refresh succeeds | returns the NEW access token |
+| Token stale, no refresh token / `invalid_grant` | throws `OidcInteractionRequiredException` |
+| Refresh failed for a recoverable reason (network, 5xx) | throws `OidcException` with `kind == OidcTokenRefreshFailureKind.transient` |
+
+Pass `forceRefresh: true` to exchange unconditionally, or a larger `minValidity` when your request may take a while to reach the resource server.
+
+You can still read the raw token off the user object (`userManager.currentUser?.token.accessToken`, or the `userManager.userChanges()` stream) when you want the current value WITHOUT any freshness guarantee — for display, diagnostics, or when you manage renewal yourself.
+
+### Silent re-authentication
+
+When the session has no refresh token — a public web client whose provider does not issue one — `signInSilent()` renews off the provider's own session cookie with a `prompt=none` request in a hidden iframe:
+
+```dart
+final user = await userManager.signInSilent();
+```
+
+It tries the refresh-token grant first when one is available, and shares the same in-flight exchange as `getAccessToken()`. It throws `OidcInteractionRequiredException` when the provider answers `login_required` / `interaction_required` / `consent_required` / `account_selection_required`.
+
+The `prompt=none` half is **web-only**: on native platforms it degrades to the refresh-token path, and even on web the hidden iframe depends on the provider session cookie being readable in a third-party context, which Safari's ITP blocks and Chrome restricts. Prefer a refresh token where your provider can issue one.
+
+## Sending the token
+
+The general idea is that when you are sending a request, you first get the access token, then add it as an `Authorization` header.
 
 ```dart
 const kAuthorizationHeader = 'Authorization';
 
-void tryAppendAccessToken(OidcUserManager userManager, Map<String, dynamic> headers) {
+Future<void> tryAppendAccessToken(
+  OidcUserManager userManager,
+  Map<String, dynamic> headers,
+) async {
   if (headers.containsKey(kAuthorizationHeader)) {
     // do nothing if header already exists.
     return;
   }
-  final accessToken = userManager.currentUser?.token.accessToken;
+  final accessToken = await userManager.getAccessToken();
   if (accessToken == null) {
     // do nothing if there is no access token.
     return;
@@ -31,6 +75,50 @@ void tryAppendAccessToken(OidcUserManager userManager, Map<String, dynamic> head
   headers[kAuthorizationHeader] = 'Bearer $accessToken';
 }
 ```
+
+### DPoP-protected resources
+
+When you enabled DPoP (`OidcUserManagerSettings.dpop`), your access token is sender-constrained (RFC 9449) and sending it as a plain `Bearer` throws that guarantee away. Mint a proof for each request with `createDPoPProof` and send the pair — `Authorization: DPoP <token>` plus a `DPoP: <proof>` header:
+
+```dart
+Future<void> tryAppendDPoPAccessToken(
+  OidcUserManager userManager,
+  Uri uri,
+  String method,
+  Map<String, dynamic> headers,
+) async {
+  final accessToken = await userManager.getAccessToken();
+  if (accessToken == null) {
+    return;
+  }
+  // Pass the same access token you are about to send, so the proof's `ath`
+  // claim matches it even if the call above just refreshed.
+  final proof = await userManager.createDPoPProof(
+    uri: uri,
+    method: method,
+    accessToken: accessToken,
+  );
+  headers[kAuthorizationHeader] =
+      proof == null ? 'Bearer $accessToken' : 'DPoP $accessToken';
+  if (proof != null) {
+    headers[oidcDPoPHeaderName] = proof;
+  }
+}
+```
+
+`createDPoPProof` returns `null` when DPoP is not enabled, so the same helper works for both configurations.
+
+A resource server may demand a nonce (RFC 9449 §8): it answers `401` with `error="use_dpop_nonce"` and a `DPoP-Nonce` header. Feed that nonce back and retry once:
+
+```dart
+final nonce = response.headers[oidcDPoPNonceHeaderName.toLowerCase()];
+if (response.statusCode == 401 && nonce != null) {
+  userManager.cacheDPoPNonce(uri, nonce);
+  // mint a fresh proof and send the request again, once.
+}
+```
+
+`userManager.dpopThumbprint` exposes the RFC 7638 thumbprint of the session proof key — the value the provider binds the token to as `cnf.jkt`.
 
 ## package:dio
 
@@ -50,8 +138,11 @@ class OidcUserManagerInterceptors extends Interceptor {
   final OidcUserManager userManager;
 
   @override
-  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    _tryAppendAccessToken(userManager, options.headers);
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    await tryAppendAccessToken(userManager, options.headers);
     handler.next(options);
   }
 }
@@ -83,8 +174,8 @@ class OidcHttpClient extends BaseClient {
   final OidcUserManager userManager;
 
   @override
-  Future<StreamedResponse> send(BaseRequest request) {
-    _tryAppendAccessToken(userManager, request.headers);
+  Future<StreamedResponse> send(BaseRequest request) async {
+    await tryAppendAccessToken(userManager, request.headers);
     return originalClient.send(request);
   }
 }

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -11,6 +11,21 @@ import 'package:oidc_core/oidc_core.dart';
 
 final _logger = Logger('OidcUserManagerBase');
 
+/// The outcome of ONE refresh-token exchange driven through the shared
+/// in-flight latch inside [OidcUserManagerBase].
+///
+/// Exactly one of `user` / `failureKind` is non-null, except for the neutral
+/// all-null outcome returned when the manager was disposed mid-flight (which
+/// every consumer treats as "do nothing"). `error` / `stackTrace` carry the
+/// original failure so a caller that must THROW (rather than swallow, as the
+/// automatic paths do) can preserve the diagnostics.
+typedef _OidcRefreshOutcome = ({
+  OidcUser? user,
+  OidcTokenRefreshFailureKind? failureKind,
+  Object? error,
+  StackTrace? stackTrace,
+});
+
 /// This class manages a single user's authentication status.
 ///
 /// It's preferred to maintain only a single instance of this class.
@@ -77,6 +92,72 @@ abstract class OidcUserManagerBase {
     return _dpopManager ??= OidcDPoPManager.generate(dpopSettings);
   }
 
+  /// Mints an RFC 9449 DPoP proof JWT for a protected-resource request, or
+  /// `null` when DPoP is not enabled (`settings.dpop == null`) or there is no
+  /// access token to bind the `ath` claim to.
+  ///
+  /// Without this, enabling [OidcUserManagerSettings.dpop] sender-constrains the
+  /// token but leaves the application unable to prove possession on its own API
+  /// calls — it would have to fall back to a plain `Bearer` header and silently
+  /// discard the guarantee. Send the pair instead:
+  ///
+  /// ```dart
+  /// final accessToken = await manager.getAccessToken();
+  /// final proof = await manager.createDPoPProof(uri: uri, method: 'GET');
+  /// final headers = {
+  ///   'Authorization': proof == null
+  ///       ? 'Bearer $accessToken'
+  ///       : 'DPoP $accessToken',
+  ///   if (proof != null) 'DPoP': proof,
+  /// };
+  /// ```
+  ///
+  /// If the resource server answers `401` with `error="use_dpop_nonce"` and a
+  /// `DPoP-Nonce` header, feed that nonce back with [cacheDPoPNonce] and mint a
+  /// fresh proof for a single retry.
+  ///
+  /// [uri] is the full request URI (RFC 9449 §4.2 `htu`; query and fragment are
+  /// stripped for you), [method] the HTTP method (`htm`). [accessToken]
+  /// overrides the token bound by the `ath` claim; it defaults to the current
+  /// user's access token, so pass whatever [getAccessToken] returned to be sure
+  /// the proof and the header agree after a refresh.
+  Future<String?> createDPoPProof({
+    required Uri uri,
+    String method = 'GET',
+    String? accessToken,
+  }) async {
+    final manager = dpopManager;
+    if (manager == null) {
+      return null;
+    }
+    final boundAccessToken = accessToken ?? currentUser?.token.accessToken;
+    if (boundAccessToken == null) {
+      return null;
+    }
+    return manager.createResourceProof(
+      method: method,
+      uri: uri,
+      accessToken: boundAccessToken,
+    );
+  }
+
+  /// Caches a `DPoP-Nonce` supplied by a resource server so the next proof
+  /// minted by [createDPoPProof] for [uri] carries it (RFC 9449 §8).
+  ///
+  /// No-op when DPoP is not enabled. Nonces are cached per endpoint, because the
+  /// authorization server and each resource server issue independent ones.
+  void cacheDPoPNonce(Uri uri, String nonce) {
+    dpopManager?.setNonceFor(uri, nonce);
+  }
+
+  /// The RFC 7638 thumbprint of this session's DPoP proof key — the value the
+  /// authorization server binds the token to as `cnf.jkt` — or `null` when DPoP
+  /// is not enabled.
+  ///
+  /// Useful for asserting that an issued access token is actually bound to this
+  /// manager's key.
+  String? get dpopThumbprint => dpopManager?.thumbprint;
+
   /// The settings used in this manager.
   final OidcUserManagerSettings settings;
 
@@ -127,15 +208,26 @@ abstract class OidcUserManagerBase {
   /// Counter for consecutive refresh failures
   int consecutiveRefreshFailures = 0;
 
-  /// #154: the in-flight automatic (on-expiry) refresh, shared between
-  /// [handleTokenExpiring] and [handleTokenExpired]. On resume both the
-  /// `expiring` and `expired` timers can be overdue and fire together; latching
-  /// both handlers onto this single future guarantees the refresh token is
-  /// exchanged exactly once (no double refresh) and lets the expired handler
-  /// defer its forget decision to the refresh outcome instead of racing it.
-  /// `null` when no auto-refresh is currently running.
-  Future<({OidcUser? user, OidcTokenRefreshFailureKind? failureKind})>?
-  _autoRefreshInFlight;
+  /// #154: the in-flight refresh, shared between [handleTokenExpiring],
+  /// [handleTokenExpired] and (#421) [getAccessToken] / [signInSilent]. On
+  /// resume both the `expiring` and `expired` timers can be overdue and fire
+  /// together; latching every handler onto this single future guarantees the
+  /// refresh token is exchanged exactly once (no double refresh) and lets the
+  /// expired handler defer its forget decision to the refresh outcome instead
+  /// of racing it.
+  ///
+  /// #421: the silent-acquisition entry points join the SAME latch, so N
+  /// parallel API calls that all discover a stale access token perform ONE
+  /// token exchange between them. That matters against an OP that rotates
+  /// refresh tokens — required for public clients by RFC 9700 §2.2.2 ("Refresh
+  /// tokens for public clients MUST be sender-constrained or use refresh token
+  /// rotation") — because rotation invalidates the previous refresh token on
+  /// every exchange, so a second concurrent exchange presents an invalidated
+  /// token and the AS "will revoke the active refresh token" (§4.14.2),
+  /// forcing a fresh authorization grant.
+  ///
+  /// `null` when no refresh is currently running.
+  Future<_OidcRefreshOutcome>? _autoRefreshInFlight;
 
   /// #201: while a cache-first background revalidation owns the refresh of the
   /// just-restored (possibly already-expired) cached token, the expiry-driven
@@ -1556,6 +1648,139 @@ abstract class OidcUserManagerBase {
     );
   }
 
+  /// Returns an access token that is guaranteed to stay valid for at least
+  /// [minValidity], refreshing it first only when it would not.
+  ///
+  /// This is the "give me a usable access token right now" entry point, meant to
+  /// be called on EVERY outgoing request to a protected resource instead of
+  /// reading `currentUser?.token.accessToken` (which is freshness-unaware):
+  ///
+  /// ```dart
+  /// final accessToken = await userManager.getAccessToken();
+  /// ```
+  ///
+  /// ## Concurrency
+  ///
+  /// Concurrent callers share a SINGLE refresh-token exchange (the same
+  /// in-flight latch the automatic on-expiry refresh uses), so N parallel API
+  /// calls that all find a stale token do not each exchange the refresh token.
+  /// This matters against an OP with refresh-token rotation, where N concurrent
+  /// exchanges of the same refresh token look like token reuse and can revoke
+  /// the entire grant family. Note that the older [refreshToken] deliberately
+  /// keeps its unconditional, un-coalesced behaviour for callers that need a
+  /// raw exchange (e.g. with an `overrideRefreshToken`).
+  ///
+  /// ## Return value and errors
+  ///
+  /// * Returns `null` when there is no signed-in user — this is a state, not an
+  ///   error, so it does not throw.
+  /// * Returns the current access token unchanged when the token carries no
+  ///   `expires_in` (the library cannot know how much time is left; the same
+  ///   assumption that disables the expiry timers) and [forceRefresh] is false.
+  /// * Throws [OidcInteractionRequiredException] when the token is stale and
+  ///   cannot be renewed silently — no refresh token, or a terminal refresh
+  ///   failure such as `invalid_grant`. Handle it by starting an interactive
+  ///   login.
+  /// * Throws an [OidcException] whose [OidcException.kind] is
+  ///   [OidcTokenRefreshFailureKind.transient] when the refresh failed for a
+  ///   recoverable reason (network / timeout / 5xx). Retrying later can succeed;
+  ///   the cached session is retained.
+  ///
+  /// [minValidity] is the freshness margin: a token expiring sooner than this is
+  /// refreshed first. [forceRefresh] refreshes unconditionally, ignoring
+  /// [minValidity].
+  Future<String?> getAccessToken({
+    Duration minValidity = const Duration(seconds: 30),
+    bool forceRefresh = false,
+  }) async {
+    ensureInit();
+    final user = currentUser;
+    if (user == null) {
+      // No session at all — a state the caller handles (e.g. show a login
+      // button), not a failure to throw about.
+      return null;
+    }
+    final token = user.token;
+    if (!forceRefresh) {
+      // `isAccessTokenAboutToExpire` reports `true` when `expiresIn` is null
+      // (unknown expiry). Treat unknown as "usable" instead, mirroring
+      // [listenToTokenRefreshIfSupported], which likewise declines to arm the
+      // expiry timers for such a token — otherwise EVERY call would refresh.
+      final stillFresh =
+          token.expiresIn == null ||
+          !token.isAccessTokenAboutToExpire(tolerance: minValidity);
+      if (stillFresh) {
+        return token.accessToken;
+      }
+    }
+
+    if (token.refreshToken == null) {
+      throw OidcInteractionRequiredException(
+        message: forceRefresh
+            ? 'A refresh was forced but the current session has no '
+                  'refresh_token; interactive re-authentication is required.'
+            : 'The access token is expired (or expires within $minValidity) '
+                  'and the current session has no refresh_token; interactive '
+                  're-authentication is required.',
+      );
+    }
+
+    final outcome = await _autoRefresh(
+      token,
+      source: OidcTokenRefreshSource.manual,
+    );
+    return _userFromRefreshOutcome(outcome)?.token.accessToken;
+  }
+
+  /// Maps a shared-latch refresh outcome onto the silent-acquisition contract
+  /// shared by [getAccessToken] and [signInSilent]: return the renewed user,
+  /// throw [OidcInteractionRequiredException] on a terminal failure, and throw a
+  /// `kind`-stamped [OidcException] on a transient one.
+  OidcUser? _userFromRefreshOutcome(_OidcRefreshOutcome outcome) {
+    final refreshedUser = outcome.user;
+    if (refreshedUser != null) {
+      return refreshedUser;
+    }
+    final failureKind = outcome.failureKind;
+    if (failureKind == null) {
+      // The manager was disposed while the refresh was in flight; the refresh
+      // deliberately became a complete no-op, so there is nothing to hand back.
+      return null;
+    }
+    final error = outcome.error;
+    if (failureKind == OidcTokenRefreshFailureKind.terminal) {
+      throw OidcInteractionRequiredException.from(
+        error ?? const OidcException('The refresh token grant was rejected.'),
+        message:
+            'The refresh token was rejected by the authorization server '
+            '(revoked, expired, or already rotated); interactive '
+            're-authentication is required.',
+        stackTrace: outcome.stackTrace,
+      );
+    }
+    if (error is OidcException) {
+      // Preserve the original diagnostics but re-stamp the classification the
+      // caller needs (the raw throw carried no `kind`).
+      throw OidcException.raw(
+        message: error.message,
+        extra: error.extra,
+        errorResponse: error.errorResponse,
+        internalException: error.internalException ?? error,
+        internalStackTrace: error.internalStackTrace ?? outcome.stackTrace,
+        rawRequest: error.rawRequest,
+        rawResponse: error.rawResponse,
+        kind: failureKind,
+      );
+    }
+    throw OidcException(
+      'Refreshing the access token failed for a recoverable reason; '
+      'retrying later may succeed.',
+      internalException: error,
+      internalStackTrace: outcome.stackTrace,
+      kind: failureKind,
+    );
+  }
+
   Future<OidcUser?> _refreshToken({
     String? overrideRefreshToken,
     OidcProviderMetadata? discoveryDocumentOverride,
@@ -1711,29 +1936,44 @@ abstract class OidcUserManagerBase {
     await _autoRefresh(event);
   }
 
-  /// Returns the in-flight automatic refresh for [event], starting one if none
-  /// is running. Concurrent callers ([handleTokenExpiring] and
-  /// [handleTokenExpired] on resume) share the SAME future, so the refresh
-  /// token is exchanged only once. The latch clears itself on completion so a
-  /// later expiry can refresh again.
-  Future<({OidcUser? user, OidcTokenRefreshFailureKind? failureKind})>
-  _autoRefresh(OidcToken event) {
-    return _autoRefreshInFlight ??= _performAutoRefresh(event).whenComplete(() {
-      _autoRefreshInFlight = null;
-    });
+  /// Returns the in-flight refresh for [event], starting one if none is
+  /// running. Concurrent callers ([handleTokenExpiring] and
+  /// [handleTokenExpired] on resume, plus every [getAccessToken] /
+  /// [signInSilent] caller) share the SAME future, so the refresh token is
+  /// exchanged only once. The latch clears itself on completion so a later
+  /// expiry can refresh again.
+  ///
+  /// [source] labels the emitted [OidcTokenRefreshFailedEvent] and only applies
+  /// to the caller that actually STARTS the exchange — a caller that joins an
+  /// already-running refresh inherits that refresh's source, because there is
+  /// only one exchange (and therefore only one failure event) to label.
+  Future<_OidcRefreshOutcome> _autoRefresh(
+    OidcToken event, {
+    OidcTokenRefreshSource source = OidcTokenRefreshSource.autoExpiry,
+  }) {
+    return _autoRefreshInFlight ??= _performAutoRefresh(event, source: source)
+        .whenComplete(() {
+          _autoRefreshInFlight = null;
+        });
   }
 
-  /// Performs one automatic (on-expiry) refresh of [event]'s refresh token and
-  /// classifies the outcome.
+  /// Performs one refresh of [event]'s refresh token and classifies the
+  /// outcome.
   ///
   /// On success the replaced user is saved (which re-arms the token timers via
   /// [userChanges]) and returned with a `null` `failureKind`. On failure the
-  /// single `OidcTokenRefreshFailedEvent` (source `autoExpiry`) is emitted,
+  /// single `OidcTokenRefreshFailedEvent` (labelled with [source]) is emitted,
   /// offline handling runs, and the failure `OidcTokenRefreshFailureKind` is
   /// returned with a `null` user so [handleTokenExpired] can decide whether to
-  /// forget the session.
-  Future<({OidcUser? user, OidcTokenRefreshFailureKind? failureKind})>
-  _performAutoRefresh(OidcToken event) async {
+  /// forget the session and [getAccessToken] can decide what to throw.
+  ///
+  /// This method never throws the refresh failure — it is shared with the
+  /// automatic (timer-driven) paths, which must not surface an unhandled async
+  /// error. Callers that need a throw re-raise from the returned `error`.
+  Future<_OidcRefreshOutcome> _performAutoRefresh(
+    OidcToken event, {
+    OidcTokenRefreshSource source = OidcTokenRefreshSource.autoExpiry,
+  }) async {
     OidcUser? newUser;
     //try getting a new token.
     try {
@@ -1773,14 +2013,19 @@ abstract class OidcUserManagerBase {
       // (possibly delayed) refresh was in flight, the outcome must be a
       // COMPLETE no-op — no user save/mutation via [createUserFromToken], no
       // `recordSuccessfulServerContact`, no event. Returning the neutral
-      // `(null, null)` also leaves [handleTokenExpired]'s forget decision a
+      // all-null outcome also leaves [handleTokenExpired]'s forget decision a
       // no-op (it only forgets on a `terminal` failureKind).
       if (_isDisposed) {
         logger.finest(
           'Auto-refresh succeeded after the manager was disposed; '
           'ignoring the new token.',
         );
-        return (user: null, failureKind: null);
+        return (
+          user: null,
+          failureKind: null,
+          error: null,
+          stackTrace: null,
+        );
       }
       newUser = await createUserFromToken(
         token: OidcToken.fromResponse(
@@ -1797,7 +2042,12 @@ abstract class OidcUserManagerBase {
       // Successful refresh - update last server contact and exit offline mode
       recordSuccessfulServerContact(newToken: newUser?.token);
       logger.fine('Refreshed a token and got a new user: ${newUser?.uid}');
-      return (user: newUser, failureKind: null);
+      return (
+        user: newUser,
+        failureKind: null,
+        error: null,
+        stackTrace: null,
+      );
     } on Object catch (e, st) {
       // Post-dispose safety: a refresh that FAILS after the manager was torn
       // down must also be a COMPLETE no-op — no failure event, no offline
@@ -1809,7 +2059,12 @@ abstract class OidcUserManagerBase {
           e,
           st,
         );
-        return (user: null, failureKind: null);
+        return (
+          user: null,
+          failureKind: null,
+          error: null,
+          stackTrace: null,
+        );
       }
       // #120: a transient failure that offline handling will absorb schedules a
       // retry; a terminal failure (e.g. invalid_grant) or a disabled offline
@@ -1825,7 +2080,7 @@ abstract class OidcUserManagerBase {
       final failedEvent = OidcTokenRefreshFailedEvent.fromError(
         error: e,
         stackTrace: st,
-        source: OidcTokenRefreshSource.autoExpiry,
+        source: source,
         willRetry: willRetry,
       );
       emitEvent(failedEvent);
@@ -1854,7 +2109,12 @@ abstract class OidcUserManagerBase {
         );
         tokenEvents.unload();
       }
-      return (user: null, failureKind: failedEvent.kind);
+      return (
+        user: null,
+        failureKind: failedEvent.kind,
+        error: e,
+        stackTrace: st,
+      );
     }
   }
 
@@ -1980,7 +2240,7 @@ abstract class OidcUserManagerBase {
         _autoRefresh(event).then((result) async {
           // Post-dispose safety: never forget (a user mutation + store write)
           // once the manager is torn down. [_performAutoRefresh] already
-          // returns the neutral `(null, null)` when disposed, so `failureKind`
+          // returns the neutral all-null outcome when disposed, so `failureKind`
           // is never `terminal` here; this is a defensive second gate against
           // a dispose that races the completion.
           if (_isDisposed) {
@@ -3553,7 +3813,122 @@ abstract class OidcUserManagerBase {
     await forgetUser();
   }
 
+  /// The OpenID Connect Core 1.0 §3.1.2.6 authorization-error codes that mean
+  /// "the OP cannot satisfy this without showing the user something", i.e.
+  /// exactly the `prompt=none` outcomes that require an interactive login.
+  static const _interactionRequiredErrorCodes = {
+    'login_required',
+    'interaction_required',
+    'consent_required',
+    'account_selection_required',
+  };
+
+  /// Renews the session WITHOUT any user interaction.
   ///
+  /// Two mechanisms, in order:
+  ///
+  /// 1. the refresh-token grant, when the current session has a refresh token.
+  ///    This shares the same in-flight latch as [getAccessToken] and the
+  ///    automatic on-expiry refresh, so it never races a second exchange.
+  /// 2. otherwise `prompt=none` against the authorization endpoint, which
+  ///    renews off the OP's own session cookie. This is the classic web-SPA
+  ///    renewal path for a public client whose OP issues no refresh token.
+  ///
+  /// ## Platform matrix — read before relying on step 2
+  ///
+  /// The `prompt=none` variant runs in a HIDDEN IFRAME and is therefore
+  /// **web-only**: on native platforms the navigation mode is ignored and the
+  /// request would surface a browser/Custom Tab, which is not silent. On native,
+  /// treat this method as "refresh-token renewal" and expect
+  /// [OidcInteractionRequiredException] when there is no refresh token.
+  ///
+  /// Even on web the iframe variant is not universally reliable: it depends on
+  /// the OP session cookie being readable in a third-party context, which
+  /// Safari's ITP blocks outright and Chrome restricts. Prefer a refresh token
+  /// when your OP can issue one.
+  ///
+  /// ## Return value and errors
+  ///
+  /// Returns the renewed [OidcUser], or `null` when the platform completes the
+  /// flow out-of-band (a full-page redirect hands the result to
+  /// `init()` instead) or when the manager was disposed mid-flight.
+  ///
+  /// Throws [OidcInteractionRequiredException] when the OP requires interaction
+  /// — a terminal refresh failure (`invalid_grant`), or a `prompt=none` response
+  /// of `login_required` / `interaction_required` / `consent_required` /
+  /// `account_selection_required`. Throws a `kind`-stamped [OidcException] for a
+  /// transient refresh failure.
+  ///
+  /// [timeout] overrides `hiddenIframeTimeout` for this call only.
+  /// [scopeOverride] and [extraParameters] are forwarded to
+  /// [loginAuthorizationCodeFlow] on the `prompt=none` path (they do not apply
+  /// to the refresh-token path, which always uses the configured scope).
+  Future<OidcUser?> signInSilent({
+    Duration? timeout,
+    List<String>? scopeOverride,
+    Map<String, dynamic>? extraParameters,
+  }) async {
+    ensureInit();
+    final token = currentUser?.token;
+    if (token != null && token.refreshToken != null) {
+      final outcome = await _autoRefresh(
+        token,
+        source: OidcTokenRefreshSource.manual,
+      );
+      return _userFromRefreshOutcome(outcome);
+    }
+
+    final baseOptions = getPlatformOptions();
+    try {
+      return await loginAuthorizationCodeFlow(
+        promptOverride: const ['none'],
+        scopeOverride: scopeOverride,
+        extraParameters: extraParameters,
+        options: OidcPlatformSpecificOptions(
+          // Every non-web section is carried over untouched: forcing the hidden
+          // iframe must not silently reset the caller's Custom Tabs / native
+          // options.
+          android: baseOptions.android,
+          ios: baseOptions.ios,
+          macos: baseOptions.macos,
+          linux: baseOptions.linux,
+          windows: baseOptions.windows,
+          web: OidcPlatformSpecificOptions_Web(
+            navigationMode:
+                OidcPlatformSpecificOptions_Web_NavigationMode.hiddenIFrame,
+            popupWidth: baseOptions.web.popupWidth,
+            popupHeight: baseOptions.web.popupHeight,
+            broadcastChannel: baseOptions.web.broadcastChannel,
+            hiddenIframeTimeout: timeout ?? baseOptions.web.hiddenIframeTimeout,
+          ),
+        ),
+      );
+    } on OidcException catch (e, st) {
+      final errorCode = e.errorResponse?.error;
+      if (errorCode != null &&
+          _interactionRequiredErrorCodes.contains(errorCode)) {
+        throw OidcInteractionRequiredException.from(
+          e,
+          message:
+              'The authorization server answered a prompt=none request with '
+              '`$errorCode`; interactive re-authentication is required.',
+          stackTrace: st,
+        );
+      }
+      rethrow;
+    }
+  }
+
+  /// Attempts a `prompt=none` re-authorization, forgetting the user when the OP
+  /// answers with an error response.
+  ///
+  /// Prefer the public [signInSilent], which additionally tries the
+  /// refresh-token grant first, lets the caller override the iframe timeout, and
+  /// reports an interaction requirement as a typed
+  /// [OidcInteractionRequiredException] instead of a bare `null`. This method is
+  /// retained because the session-monitor reaction wants the
+  /// forget-on-error behaviour rather than a throw.
+  @Deprecated('use signInSilent')
   @protected
   Future<OidcUser?> reAuthorizeUser() async {
     try {

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -276,7 +276,14 @@ abstract class OidcUserManagerBase {
   /// simply already-completed) — and safe to call after [dispose] (the
   /// revalidation future never throws; see [_scheduleBackgroundRevalidation]'s
   /// own all-swallowing `try`/`catch`, mirrored by [loadCachedTokens] and
-  /// [_refreshToken]).
+  /// [_refreshToken]). That guarantee depends on the `try` wrapping the
+  /// `await initFuture` at the very top of
+  /// [_scheduleBackgroundRevalidation] too, not just the revalidation logic
+  /// after it — `init()` itself can fail (e.g. a subclass's
+  /// [attachLifecycleListeners] override throwing synchronously), and a
+  /// failed `initFuture` must still hit that `catch`/`finally` like any other
+  /// error, or this future would stay permanently errored and every future
+  /// join would rethrow it forever.
   ///
   /// Reads [_cacheFirstRevalidationFuture] into a local variable synchronously
   /// (no `await` before the read) so a concurrent settle-and-clear by
@@ -3811,10 +3818,22 @@ abstract class OidcUserManagerBase {
   /// token is discarded as invalid (and offline auth is not keeping it), the
   /// stale restored user is forgotten.
   Future<void> _scheduleBackgroundRevalidation(OidcUser restoredUser) async {
-    // Wait until init() has fully returned (didInit == true) before touching
-    // init-guarded getters.
-    await initFuture;
     try {
+      // Wait until init() has fully returned (didInit == true) before
+      // touching init-guarded getters. Deliberately INSIDE this try: if
+      // `init()` itself fails (e.g. `attachLifecycleListeners()`, called
+      // AFTER this revalidation is armed — see `_tryCacheFirstInit` — throws
+      // synchronously), `initFuture` rethrows that same error here, and it
+      // must still hit the catch-all below so the `finally` always runs. An
+      // earlier revision awaited `initFuture` OUTSIDE this try: a failed
+      // `init()` then permanently skipped the `finally`, leaving
+      // `_cacheFirstRevalidationFuture` pointing at a forever-errored future
+      // that every later [_joinCacheFirstRevalidationIfInFlight] call
+      // (`getAccessToken`/`signInSilent`) re-awaited and rethrew, AND leaving
+      // `_cacheFirstRevalidationInFlight` stuck `true` forever, permanently
+      // suppressing the on-expiry auto-refresh gated on it in
+      // [handleTokenExpiring]/[handleTokenExpired].
+      await initFuture;
       await _refreshDiscoveryInBackgroundIfStale();
       await loadCachedTokens(forceRebuild: true);
       // Reconcile the optimistically-surfaced restore with the authoritative

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -244,6 +244,64 @@ abstract class OidcUserManagerBase {
   /// settles, after which normal on-expiry auto-refresh resumes.
   bool _cacheFirstRevalidationInFlight = false;
 
+  /// The [_scheduleBackgroundRevalidation] future currently running, non-null
+  /// for exactly the same window as [_cacheFirstRevalidationInFlight] (both are
+  /// set together in [_tryCacheFirstInit] and cleared together in
+  /// [_scheduleBackgroundRevalidation]'s `finally`).
+  ///
+  /// #421/#422/#423: [handleTokenExpiring] / [handleTokenExpired] are gated on
+  /// the bool above, but [getAccessToken] and [signInSilent] are NOT — they
+  /// join the SAME shared [_autoRefreshInFlight] latch used by the expiry
+  /// timers and the plain manual refresh, which the background revalidation's
+  /// refresh (driven through [loadCachedTokens] -> the raw, un-coalesced
+  /// [_refreshToken]) never populates. So while a background revalidation is
+  /// running, [getAccessToken] / [signInSilent] would see no in-flight
+  /// [_autoRefreshInFlight] and start a SECOND, competing `/token` exchange
+  /// that presents the SAME refresh token the revalidation is already
+  /// exchanging — exactly the RFC 9700 §4.14.2 rotation-reuse hazard
+  /// [_cacheFirstRevalidationInFlight] exists to prevent for the timer paths.
+  /// [_joinCacheFirstRevalidationIfInFlight] closes that gap: those two entry
+  /// points await this future (joining the single in-flight revalidation and
+  /// reusing whatever it concludes — refreshed, retained, or forgotten user)
+  /// instead of starting their own exchange.
+  Future<void>? _cacheFirstRevalidationFuture;
+
+  /// Awaits an in-flight cache-first background revalidation
+  /// ([_tryCacheFirstInit] / [_scheduleBackgroundRevalidation]), if one is
+  /// currently running, so the caller joins its outcome instead of starting a
+  /// second, competing refresh-token exchange.
+  ///
+  /// A no-op when no revalidation is in flight — including when one has
+  /// already settled by the time this is called (the captured future is
+  /// simply already-completed) — and safe to call after [dispose] (the
+  /// revalidation future never throws; see [_scheduleBackgroundRevalidation]'s
+  /// own all-swallowing `try`/`catch`, mirrored by [loadCachedTokens] and
+  /// [_refreshToken]).
+  ///
+  /// Reads [_cacheFirstRevalidationFuture] into a local variable synchronously
+  /// (no `await` before the read) so a concurrent settle-and-clear by
+  /// [_scheduleBackgroundRevalidation]'s `finally` block can never race this
+  /// check: either this call observes the field before it is nulled (and
+  /// awaits the real future) or after (and no-ops), never a torn read.
+  ///
+  /// Returns `true` when an actual in-flight revalidation was joined (as
+  /// opposed to a no-op because none was running), so a caller can tell "a
+  /// renewal attempt equivalent to mine just happened" apart from "nothing
+  /// was in flight, proceed as usual".
+  ///
+  /// Private (not `@protected`): this is plumbing internal to
+  /// [getAccessToken] / [signInSilent], not something a platform subclass
+  /// needs to override or call — kept off the extendable surface deliberately
+  /// (see the source-breaking-for-subclassers advisory on #421-424).
+  Future<bool> _joinCacheFirstRevalidationIfInFlight() async {
+    final revalidation = _cacheFirstRevalidationFuture;
+    if (revalidation == null) {
+      return false;
+    }
+    await revalidation;
+    return true;
+  }
+
   /// Returns true if the manager is currently in offline mode.
   bool get isInOfflineMode => offlineModeStartedAt != null;
 
@@ -1670,6 +1728,13 @@ abstract class OidcUserManagerBase {
   /// keeps its unconditional, un-coalesced behaviour for callers that need a
   /// raw exchange (e.g. with an `overrideRefreshToken`).
   ///
+  /// This call also joins (rather than races) an in-flight
+  /// [OidcInitMode.cacheFirst] background revalidation — see
+  /// [_cacheFirstRevalidationFuture] — so calling this immediately after
+  /// `await manager.init()` returns (cacheFirst is the DEFAULT) never presents
+  /// the same refresh token a second time while the background pass is still
+  /// exchanging it.
+  ///
   /// ## Return value and errors
   ///
   /// * Returns `null` when there is no signed-in user — this is a state, not an
@@ -1683,8 +1748,18 @@ abstract class OidcUserManagerBase {
   ///   login.
   /// * Throws an [OidcException] whose [OidcException.kind] is
   ///   [OidcTokenRefreshFailureKind.transient] when the refresh failed for a
-  ///   recoverable reason (network / timeout / 5xx). Retrying later can succeed;
-  ///   the cached session is retained.
+  ///   recoverable reason (network / timeout / 5xx) **and offline mode did NOT
+  ///   absorb it** — i.e. [OidcUserManagerSettings.supportOfflineAuth] is
+  ///   `false`, or the specific error isn't offline-eligible. Retrying later
+  ///   can succeed; the cached session is retained.
+  /// * Returns the cached (now possibly stale) access token, WITHOUT throwing,
+  ///   when a recoverable failure occurs and offline mode DOES absorb it
+  ///   ([OidcUserManagerSettings.supportOfflineAuth] is `true` for an
+  ///   offline-eligible error): this mirrors the legacy [refreshToken]'s
+  ///   "keep the cached session" behavior, so a call made while offline gets a
+  ///   usable (if stale) token instead of an exception — otherwise every
+  ///   `getAccessToken`/[signInSilent] call while offline would throw, which
+  ///   would defeat the point of enabling offline auth support.
   ///
   /// [minValidity] is the freshness margin: a token expiring sooner than this is
   /// refreshed first. [forceRefresh] refreshes unconditionally, ignoring
@@ -1694,6 +1769,14 @@ abstract class OidcUserManagerBase {
     bool forceRefresh = false,
   }) async {
     ensureInit();
+    // Join (rather than race) an in-flight cache-first background
+    // revalidation — see [_cacheFirstRevalidationFuture] for why this call
+    // would otherwise start a SECOND `/token` exchange presenting the same
+    // refresh token the revalidation is already exchanging. After this
+    // completes, [currentUser] already reflects whatever the revalidation
+    // concluded (refreshed / retained / forgotten), so the freshness check
+    // below sees the post-revalidation state.
+    await _joinCacheFirstRevalidationIfInFlight();
     final user = currentUser;
     if (user == null) {
       // No session at all — a state the caller handles (e.g. show a login
@@ -1961,11 +2044,23 @@ abstract class OidcUserManagerBase {
   /// outcome.
   ///
   /// On success the replaced user is saved (which re-arms the token timers via
-  /// [userChanges]) and returned with a `null` `failureKind`. On failure the
-  /// single `OidcTokenRefreshFailedEvent` (labelled with [source]) is emitted,
-  /// offline handling runs, and the failure `OidcTokenRefreshFailureKind` is
-  /// returned with a `null` user so [handleTokenExpired] can decide whether to
-  /// forget the session and [getAccessToken] can decide what to throw.
+  /// [userChanges]) and returned with a `null` `failureKind`.
+  ///
+  /// On failure the single `OidcTokenRefreshFailedEvent` (labelled with
+  /// [source]) is emitted, then offline handling runs:
+  /// * When [handleOfflineEligibleFailure] ABSORBS the failure (a recoverable
+  ///   / offline-eligible error with [OidcUserManagerSettings.supportOfflineAuth]
+  ///   enabled), this returns the RETAINED [currentUser] with a `null`
+  ///   `failureKind` — the same "keep the cached session, don't throw"
+  ///   contract [_refreshToken] already gives `refreshToken()`. Without this,
+  ///   [getAccessToken] / [signInSilent] would throw a `kind: transient`
+  ///   [OidcException] the moment offline mode kicks in, defeating the entire
+  ///   point of `supportOfflineAuth` for those two entry points (a `getAccessToken`
+  ///   call while offline should hand back the cached token, not throw).
+  /// * Otherwise (terminal failure, or offline auth not eligible/enabled) the
+  ///   failure `OidcTokenRefreshFailureKind` is returned with a `null` user so
+  ///   [handleTokenExpired] can decide whether to forget the session and
+  ///   [getAccessToken] / [signInSilent] can decide what to throw.
   ///
   /// This method never throws the refresh failure — it is shared with the
   /// automatic (timer-driven) paths, which must not surface an unhandled async
@@ -2108,12 +2203,25 @@ abstract class OidcUserManagerBase {
           e,
         );
         tokenEvents.unload();
+        return (
+          user: null,
+          failureKind: failedEvent.kind,
+          error: e,
+          stackTrace: st,
+        );
       }
+      // Offline mode absorbed the failure: report a SUCCESS-shaped outcome
+      // (the retained user, `failureKind: null`) rather than the raw failure.
+      // [handleTokenExpired] only forgets on `failureKind == terminal`, so
+      // this is a no-op change for the timer-driven callers (unaffected —
+      // they already never saw `terminal` here); it is what makes
+      // [getAccessToken] / [signInSilent] hand back the cached access token
+      // instead of throwing while offline (see the dartdoc above).
       return (
-        user: null,
-        failureKind: failedEvent.kind,
-        error: e,
-        stackTrace: st,
+        user: currentUser,
+        failureKind: null,
+        error: null,
+        stackTrace: null,
       );
     }
   }
@@ -3631,8 +3739,16 @@ abstract class OidcUserManagerBase {
     // timers). The background pass owns the first refresh; the expiry-driven
     // auto-refresh stays suppressed until [_scheduleBackgroundRevalidation]
     // clears the gate.
+    //
+    // The future is captured into [_cacheFirstRevalidationFuture] in the SAME
+    // synchronous step (calling an async function runs it up to its first
+    // `await` and returns its Future immediately) so there is never a window
+    // where the bool is `true` but the future field is still `null` for a
+    // concurrent [getAccessToken] / [signInSilent] to observe.
     _cacheFirstRevalidationInFlight = true;
-    unawaited(_scheduleBackgroundRevalidation(restored));
+    final revalidationFuture = _scheduleBackgroundRevalidation(restored);
+    _cacheFirstRevalidationFuture = revalidationFuture;
+    unawaited(revalidationFuture);
     return true;
   }
 
@@ -3740,6 +3856,13 @@ abstract class OidcUserManagerBase {
       // expiries must go through [handleTokenExpiring] / [handleTokenExpired]
       // again.
       _cacheFirstRevalidationInFlight = false;
+      // Clear alongside the bool above: a caller that captured this future via
+      // [_joinCacheFirstRevalidationIfInFlight] already holds its own
+      // reference (it read the field into a local before this `finally` runs),
+      // so nulling the field here only stops a LATER caller from joining a
+      // revalidation that has already settled — it does not affect anyone
+      // already awaiting it.
+      _cacheFirstRevalidationFuture = null;
     }
   }
 
@@ -3829,7 +3952,10 @@ abstract class OidcUserManagerBase {
   ///
   /// 1. the refresh-token grant, when the current session has a refresh token.
   ///    This shares the same in-flight latch as [getAccessToken] and the
-  ///    automatic on-expiry refresh, so it never races a second exchange.
+  ///    automatic on-expiry refresh, so it never races a second exchange; it
+  ///    also joins an in-flight [OidcInitMode.cacheFirst] background
+  ///    revalidation the same way [getAccessToken] does, reusing its outcome
+  ///    instead of presenting the refresh token a second time.
   /// 2. otherwise `prompt=none` against the authorization endpoint, which
   ///    renews off the OP's own session cookie. This is the classic web-SPA
   ///    renewal path for a public client whose OP issues no refresh token.
@@ -3857,7 +3983,10 @@ abstract class OidcUserManagerBase {
   /// — a terminal refresh failure (`invalid_grant`), or a `prompt=none` response
   /// of `login_required` / `interaction_required` / `consent_required` /
   /// `account_selection_required`. Throws a `kind`-stamped [OidcException] for a
-  /// transient refresh failure.
+  /// transient refresh failure that offline mode did NOT absorb — same caveat
+  /// as [getAccessToken]: with [OidcUserManagerSettings.supportOfflineAuth]
+  /// enabled and an offline-eligible error, this returns the retained
+  /// [currentUser] instead of throwing.
   ///
   /// [timeout] overrides `hiddenIframeTimeout` for this call only.
   /// [scopeOverride] and [extraParameters] are forwarded to
@@ -3869,8 +3998,34 @@ abstract class OidcUserManagerBase {
     Map<String, dynamic>? extraParameters,
   }) async {
     ensureInit();
+    // Join (rather than race) an in-flight cache-first background
+    // revalidation — see [_cacheFirstRevalidationFuture]. Re-read
+    // [currentUser] AFTER the join (not a pre-join local) so the
+    // refresh-token check below reflects whatever the revalidation concluded.
+    final joinedRevalidation = await _joinCacheFirstRevalidationIfInFlight();
     final token = currentUser?.token;
     if (token != null && token.refreshToken != null) {
+      // #421/#422/#423: when we just joined an in-flight revalidation AND its
+      // outcome left this token no longer close to expiring, mechanism #1's
+      // goal ("renew via the refresh-token grant") is ALREADY satisfied by
+      // that revalidation — reuse it instead of presenting the refresh token
+      // a second time (the very race this join exists to prevent).
+      //
+      // When the token is STILL stale — no revalidation ran (joinedRevalidation
+      // is false: the normal, non-racing case, entirely unchanged below), or
+      // one ran but failed to refresh it (a transient failure that offline
+      // mode absorbed, retaining the old token) — fall through to the
+      // existing unconditional renewal attempt, so a real failure is still
+      // thrown here with the correct [OidcTokenRefreshFailureKind], exactly as
+      // this method has always promised. (A terminal failure during the
+      // revalidation instead forgets the user entirely, so `token` above is
+      // `null` and this whole branch is skipped in favor of the prompt=none
+      // fallback below — unchanged.)
+      final tokenIsFreshEnough =
+          token.expiresIn == null || !token.isAccessTokenAboutToExpire();
+      if (joinedRevalidation && tokenIsFreshEnough) {
+        return currentUser;
+      }
       final outcome = await _autoRefresh(
         token,
         source: OidcTokenRefreshSource.manual,

--- a/packages/oidc_core/lib/src/models/exception.dart
+++ b/packages/oidc_core/lib/src/models/exception.dart
@@ -10,6 +10,7 @@ class OidcException implements Exception {
     this.internalStackTrace,
     this.rawRequest,
     this.rawResponse,
+    this.kind,
   }) : errorResponse = null;
 
   const OidcException.serverError({
@@ -18,9 +19,29 @@ class OidcException implements Exception {
     this.rawRequest,
     this.rawResponse,
     String? message,
+    this.kind,
   }) : message = message ?? 'Server sent an error response',
        internalException = null,
        internalStackTrace = null;
+
+  /// Creates an exception with every field supplied explicitly.
+  ///
+  /// Unlike the default constructor (which forces `errorResponse` to null) and
+  /// [OidcException.serverError] (which forces the internal error fields to
+  /// null), this lets a caller carry BOTH an [errorResponse] and an
+  /// [internalException]/[internalStackTrace] at once, which is what re-throwing
+  /// an already-classified failure needs in order to preserve the original
+  /// diagnostics. Used by [OidcInteractionRequiredException].
+  const OidcException.raw({
+    required this.message,
+    this.extra = const {},
+    this.errorResponse,
+    this.internalException,
+    this.internalStackTrace,
+    this.rawRequest,
+    this.rawResponse,
+    this.kind,
+  });
 
   final String message;
   final Map<String, dynamic> extra;
@@ -30,10 +51,109 @@ class OidcException implements Exception {
   final http.Request? rawRequest;
   final http.Response? rawResponse;
 
+  /// The classification of this failure, when the library could derive one.
+  ///
+  /// Mirrors the classification already carried by
+  /// [OidcTokenRefreshFailedEvent.kind] (derived from
+  /// [OidcOfflineAuthErrorHandler.categorizeError]), so an awaiting caller can
+  /// decide "re-authenticate now" vs. "retry later" WITHOUT string-comparing
+  /// RFC 6749 §5.2 error codes:
+  ///
+  /// * [OidcTokenRefreshFailureKind.terminal] — the grant is dead
+  ///   (`invalid_grant`, or a `prompt=none` attempt that came back
+  ///   `login_required` / `interaction_required` / `consent_required`).
+  ///   Re-authentication is required; such failures are thrown as
+  ///   [OidcInteractionRequiredException].
+  /// * [OidcTokenRefreshFailureKind.transient] — the liveness of the grant is
+  ///   unknown (network / timeout / TLS / 5xx). Retrying can succeed.
+  ///
+  /// `null` on the many paths that raise an [OidcException] without any
+  /// refresh-failure classification (validation errors, misconfiguration, …),
+  /// which is every path that existed before this field was added.
+  final OidcTokenRefreshFailureKind? kind;
+
   @override
   String toString() {
     final message = this.message;
     return 'OidcException: $message, '
+        'extra: $extra, '
+        'error: ${errorResponse?.error}';
+  }
+}
+
+/// Thrown when the session cannot be renewed without user interaction.
+///
+/// This is the typed counterpart of MSAL.NET's `MsalUiRequiredException`: it
+/// marks exactly the failures whose recommended handling is "start an
+/// interactive login", so consumers never have to string-match OAuth error
+/// codes:
+///
+/// ```dart
+/// try {
+///   final accessToken = await manager.getAccessToken();
+///   // ... use it
+/// } on OidcInteractionRequiredException {
+///   await manager.loginAuthorizationCodeFlow();
+/// }
+/// ```
+///
+/// It is raised when:
+///
+/// * the refresh-token grant failed terminally — the refresh token was revoked,
+///   expired, or already rotated (`invalid_grant`, RFC 6749 §5.2), or the
+///   authorization server returned another non-recoverable client error;
+/// * there is no refresh token at all to renew a stale access token with; or
+/// * a `prompt=none` attempt (see [OidcUserManagerBase.signInSilent]) came back
+///   with `login_required`, `interaction_required`, `consent_required` or
+///   `account_selection_required` (OpenID Connect Core 1.0 §3.1.2.6).
+///
+/// Being a subclass, every existing `on OidcException` catch keeps matching it.
+/// [kind] is always [OidcTokenRefreshFailureKind.terminal].
+class OidcInteractionRequiredException extends OidcException {
+  ///
+  const OidcInteractionRequiredException({
+    required super.message,
+    super.extra,
+    super.errorResponse,
+    super.internalException,
+    super.internalStackTrace,
+    super.rawRequest,
+    super.rawResponse,
+  }) : super.raw(kind: OidcTokenRefreshFailureKind.terminal);
+
+  /// Wraps an already-caught [error] while preserving its diagnostics.
+  ///
+  /// When [error] is an [OidcException], its `errorResponse`, `extra` and raw
+  /// HTTP exchange are carried over and the ORIGINAL exception is kept as
+  /// [internalException] so nothing is lost; otherwise [error] itself becomes
+  /// [internalException].
+  factory OidcInteractionRequiredException.from(
+    Object error, {
+    required String message,
+    StackTrace? stackTrace,
+  }) {
+    if (error is OidcException) {
+      return OidcInteractionRequiredException(
+        message: message,
+        extra: error.extra,
+        errorResponse: error.errorResponse,
+        internalException: error,
+        internalStackTrace: stackTrace ?? error.internalStackTrace,
+        rawRequest: error.rawRequest,
+        rawResponse: error.rawResponse,
+      );
+    }
+    return OidcInteractionRequiredException(
+      message: message,
+      internalException: error,
+      internalStackTrace: stackTrace,
+    );
+  }
+
+  @override
+  String toString() {
+    final message = this.message;
+    return 'OidcInteractionRequiredException: $message, '
         'extra: $extra, '
         'error: ${errorResponse?.error}';
   }

--- a/packages/oidc_core/test/app_boundary_api_test.dart
+++ b/packages/oidc_core/test/app_boundary_api_test.dart
@@ -1,0 +1,854 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+const _issuer = 'https://op.example.com';
+final _signingKey = JsonWebKey.generate('RS256');
+
+String _signIdToken({
+  String subject = 'user-1',
+  Duration expiresIn = const Duration(hours: 1),
+}) {
+  final now = clock.now().millisecondsSinceEpoch ~/ 1000;
+  return (JsonWebSignatureBuilder()
+        ..jsonContent = {
+          'iss': _issuer,
+          'sub': subject,
+          'aud': 'client-1',
+          'exp': now + expiresIn.inSeconds,
+          'iat': now,
+        }
+        ..addRecipient(_signingKey, algorithm: 'RS256'))
+      .build()
+      .toCompactSerialization();
+}
+
+Map<String, dynamic> _decodeSegment(String segment) =>
+    jsonDecode(utf8.decode(base64Url.decode(base64Url.normalize(segment))))
+        as Map<String, dynamic>;
+
+({Map<String, dynamic> header, Map<String, dynamic> payload}) _parseProof(
+  String proof,
+) {
+  final parts = proof.split('.');
+  expect(parts, hasLength(3), reason: 'compact JWS has 3 segments');
+  return (header: _decodeSegment(parts[0]), payload: _decodeSegment(parts[1]));
+}
+
+/// A concrete manager that lets a test seed a user and observe/short-circuit
+/// the authorization request the `prompt=none` path builds.
+class _M extends OidcUserManagerBase {
+  _M({
+    required super.discoveryDocument,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    super.httpClient,
+    super.keyStore,
+  });
+
+  void seed(OidcUser? user) => userSubject.add(user);
+
+  /// Every authorization request this manager was asked to perform, with the
+  /// resolved platform options it was asked to perform it with.
+  final authorizeCalls =
+      <({OidcAuthorizeRequest request, OidcPlatformSpecificOptions options})>[];
+
+  /// When set, [getAuthorizationResponse] throws this instead of returning
+  /// `null` (models an OP answering the `prompt=none` request with an error).
+  Object? authorizeError;
+
+  @override
+  bool get isWeb => false;
+
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async {
+    authorizeCalls.add((request: request, options: options));
+    final error = authorizeError;
+    if (error != null) {
+      throw error;
+    }
+    return null;
+  }
+
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+OidcProviderMetadata _metadata() => OidcProviderMetadata.fromJson({
+  'issuer': _issuer,
+  'authorization_endpoint': '$_issuer/authorize',
+  'token_endpoint': '$_issuer/token',
+  'userinfo_endpoint': '$_issuer/userinfo',
+});
+
+Future<_M> _build(
+  http.Client client, {
+  OidcDPoPSettings? dpop,
+  OidcPlatformSpecificOptions? options,
+}) async {
+  final manager = _M(
+    discoveryDocument: _metadata(),
+    clientCredentials: const OidcClientAuthentication.none(
+      clientId: 'client-1',
+    ),
+    store: OidcMemoryStore(),
+    httpClient: client,
+    keyStore: JsonWebKeyStore()..addKey(_signingKey),
+    settings: OidcUserManagerSettings(
+      redirectUri: Uri.parse('com.example.app://cb'),
+      userInfoSettings: const OidcUserInfoSettings(sendUserInfoRequest: false),
+      dpop: dpop,
+      options: options,
+    ),
+  );
+  await manager.init();
+  addTearDown(manager.dispose);
+  return manager;
+}
+
+/// A user whose access token is still valid for [expiresIn].
+///
+/// A long, explicit `expiresIn` keeps the expiry timers armed far in the future
+/// so the tests below drive the refresh themselves through
+/// `getAccessToken`/`signInSilent` — no timer ever races them.
+Future<OidcUser> _user({
+  String? refreshToken = 'rt-1',
+  Duration? expiresIn = const Duration(hours: 1),
+}) => OidcUser.fromIdToken(
+  token: OidcToken(
+    creationTime: clock.now().toUtc(),
+    idToken: _signIdToken(),
+    accessToken: 'at-1',
+    refreshToken: refreshToken,
+    tokenType: 'Bearer',
+    expiresIn: expiresIn,
+  ),
+);
+
+String _tokenResponseBody({String accessToken = 'at-2'}) => jsonEncode({
+  'access_token': accessToken,
+  'token_type': 'Bearer',
+  'expires_in': 3600,
+  'id_token': _signIdToken(),
+  'refresh_token': 'rt-2',
+});
+
+void main() {
+  group('#424 typed failure classification on OidcException', () {
+    test('the pre-existing constructors keep a null `kind` (nothing that '
+        'threw before is suddenly classified)', () {
+      const plain = OidcException('boom');
+      expect(plain.kind, isNull);
+
+      const server = OidcException.serverError(
+        errorResponse: OidcErrorResponse(src: {}, error: 'invalid_request'),
+      );
+      expect(server.kind, isNull);
+      expect(server.errorResponse?.error, 'invalid_request');
+    });
+
+    test('OidcInteractionRequiredException is still caught by `on '
+        'OidcException` (additive, non-breaking)', () {
+      OidcException? caught;
+      try {
+        throw const OidcInteractionRequiredException(message: 'need login');
+      } on OidcException catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<OidcInteractionRequiredException>());
+      expect(caught.kind, OidcTokenRefreshFailureKind.terminal);
+    });
+
+    test('OidcInteractionRequiredException.from preserves the original '
+        'diagnostics of an OidcException', () {
+      final rawResponse = http.Response('{"error":"invalid_grant"}', 400);
+      final original = OidcException.serverError(
+        errorResponse: const OidcErrorResponse(
+          src: {},
+          error: 'invalid_grant',
+          errorDescription: 'token revoked',
+        ),
+        extra: const {'hint': 'x'},
+        rawResponse: rawResponse,
+      );
+
+      final wrapped = OidcInteractionRequiredException.from(
+        original,
+        message: 'interactive re-authentication is required',
+      );
+
+      expect(wrapped.errorResponse?.error, 'invalid_grant');
+      expect(wrapped.errorResponse?.errorDescription, 'token revoked');
+      expect(wrapped.extra, const {'hint': 'x'});
+      expect(wrapped.rawResponse, same(rawResponse));
+      expect(wrapped.internalException, same(original));
+      expect(wrapped.kind, OidcTokenRefreshFailureKind.terminal);
+    });
+
+    test('OidcInteractionRequiredException.from wraps a non-Oidc error as the '
+        'internal exception', () {
+      final wrapped = OidcInteractionRequiredException.from(
+        const FormatException('nope'),
+        message: 'need login',
+      );
+      expect(wrapped.internalException, isA<FormatException>());
+      expect(wrapped.errorResponse, isNull);
+    });
+
+    test('toString names the concrete type', () {
+      expect(
+        const OidcInteractionRequiredException(message: 'm').toString(),
+        startsWith('OidcInteractionRequiredException: m'),
+      );
+      expect(
+        const OidcException('m').toString(),
+        startsWith('OidcException: m'),
+      );
+    });
+  });
+
+  group('#421 getAccessToken', () {
+    test(
+      'returns null (does not throw) when there is no signed-in user',
+      () async {
+        final manager = await _build(
+          MockClient((req) async => http.Response('{}', 404)),
+        );
+        expect(await manager.getAccessToken(), isNull);
+      },
+    );
+
+    test('returns the cached token WITHOUT a network call when it is still '
+        'valid for minValidity', () async {
+      var tokenCalls = 0;
+      final manager = await _build(
+        MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            tokenCalls++;
+          }
+          return http.Response('{}', 404);
+        }),
+      );
+      manager.seed(await _user());
+
+      expect(await manager.getAccessToken(), 'at-1');
+      expect(tokenCalls, 0, reason: 'a fresh token must not be exchanged');
+    });
+
+    test('refreshes when the token expires within minValidity, and returns the '
+        'NEW access token', () async {
+      var tokenCalls = 0;
+      final manager = await _build(
+        MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            tokenCalls++;
+            return http.Response(
+              _tokenResponseBody(),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        }),
+      );
+      manager.seed(await _user());
+
+      // The seeded token is valid for 1h, so a 2h freshness margin forces the
+      // refresh deterministically (no timer involved).
+      final accessToken = await manager.getAccessToken(
+        minValidity: const Duration(hours: 2),
+      );
+      expect(accessToken, 'at-2');
+      expect(tokenCalls, 1);
+      expect(manager.currentUser?.token.accessToken, 'at-2');
+    });
+
+    test(
+      'forceRefresh exchanges even a token that is comfortably fresh',
+      () async {
+        var tokenCalls = 0;
+        final manager = await _build(
+          MockClient((req) async {
+            if (req.url.path.endsWith('/token')) {
+              tokenCalls++;
+              return http.Response(
+                _tokenResponseBody(),
+                200,
+                headers: const {'content-type': 'application/json'},
+              );
+            }
+            return http.Response('{}', 404);
+          }),
+        );
+        manager.seed(await _user());
+
+        expect(await manager.getAccessToken(forceRefresh: true), 'at-2');
+        expect(tokenCalls, 1);
+      },
+    );
+
+    test('a token with no expires_in is returned as-is (unknown expiry is not '
+        'treated as expired)', () async {
+      var tokenCalls = 0;
+      final manager = await _build(
+        MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            tokenCalls++;
+          }
+          return http.Response('{}', 404);
+        }),
+      );
+      manager.seed(await _user(expiresIn: null));
+
+      expect(
+        await manager.getAccessToken(minValidity: const Duration(days: 365)),
+        'at-1',
+      );
+      expect(tokenCalls, 0);
+    });
+
+    test('CONCURRENT callers share ONE refresh-token exchange (the rotating '
+        'refresh-token stampede #421 describes)', () async {
+      final gate = Completer<http.Response>();
+      var tokenCalls = 0;
+      final manager = await _build(
+        MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            tokenCalls++;
+            return gate.future;
+          }
+          return http.Response('{}', 404);
+        }),
+      );
+      manager.seed(await _user());
+
+      final calls = [
+        manager.getAccessToken(minValidity: const Duration(hours: 2)),
+        manager.getAccessToken(minValidity: const Duration(hours: 2)),
+        manager.getAccessToken(minValidity: const Duration(hours: 2)),
+      ];
+      await pumpEventQueue();
+      expect(
+        tokenCalls,
+        1,
+        reason: 'three concurrent callers must exchange the refresh token once',
+      );
+
+      gate.complete(
+        http.Response(
+          _tokenResponseBody(),
+          200,
+          headers: const {'content-type': 'application/json'},
+        ),
+      );
+      expect(await Future.wait(calls), ['at-2', 'at-2', 'at-2']);
+      expect(tokenCalls, 1);
+    });
+
+    test('throws OidcInteractionRequiredException when the stale session has '
+        'no refresh token', () async {
+      final manager = await _build(
+        MockClient((req) async => http.Response('{}', 404)),
+      );
+      manager.seed(await _user(refreshToken: null));
+
+      await expectLater(
+        manager.getAccessToken(minValidity: const Duration(hours: 2)),
+        throwsA(isA<OidcInteractionRequiredException>()),
+      );
+    });
+
+    test('throws OidcInteractionRequiredException on a TERMINAL refresh '
+        'failure (invalid_grant)', () async {
+      final manager = await _build(
+        MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            return http.Response(
+              jsonEncode({'error': 'invalid_grant'}),
+              400,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        }),
+      );
+      manager.seed(await _user());
+
+      await expectLater(
+        manager.getAccessToken(minValidity: const Duration(hours: 2)),
+        throwsA(
+          isA<OidcInteractionRequiredException>()
+              .having(
+                (e) => e.kind,
+                'kind',
+                OidcTokenRefreshFailureKind.terminal,
+              )
+              .having(
+                (e) => e.errorResponse?.error,
+                'errorResponse.error',
+                'invalid_grant',
+              ),
+        ),
+      );
+    });
+
+    test('throws a `transient`-classified OidcException — NOT an '
+        'interaction-required one — on a recoverable failure', () async {
+      final manager = await _build(
+        MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            return http.Response(
+              jsonEncode({'error': 'server_error'}),
+              500,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        }),
+      );
+      manager.seed(await _user());
+
+      await expectLater(
+        manager.getAccessToken(minValidity: const Duration(hours: 2)),
+        throwsA(
+          isA<OidcException>()
+              .having(
+                (e) => e.kind,
+                'kind',
+                OidcTokenRefreshFailureKind.transient,
+              )
+              .having(
+                (e) => e is OidcInteractionRequiredException,
+                'is interaction-required',
+                isFalse,
+              ),
+        ),
+      );
+    });
+
+    test('the refresh it drives is reported as a `manual` refresh failure '
+        'event, not an autoExpiry one', () async {
+      final manager = await _build(
+        MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            return http.Response(
+              jsonEncode({'error': 'invalid_grant'}),
+              400,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        }),
+      );
+      manager.seed(await _user());
+
+      final events = <OidcEvent>[];
+      final sub = manager.events().listen(events.add);
+      addTearDown(sub.cancel);
+
+      await expectLater(
+        manager.getAccessToken(minValidity: const Duration(hours: 2)),
+        throwsA(isA<OidcInteractionRequiredException>()),
+      );
+      await pumpEventQueue();
+
+      final failures = events.whereType<OidcTokenRefreshFailedEvent>().toList();
+      expect(failures, hasLength(1));
+      expect(failures.single.source, OidcTokenRefreshSource.manual);
+      expect(failures.single.kind, OidcTokenRefreshFailureKind.terminal);
+    });
+
+    test('the legacy refreshToken() keeps its unconditional, un-coalesced '
+        'behaviour (no silent change for existing callers)', () async {
+      var tokenCalls = 0;
+      final manager = await _build(
+        MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            tokenCalls++;
+            return http.Response(
+              _tokenResponseBody(accessToken: 'at-$tokenCalls'),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        }),
+      );
+      manager.seed(await _user());
+
+      // A comfortably fresh token: getAccessToken skips the exchange, while
+      // refreshToken() still performs it.
+      expect(await manager.getAccessToken(), 'at-1');
+      expect(tokenCalls, 0);
+      await manager.refreshToken();
+      expect(tokenCalls, 1);
+    });
+  });
+
+  group('#422 public DPoP proof facade', () {
+    test(
+      'returns null (and has no thumbprint) when DPoP is disabled',
+      () async {
+        final manager = await _build(
+          MockClient((req) async => http.Response('{}', 404)),
+        );
+        manager.seed(await _user());
+
+        expect(manager.dpopThumbprint, isNull);
+        expect(
+          await manager.createDPoPProof(uri: Uri.parse('$_issuer/api')),
+          isNull,
+        );
+        // A no-op rather than a crash when DPoP is off.
+        manager.cacheDPoPNonce(Uri.parse('$_issuer/api'), 'n-1');
+      },
+    );
+
+    test(
+      'mints an RFC 9449 resource proof bound to the current access token',
+      () async {
+        final manager = await _build(
+          MockClient((req) async => http.Response('{}', 404)),
+          dpop: const OidcDPoPSettings(),
+        );
+        manager.seed(await _user());
+
+        final proof = await manager.createDPoPProof(
+          uri: Uri.parse('$_issuer/api/orders?page=2'),
+          method: 'post',
+        );
+        expect(proof, isNotNull);
+        final parsed = _parseProof(proof!);
+
+        expect(parsed.header['typ'], oidcDPoPProofTyp);
+        expect(parsed.header['jwk'], isA<Map<String, dynamic>>());
+        expect(
+          (parsed.header['jwk'] as Map<String, dynamic>).containsKey('d'),
+          isFalse,
+          reason: 'the embedded jwk must never carry private key material',
+        );
+        expect(parsed.payload['htm'], 'POST', reason: 'htm is uppercased');
+        expect(
+          parsed.payload['htu'],
+          '$_issuer/api/orders',
+          reason: 'htu drops the query string',
+        );
+        expect(parsed.payload['ath'], oidcDPoPAth('at-1'));
+        expect(parsed.payload.containsKey('nonce'), isFalse);
+      },
+    );
+
+    test('an explicit accessToken overrides the `ath` binding', () async {
+      final manager = await _build(
+        MockClient((req) async => http.Response('{}', 404)),
+        dpop: const OidcDPoPSettings(),
+      );
+      manager.seed(await _user());
+
+      final proof = await manager.createDPoPProof(
+        uri: Uri.parse('$_issuer/api'),
+        accessToken: 'other-token',
+      );
+      expect(_parseProof(proof!).payload['ath'], oidcDPoPAth('other-token'));
+    });
+
+    test('returns null when DPoP is enabled but there is no access token to '
+        'bind', () async {
+      final manager = await _build(
+        MockClient((req) async => http.Response('{}', 404)),
+        dpop: const OidcDPoPSettings(),
+      );
+      expect(
+        await manager.createDPoPProof(uri: Uri.parse('$_issuer/api')),
+        isNull,
+      );
+    });
+
+    test('cacheDPoPNonce feeds a resource-server `DPoP-Nonce` into the NEXT '
+        'proof for that endpoint only', () async {
+      final manager = await _build(
+        MockClient((req) async => http.Response('{}', 404)),
+        dpop: const OidcDPoPSettings(),
+      );
+      manager.seed(await _user());
+
+      final resource = Uri.parse('$_issuer/api/orders');
+      manager.cacheDPoPNonce(resource, 'nonce-abc');
+
+      final withNonce = await manager.createDPoPProof(uri: resource);
+      expect(_parseProof(withNonce!).payload['nonce'], 'nonce-abc');
+
+      final other = await manager.createDPoPProof(
+        uri: Uri.parse('$_issuer/api/invoices'),
+      );
+      expect(
+        _parseProof(other!).payload.containsKey('nonce'),
+        isFalse,
+        reason: 'nonces are cached per endpoint',
+      );
+    });
+
+    test('dpopThumbprint is the RFC 7638 thumbprint of the session proof key '
+        '(the `cnf.jkt` value)', () async {
+      final manager = await _build(
+        MockClient((req) async => http.Response('{}', 404)),
+        dpop: const OidcDPoPSettings(),
+      );
+      manager.seed(await _user());
+
+      final thumbprint = manager.dpopThumbprint;
+      expect(thumbprint, isNotNull);
+      // Stable across calls (the same per-session key is reused).
+      expect(manager.dpopThumbprint, thumbprint);
+
+      final proof = await manager.createDPoPProof(uri: Uri.parse('$_issuer/a'));
+      final jwk = _parseProof(proof!).header['jwk'] as Map<String, dynamic>;
+      expect(oidcJwkThumbprint(JsonWebKey.fromJson(jwk)!), thumbprint);
+    });
+  });
+
+  group('#423 signInSilent', () {
+    test('uses the refresh-token grant when one is available, WITHOUT touching '
+        'the authorization endpoint', () async {
+      var tokenCalls = 0;
+      final manager = await _build(
+        MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            tokenCalls++;
+            return http.Response(
+              _tokenResponseBody(),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        }),
+      );
+      manager.seed(await _user());
+
+      final user = await manager.signInSilent();
+      expect(user?.token.accessToken, 'at-2');
+      expect(tokenCalls, 1);
+      expect(manager.authorizeCalls, isEmpty);
+    });
+
+    test('shares the SAME in-flight exchange as getAccessToken', () async {
+      final gate = Completer<http.Response>();
+      var tokenCalls = 0;
+      final manager = await _build(
+        MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            tokenCalls++;
+            return gate.future;
+          }
+          return http.Response('{}', 404);
+        }),
+      );
+      manager.seed(await _user());
+
+      final silent = manager.signInSilent();
+      final acquired = manager.getAccessToken(
+        minValidity: const Duration(hours: 2),
+      );
+      await pumpEventQueue();
+      expect(tokenCalls, 1);
+
+      gate.complete(
+        http.Response(
+          _tokenResponseBody(),
+          200,
+          headers: const {'content-type': 'application/json'},
+        ),
+      );
+      expect((await silent)?.token.accessToken, 'at-2');
+      expect(await acquired, 'at-2');
+      expect(tokenCalls, 1);
+    });
+
+    test('throws OidcInteractionRequiredException when the refresh token is '
+        'terminally rejected', () async {
+      final manager = await _build(
+        MockClient((req) async {
+          if (req.url.path.endsWith('/token')) {
+            return http.Response(
+              jsonEncode({'error': 'invalid_grant'}),
+              400,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{}', 404);
+        }),
+      );
+      manager.seed(await _user());
+
+      await expectLater(
+        manager.signInSilent(),
+        throwsA(isA<OidcInteractionRequiredException>()),
+      );
+    });
+
+    test('falls back to a hidden-iframe `prompt=none` authorization request '
+        'when there is no refresh token', () async {
+      final manager = await _build(
+        MockClient((req) async => http.Response('{}', 404)),
+      );
+      manager.seed(await _user(refreshToken: null));
+
+      await manager.signInSilent(timeout: const Duration(seconds: 3));
+
+      expect(manager.authorizeCalls, hasLength(1));
+      final call = manager.authorizeCalls.single;
+      expect(call.request.prompt, ['none']);
+      expect(
+        call.options.web.navigationMode,
+        OidcPlatformSpecificOptions_Web_NavigationMode.hiddenIFrame,
+      );
+      expect(call.options.web.hiddenIframeTimeout, const Duration(seconds: 3));
+    });
+
+    test('the forced hidden-iframe options preserve every OTHER configured '
+        'option (web and native alike)', () async {
+      const configured = OidcPlatformSpecificOptions(
+        web: OidcPlatformSpecificOptions_Web(
+          broadcastChannel: 'custom/channel',
+          popupWidth: 123,
+          popupHeight: 456,
+          hiddenIframeTimeout: Duration(seconds: 42),
+        ),
+      );
+      final manager = await _build(
+        MockClient((req) async => http.Response('{}', 404)),
+        options: configured,
+      );
+      manager.seed(await _user(refreshToken: null));
+
+      await manager.signInSilent();
+
+      final options = manager.authorizeCalls.single.options;
+      expect(options.web.broadcastChannel, 'custom/channel');
+      expect(options.web.popupWidth, 123);
+      expect(options.web.popupHeight, 456);
+      expect(
+        options.web.hiddenIframeTimeout,
+        const Duration(seconds: 42),
+        reason: 'an omitted timeout keeps the configured one',
+      );
+      expect(options.android, same(configured.android));
+      expect(options.ios, same(configured.ios));
+      expect(options.macos, same(configured.macos));
+      expect(options.linux, same(configured.linux));
+      expect(options.windows, same(configured.windows));
+    });
+
+    test('forwards scopeOverride and extraParameters to the prompt=none '
+        'request', () async {
+      final manager = await _build(
+        MockClient((req) async => http.Response('{}', 404)),
+      );
+      manager.seed(await _user(refreshToken: null));
+
+      await manager.signInSilent(
+        scopeOverride: const ['openid', 'orders'],
+        extraParameters: const {'acme': 'yes'},
+      );
+
+      final request = manager.authorizeCalls.single.request;
+      expect(request.scope, ['openid', 'orders']);
+      expect(request.extra['acme'], 'yes');
+    });
+
+    for (final code in const [
+      'login_required',
+      'interaction_required',
+      'consent_required',
+      'account_selection_required',
+    ]) {
+      test('maps a `$code` prompt=none response to '
+          'OidcInteractionRequiredException', () async {
+        final manager = await _build(
+          MockClient((req) async => http.Response('{}', 404)),
+        );
+        manager.seed(await _user(refreshToken: null));
+        manager.authorizeError = OidcException.serverError(
+          errorResponse: OidcErrorResponse(src: const {}, error: code),
+        );
+
+        await expectLater(
+          manager.signInSilent(),
+          throwsA(
+            isA<OidcInteractionRequiredException>()
+                .having((e) => e.errorResponse?.error, 'error code', code)
+                .having(
+                  (e) => e.kind,
+                  'kind',
+                  OidcTokenRefreshFailureKind.terminal,
+                ),
+          ),
+        );
+      });
+    }
+
+    test('does NOT swallow an unrelated authorization error into an '
+        'interaction-required one', () async {
+      final manager = await _build(
+        MockClient((req) async => http.Response('{}', 404)),
+      );
+      manager.seed(await _user(refreshToken: null));
+      manager.authorizeError = OidcException.serverError(
+        errorResponse: const OidcErrorResponse(
+          src: {},
+          error: 'invalid_request',
+        ),
+      );
+
+      await expectLater(
+        manager.signInSilent(),
+        throwsA(
+          isA<OidcException>().having(
+            (e) => e is OidcInteractionRequiredException,
+            'is interaction-required',
+            isFalse,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/oidc_core/test/cache_first_revalidation_init_failure_test.dart
+++ b/packages/oidc_core/test/cache_first_revalidation_init_failure_test.dart
@@ -110,6 +110,16 @@ class _ThrowingAttachManager extends OidcUserManagerBase {
     throw _InjectedAttachFailure();
   }
 
+  /// Test-only synchronous entry points for the two timer-driven expiry
+  /// handlers (mirrors the `*Test`-suffixed wrappers already used for this
+  /// purpose elsewhere, e.g. `user_manager_internals_coverage_test.dart`) —
+  /// see the A3 test below (PR #425 review advisory A3).
+  Future<void> handleTokenExpiringForTest(OidcToken event) =>
+      handleTokenExpiring(event);
+
+  void handleTokenExpiredForTest(OidcToken event) =>
+      handleTokenExpired(event);
+
   @override
   Future<OidcAuthorizeResponse?> getAuthorizationResponse(
     OidcProviderMetadata metadata,
@@ -160,16 +170,57 @@ http.Client _client() => MockClient((req) async {
   return http.Response('unexpected request in this probe: ${req.url}', 599);
 });
 
-String _freshCachedTokenJson() => jsonEncode(
-  OidcToken(
-    creationTime: clock.now().toUtc(),
-    idToken: _signIdToken(),
-    accessToken: 'at-cached',
-    tokenType: 'Bearer',
-    expiresIn: const Duration(hours: 1),
-    refreshToken: 'rt-1',
-  ).toJson(),
+/// Same as [_client] (answers discovery), but also answers `/token` and
+/// records one entry per exchange, for the A3 test below — which asserts an
+/// exact `/token` exchange COUNT rather than just "no rethrow". `/userinfo`
+/// still must never be hit: the refreshed token replaces the existing
+/// cache-first-restored user via `currentUser.replaceToken` (id_token
+/// verified locally against the injected [_signingKey]), never a fresh
+/// `OidcUser.fromIdToken` build that would need a userinfo call.
+http.Client _clientCountingTokenExchanges(List<String> tokenExchanges) =>
+    MockClient((req) async {
+      final path = req.url.path;
+      if (path.endsWith('openid-configuration')) {
+        return http.Response(
+          jsonEncode(_metadataJson()),
+          200,
+          headers: const {'content-type': 'application/json'},
+        );
+      }
+      if (path.endsWith('/token')) {
+        tokenExchanges.add(req.body);
+        return http.Response(
+          jsonEncode({
+            'access_token': 'at-refreshed',
+            'token_type': 'Bearer',
+            'expires_in': 3600,
+            'refresh_token': 'rt-1',
+            'id_token': _signIdToken(),
+          }),
+          200,
+          headers: const {'content-type': 'application/json'},
+        );
+      }
+      return http.Response(
+        'unexpected request in this probe: ${req.url}',
+        599,
+      );
+    });
+
+/// Shared by [_freshCachedTokenJson] (seeds the store) and the A3 test below
+/// (builds the `event` handed directly to `handleTokenExpiring`/
+/// `handleTokenExpired`) — both need the same fresh, `refreshToken`-bearing
+/// token shape.
+OidcToken _freshToken() => OidcToken(
+  creationTime: clock.now().toUtc(),
+  idToken: _signIdToken(),
+  accessToken: 'at-cached',
+  tokenType: 'Bearer',
+  expiresIn: const Duration(hours: 1),
+  refreshToken: 'rt-1',
 );
+
+String _freshCachedTokenJson() => jsonEncode(_freshToken().toJson());
 
 Future<OidcMemoryStore> _seededStore() async {
   final store = OidcMemoryStore();
@@ -193,18 +244,20 @@ Future<OidcMemoryStore> _seededStore() async {
   return store;
 }
 
-_ThrowingAttachManager _lazyManager(OidcStore store) =>
-    _ThrowingAttachManager.lazy(
-      discoveryDocumentUri: _wellKnown,
-      clientCredentials: const OidcClientAuthentication.none(
-        clientId: 'client-1',
-      ),
-      store: store,
-      httpClient: _client(),
-      keyStore: JsonWebKeyStore()..addKey(_signingKey),
-      // DEFAULT settings: OidcInitMode.cacheFirst is the default init mode.
-      settings: OidcUserManagerSettings(redirectUri: Uri.parse('app://cb')),
-    );
+_ThrowingAttachManager _lazyManager(
+  OidcStore store, {
+  http.Client? httpClient,
+}) => _ThrowingAttachManager.lazy(
+  discoveryDocumentUri: _wellKnown,
+  clientCredentials: const OidcClientAuthentication.none(
+    clientId: 'client-1',
+  ),
+  store: store,
+  httpClient: httpClient ?? _client(),
+  keyStore: JsonWebKeyStore()..addKey(_signingKey),
+  // DEFAULT settings: OidcInitMode.cacheFirst is the default init mode.
+  settings: OidcUserManagerSettings(redirectUri: Uri.parse('app://cb')),
+);
 
 void main() {
   group(
@@ -261,6 +314,86 @@ void main() {
           }
           expect(secondError, isNull);
           expect(token2, 'at-cached');
+
+          await manager.dispose();
+        },
+        timeout: const Timeout(Duration(seconds: 10)),
+      );
+
+      test(
+        'on-expiry auto-refresh (handleTokenExpiring + handleTokenExpired) '
+        'is not silently disabled forever by a failed init(): exactly ONE '
+        '/token exchange once the revalidation has settled (PR #425 review '
+        'advisory A3)',
+        () async {
+          // A1 fixed a DIFFERENT, more visible symptom: getAccessToken()
+          // rethrowing the stale init() error forever. But
+          // `_cacheFirstRevalidationInFlight` gates BOTH
+          // getAccessToken()/signInSilent() (via
+          // _joinCacheFirstRevalidationIfInFlight) AND the timer-driven
+          // handleTokenExpiring/handleTokenExpired (a direct `if
+          // (_cacheFirstRevalidationInFlight) return;` each, ~:2019/~:2346) —
+          // and only the bool's OWN clearing in
+          // _scheduleBackgroundRevalidation's `finally` (~:3877) protects the
+          // second gate. A test that calls getAccessToken() cannot isolate
+          // this: pre-fix it throws (masking the bool's stuck state) and
+          // post-fix it returns the cached token without ever exercising
+          // these two handlers at all. This probe never calls
+          // getAccessToken()/signInSilent() — it drives the two handlers
+          // directly and counts real `/token` exchanges, so a stuck-`true`
+          // gate is visible as its own distinct symptom (ZERO exchanges, not
+          // a rethrown error and not a race producing two).
+          final tokenExchanges = <String>[];
+          final manager = _lazyManager(
+            await _seededStore(),
+            httpClient: _clientCountingTokenExchanges(tokenExchanges),
+          );
+
+          Object? initError;
+          try {
+            await manager.init();
+          } on Object catch (e) {
+            initError = e;
+          }
+          expect(initError, isA<_InjectedAttachFailure>());
+
+          // Let the already-scheduled `_scheduleBackgroundRevalidation`'s own
+          // `await initFuture` observe the SAME rejection and run its
+          // catch/finally. This deliberately does NOT go through
+          // getAccessToken()/_joinCacheFirstRevalidationIfInFlight (which
+          // would explicitly await the captured revalidation future and so
+          // synchronize on it for free, masking any timing gap here). There
+          // is no further network I/O on the error path (the catch/finally
+          // do only synchronous field writes and a log call), so a single
+          // `pumpEventQueue()` — draining far more than the one microtask
+          // needed — is enough to let it settle either way: post-fix it
+          // clears the gate; pre-fix (see the mutation-check in the MR
+          // description) it never does, no matter how long this waits.
+          await pumpEventQueue();
+
+          // Drive BOTH handlers off the SAME token event, back-to-back with
+          // no `await` between them — exactly the "resume fires both
+          // timers" interleaving [_autoRefresh]'s shared in-flight latch
+          // (#154) exists for, so they race the SAME gate value and (post-
+          // fix) share the SAME single exchange instead of each starting its
+          // own.
+          final tokenEvent = _freshToken();
+          final expiringDone = manager.handleTokenExpiringForTest(tokenEvent);
+          manager.handleTokenExpiredForTest(tokenEvent);
+          await expiringDone;
+          await pumpEventQueue();
+
+          expect(
+            tokenExchanges,
+            hasLength(1),
+            reason:
+                'pre-fix, _cacheFirstRevalidationInFlight never clears '
+                'after a failed init(), so both handlers hit their early '
+                '`if (_cacheFirstRevalidationInFlight) return;` and NO '
+                '/token exchange happens at all (0 — a permanently, '
+                'silently disabled auto-refresh-on-expiry — not a race '
+                'producing 2)',
+          );
 
           await manager.dispose();
         },

--- a/packages/oidc_core/test/cache_first_revalidation_init_failure_test.dart
+++ b/packages/oidc_core/test/cache_first_revalidation_init_failure_test.dart
@@ -117,8 +117,7 @@ class _ThrowingAttachManager extends OidcUserManagerBase {
   Future<void> handleTokenExpiringForTest(OidcToken event) =>
       handleTokenExpiring(event);
 
-  void handleTokenExpiredForTest(OidcToken event) =>
-      handleTokenExpired(event);
+  void handleTokenExpiredForTest(OidcToken event) => handleTokenExpired(event);
 
   @override
   Future<OidcAuthorizeResponse?> getAuthorizationResponse(

--- a/packages/oidc_core/test/cache_first_revalidation_init_failure_test.dart
+++ b/packages/oidc_core/test/cache_first_revalidation_init_failure_test.dart
@@ -1,0 +1,271 @@
+@TestOn('vm')
+library;
+
+// Regression test for the PR #425 review advisory A1: in
+// `_scheduleBackgroundRevalidation`, `await initFuture;` (~:3816) sits OUTSIDE
+// the `try` that begins right below it (~:3817). The `finally`
+// (~:3852-3865) that clears `_cacheFirstRevalidationInFlight` /
+// `_cacheFirstRevalidationFuture` — the gate `_joinCacheFirstRevalidationIfInFlight`
+// (~:296-303) awaits, and that `handleTokenExpiring`/`handleTokenExpired`
+// (~:2012/~:2339) also read — therefore never runs if `initFuture` completes
+// with an error.
+//
+// `initFuture` CAN fail: `init()`'s cache-first branch (~:3677-3681) restores
+// the cached user, arms the gate, starts `_scheduleBackgroundRevalidation`
+// (which immediately awaits `initFuture`), and only THEN calls
+// `attachLifecycleListeners()` (~:3679) — a `@protected`, overridable method
+// that constructs subclass/platform-supplied streams and can throw
+// synchronously. `AsyncMemoizer.hasRun`/`didInit` flips to `true` as soon as
+// `init()` is called (before its callback even finishes; see
+// `package:async`'s `Completer.isCompleted` semantics), so `ensureInit()`
+// never gates a caller off an already-failed init — every later
+// `getAccessToken()`/`signInSilent()` reaches
+// `_joinCacheFirstRevalidationIfInFlight`, which (pre-fix) re-awaits the SAME
+// already-settled, permanently-errored future and rethrows the STALE init
+// error forever instead of returning the still-valid cache-first-restored
+// token.
+//
+// This probe: a manager whose `attachLifecycleListeners()` throws
+// synchronously, seeded with a FRESH (non-expiring) cached token + cached
+// discovery document so `_tryCacheFirstInit()` restores locally with zero
+// network I/O. `init()` throws the injected failure (exactly what its own
+// caller already observed) — then `getAccessToken()` must NOT re-surface that
+// same error.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+const _issuer = 'https://op.example.com';
+final Uri _wellKnown = Uri.parse(
+  '$_issuer/.well-known/openid-configuration',
+);
+final JsonWebKey _signingKey = JsonWebKey.generate('RS256');
+
+String _signIdToken({
+  String subject = 'user-1',
+  Duration expiresIn = const Duration(hours: 1),
+}) {
+  final now = clock.now().millisecondsSinceEpoch ~/ 1000;
+  return (JsonWebSignatureBuilder()
+        ..jsonContent = {
+          'iss': _issuer,
+          'sub': subject,
+          'aud': 'client-1',
+          'exp': now + expiresIn.inSeconds,
+          'iat': now,
+        }
+        ..addRecipient(_signingKey, algorithm: 'RS256'))
+      .build()
+      .toCompactSerialization();
+}
+
+Map<String, dynamic> _metadataJson() => {
+  'issuer': _issuer,
+  'authorization_endpoint': '$_issuer/authorize',
+  'token_endpoint': '$_issuer/token',
+  'userinfo_endpoint': '$_issuer/userinfo',
+  // No `jwks_uri`: the signing key is injected into the manager's keyStore
+  // directly, so id_token verification never needs a network JWKS fetch.
+  'id_token_signing_alg_values_supported': ['RS256'],
+};
+
+/// Thrown from [_ThrowingAttachManager.attachLifecycleListeners] to simulate a
+/// subclass override whose stream/listener wiring fails synchronously (e.g. a
+/// platform-specific stream constructor that isn't available in the current
+/// environment).
+class _InjectedAttachFailure extends Error {
+  @override
+  String toString() =>
+      '_InjectedAttachFailure: injected attachLifecycleListeners() failure';
+}
+
+/// Same harness shape as `cache_first_revalidation_join_test.dart`'s
+/// `_Manager` (duplicated: that file's helpers are library-private), except
+/// [attachLifecycleListeners] throws synchronously instead of wiring up the
+/// (unused, in this test) lifecycle streams — reproducing the exact #425
+/// review advisory A1 window in `init()`'s cache-first branch
+/// (`user_manager_base.dart:3677-3681`): restore-then-arm-then-attach.
+class _ThrowingAttachManager extends OidcUserManagerBase {
+  _ThrowingAttachManager.lazy({
+    required super.discoveryDocumentUri,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    super.httpClient,
+    super.keyStore,
+  }) : super.lazy();
+
+  @override
+  bool get isWeb => false;
+
+  @override
+  void attachLifecycleListeners() {
+    throw _InjectedAttachFailure();
+  }
+
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+/// Answers discovery only; `/token` and `/userinfo` must never be hit by this
+/// probe — the seeded cached token is fresh, so `getAccessToken()` must
+/// short-circuit on the cache-first-restored user without any network call.
+http.Client _client() => MockClient((req) async {
+  final path = req.url.path;
+  if (path.endsWith('openid-configuration')) {
+    return http.Response(
+      jsonEncode(_metadataJson()),
+      200,
+      headers: const {'content-type': 'application/json'},
+    );
+  }
+  return http.Response('unexpected request in this probe: ${req.url}', 599);
+});
+
+String _freshCachedTokenJson() => jsonEncode(
+  OidcToken(
+    creationTime: clock.now().toUtc(),
+    idToken: _signIdToken(),
+    accessToken: 'at-cached',
+    tokenType: 'Bearer',
+    expiresIn: const Duration(hours: 1),
+    refreshToken: 'rt-1',
+  ).toJson(),
+);
+
+Future<OidcMemoryStore> _seededStore() async {
+  final store = OidcMemoryStore();
+  await store.init();
+  // A FRESH cached discovery document, so `_tryCacheFirstInit` restores
+  // locally with zero network I/O.
+  await store.setMany(
+    OidcStoreNamespace.discoveryDocument,
+    values: {
+      _wellKnown.toString(): jsonEncode(_metadataJson()),
+      '$_wellKnown::oidc_discovery_fetched_at': clock
+          .now()
+          .millisecondsSinceEpoch
+          .toString(),
+    },
+  );
+  await store.setMany(
+    OidcStoreNamespace.secureTokens,
+    values: {OidcConstants_Store.currentToken: _freshCachedTokenJson()},
+  );
+  return store;
+}
+
+_ThrowingAttachManager _lazyManager(OidcStore store) =>
+    _ThrowingAttachManager.lazy(
+      discoveryDocumentUri: _wellKnown,
+      clientCredentials: const OidcClientAuthentication.none(
+        clientId: 'client-1',
+      ),
+      store: store,
+      httpClient: _client(),
+      keyStore: JsonWebKeyStore()..addKey(_signingKey),
+      // DEFAULT settings: OidcInitMode.cacheFirst is the default init mode.
+      settings: OidcUserManagerSettings(redirectUri: Uri.parse('app://cb')),
+    );
+
+void main() {
+  group(
+    'cache-first background revalidation vs. a failed init() '
+    '(PR #425 review advisory A1)',
+    () {
+      test(
+        'getAccessToken() after a failed init() does NOT rethrow the stale '
+        'init error forever',
+        () async {
+          final manager = _lazyManager(await _seededStore());
+
+          Object? initError;
+          try {
+            await manager.init();
+          } on Object catch (e) {
+            initError = e;
+          }
+          // Sanity: the injected failure really propagated out of init() —
+          // exactly what init()'s own caller already observed directly.
+          expect(initError, isA<_InjectedAttachFailure>());
+
+          // The bug: `_scheduleBackgroundRevalidation`'s unguarded
+          // `await initFuture` (outside its own try/finally) rethrows this
+          // SAME error and never clears `_cacheFirstRevalidationFuture` /
+          // `_cacheFirstRevalidationInFlight` — so every subsequent
+          // getAccessToken()/signInSilent() re-joins the
+          // permanently-errored future and rethrows it forever, instead of
+          // returning the still-valid, cache-first-restored cached token.
+          String? token1;
+          Object? getAccessTokenError;
+          try {
+            token1 = await manager.getAccessToken();
+          } on Object catch (e) {
+            getAccessTokenError = e;
+          }
+          expect(
+            getAccessTokenError,
+            isNot(isA<_InjectedAttachFailure>()),
+            reason:
+                'getAccessToken() must not leak the stale init() failure '
+                'forever',
+          );
+          expect(token1, 'at-cached');
+
+          // The leak (when present) is PERMANENT, not a one-shot fluke —
+          // probe a second call too.
+          Object? secondError;
+          String? token2;
+          try {
+            token2 = await manager.getAccessToken();
+          } on Object catch (e) {
+            secondError = e;
+          }
+          expect(secondError, isNull);
+          expect(token2, 'at-cached');
+
+          await manager.dispose();
+        },
+        timeout: const Timeout(Duration(seconds: 10)),
+      );
+    },
+  );
+}

--- a/packages/oidc_core/test/cache_first_revalidation_join_test.dart
+++ b/packages/oidc_core/test/cache_first_revalidation_join_test.dart
@@ -1,0 +1,299 @@
+@TestOn('vm')
+library;
+
+// Regression test for the PR #425 review BLOCKER: `getAccessToken()` and
+// `signInSilent()` (#421/#423) joined the shared `_autoRefreshInFlight` latch
+// used by the expiry timers, but NOT the separate in-flight cache-first
+// (`OidcInitMode.cacheFirst`, the DEFAULT) background revalidation, which
+// refreshes through the raw, un-coalesced `_refreshToken` instead. A caller
+// invoking `getAccessToken()` / `signInSilent()` immediately after
+// `await manager.init()` returns (cacheFirst returns before the background
+// revalidation settles, by design) raced that revalidation and presented the
+// SAME still-valid refresh token in a SECOND, concurrent `/token` exchange —
+// the RFC 9700 §4.14.2 rotation-reuse hazard the pre-existing
+// `_cacheFirstRevalidationInFlight` gate exists to prevent for the
+// timer-driven paths (`handleTokenExpiring` / `handleTokenExpired`).
+//
+// This reproduces the reviewer's exact probe: seed the store with an EXPIRED
+// cached token (`refresh_token=rt-1`) plus a FRESH cached discovery document,
+// build the manager with DEFAULT settings (cacheFirst), `await init()`, then
+// perform ONE action immediately — with a MockClient that delays every
+// `/token` response by 50ms (so the background revalidation's own exchange is
+// still in flight when the action runs) and records every request body.
+//
+// | action           | before fix | after fix |
+// |------------------|------------|-----------|
+// | none (control)   | 1          | 1         |
+// | getAccessToken   | 2 (RACE)   | 1         |
+// | refreshToken     | 2          | 2 (unfixed by design, see #421 advisory) |
+// | signInSilent     | 2 (RACE)   | 1         |
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+const _issuer = 'https://op.example.com';
+final Uri _wellKnown = Uri.parse(
+  '$_issuer/.well-known/openid-configuration',
+);
+final JsonWebKey _signingKey = JsonWebKey.generate('RS256');
+
+String _signIdToken({
+  String subject = 'user-1',
+  Duration expiresIn = const Duration(hours: 1),
+}) {
+  final now = clock.now().millisecondsSinceEpoch ~/ 1000;
+  return (JsonWebSignatureBuilder()
+        ..jsonContent = {
+          'iss': _issuer,
+          'sub': subject,
+          'aud': 'client-1',
+          'exp': now + expiresIn.inSeconds,
+          'iat': now,
+        }
+        ..addRecipient(_signingKey, algorithm: 'RS256'))
+      .build()
+      .toCompactSerialization();
+}
+
+Map<String, dynamic> _metadataJson() => {
+  'issuer': _issuer,
+  'authorization_endpoint': '$_issuer/authorize',
+  'token_endpoint': '$_issuer/token',
+  'userinfo_endpoint': '$_issuer/userinfo',
+  // No `jwks_uri`: the signing key is injected into the manager's keyStore
+  // directly, so id_token verification never needs a network JWKS fetch.
+  'id_token_signing_alg_values_supported': ['RS256'],
+};
+
+/// A concrete manager built via the `.lazy` constructor, mirroring
+/// `cache_first_init_test.dart`'s harness (duplicated here since that file's
+/// helpers are library-private).
+class _Manager extends OidcUserManagerBase {
+  _Manager.lazy({
+    required super.discoveryDocumentUri,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    super.httpClient,
+    super.keyStore,
+  }) : super.lazy();
+
+  @override
+  bool get isWeb => false;
+
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+/// A MockClient that answers discovery/userinfo immediately, but for `/token`
+/// requests: records the request BODY (so a test can assert every exchange
+/// presented `refresh_token=rt-1`, proving the race — both exchanges read the
+/// same still-cached token before either had a chance to complete) and delays
+/// the response by [tokenDelay] before answering success. The 50ms delay
+/// reproduces the reviewer's probe window in which the background
+/// revalidation's own exchange is still in flight when the test's action runs.
+http.Client _client(
+  List<String> tokenBodies, {
+  Duration tokenDelay = const Duration(milliseconds: 50),
+}) => MockClient((req) async {
+  final path = req.url.path;
+  if (path.endsWith('openid-configuration')) {
+    return http.Response(
+      jsonEncode(_metadataJson()),
+      200,
+      headers: const {'content-type': 'application/json'},
+    );
+  }
+  if (path.endsWith('/userinfo')) {
+    return http.Response(
+      jsonEncode({'sub': 'user-1'}),
+      200,
+      headers: const {'content-type': 'application/json'},
+    );
+  }
+  if (path.endsWith('/token')) {
+    tokenBodies.add(req.body);
+    await Future<void>.delayed(tokenDelay);
+    return http.Response(
+      jsonEncode({
+        'access_token': 'at-refreshed',
+        'token_type': 'Bearer',
+        'expires_in': 3600,
+        // Deliberately NOT rotated: every captured body is expected to show
+        // `refresh_token=rt-1` because a RACING second exchange reads the
+        // pre-refresh cached token before either request completes.
+        'refresh_token': 'rt-1',
+        'id_token': _signIdToken(),
+      }),
+      200,
+      headers: const {'content-type': 'application/json'},
+    );
+  }
+  return http.Response('{}', 404);
+});
+
+String _expiredCachedTokenJson() => jsonEncode(
+  OidcToken(
+    creationTime: clock.now().subtract(const Duration(hours: 2)).toUtc(),
+    idToken: _signIdToken(expiresIn: const Duration(hours: -1)),
+    accessToken: 'at-expired',
+    tokenType: 'Bearer',
+    expiresIn: const Duration(hours: 1),
+    refreshToken: 'rt-1',
+  ).toJson(),
+);
+
+Future<OidcMemoryStore> _seededStore() async {
+  final store = OidcMemoryStore();
+  await store.init();
+  // A FRESH cached discovery document, so `_tryCacheFirstInit` restores
+  // locally with zero network I/O (matches `cache_first_init_test.dart`'s
+  // "expired+refreshable" seed).
+  await store.setMany(
+    OidcStoreNamespace.discoveryDocument,
+    values: {
+      _wellKnown.toString(): jsonEncode(_metadataJson()),
+      '$_wellKnown::oidc_discovery_fetched_at': clock
+          .now()
+          .millisecondsSinceEpoch
+          .toString(),
+    },
+  );
+  await store.setMany(
+    OidcStoreNamespace.secureTokens,
+    values: {OidcConstants_Store.currentToken: _expiredCachedTokenJson()},
+  );
+  return store;
+}
+
+_Manager _lazyManager({
+  required OidcStore store,
+  required http.Client client,
+}) => _Manager.lazy(
+  discoveryDocumentUri: _wellKnown,
+  clientCredentials: const OidcClientAuthentication.none(clientId: 'client-1'),
+  store: store,
+  httpClient: client,
+  keyStore: JsonWebKeyStore()..addKey(_signingKey),
+  // DEFAULT settings: OidcInitMode.cacheFirst is the default init mode, and
+  // this deliberately does NOT set supportOfflineAuth — the probe only
+  // exercises the SUCCESS interleaving (the MockClient above never fails).
+  settings: OidcUserManagerSettings(redirectUri: Uri.parse('app://cb')),
+);
+
+/// Runs ONE probe: seed the expired-cached-token store above, `await init()`
+/// (which starts the background revalidation but returns immediately — the
+/// whole point of the cacheFirst default), then run [action] IMMEDIATELY
+/// after — the exact window the reviewer's probe demonstrated the race in.
+/// Returns every captured `/token` request body once everything (the
+/// revalidation, and whatever [action] started) has settled.
+Future<List<String>> _runProbe(
+  Future<void> Function(_Manager manager)? action,
+) async {
+  final tokenBodies = <String>[];
+  final store = await _seededStore();
+  final manager = _lazyManager(store: store, client: _client(tokenBodies));
+
+  await manager.init();
+  await action?.call(manager);
+  // `pumpEventQueue()` alone only flushes zero-delay event-loop turns, which
+  // can race ahead of a REAL 50ms `Future.delayed` timer; wait out the mock's
+  // delay explicitly (with margin) before also draining any remaining
+  // microtask follow-up work.
+  await Future<void>.delayed(const Duration(milliseconds: 250));
+  await pumpEventQueue();
+
+  await manager.dispose();
+  return tokenBodies;
+}
+
+void main() {
+  group(
+    'cache-first revalidation vs. silent-acquisition race (PR #425 review)',
+    () {
+      test(
+        '[none] control: the background revalidation alone performs exactly '
+        'ONE /token exchange',
+        () async {
+          final bodies = await _runProbe(null);
+          expect(bodies, hasLength(1));
+          expect(bodies.single, contains('refresh_token=rt-1'));
+        },
+      );
+
+      test(
+        '[getAccessToken] called immediately after init() JOINS the in-flight '
+        'revalidation instead of racing it: exactly ONE /token exchange '
+        '(was TWO before the fix)',
+        () async {
+          final bodies = await _runProbe((manager) => manager.getAccessToken());
+          expect(bodies, hasLength(1));
+          expect(bodies.single, contains('refresh_token=rt-1'));
+        },
+      );
+
+      test(
+        '[signInSilent] called immediately after init() JOINS the in-flight '
+        'revalidation instead of racing it: exactly ONE /token exchange '
+        '(was TWO before the fix)',
+        () async {
+          final bodies = await _runProbe((manager) => manager.signInSilent());
+          expect(bodies, hasLength(1));
+          expect(bodies.single, contains('refresh_token=rt-1'));
+        },
+      );
+
+      test(
+        '[refreshToken] called immediately after init() is DELIBERATELY left '
+        'un-coalesced (#421 remains open for this entry point, see the PR '
+        'description): TWO /token exchanges, both presenting the SAME '
+        'pre-refresh token',
+        () async {
+          final bodies = await _runProbe((manager) => manager.refreshToken());
+          expect(bodies, hasLength(2));
+          for (final body in bodies) {
+            expect(body, contains('refresh_token=rt-1'));
+          }
+        },
+      );
+    },
+  );
+}

--- a/packages/oidc_core/test/get_access_token_offline_test.dart
+++ b/packages/oidc_core/test/get_access_token_offline_test.dart
@@ -1,0 +1,289 @@
+@TestOn('vm')
+library;
+
+// Regression test for the PR #425 review advisory: `_performAutoRefresh` (the
+// shared latch behind `getAccessToken()` / `signInSilent()`) returned
+// `failureKind: transient` even when `handleOfflineEligibleFailure` had
+// ALREADY absorbed the error and entered offline mode — so a `getAccessToken`
+// call while offline THREW a `kind: transient` `OidcException` instead of
+// handing back the cached (stale) access token, unlike the legacy
+// `_refreshToken` (used by `refreshToken()`), which returns the retained user
+// silently on the identical offline-absorbed failure. With
+// `supportOfflineAuth: true`, losing the network should retain the session,
+// not throw — that is the entire point of enabling offline auth support.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+const _issuer = 'https://op.example.com';
+final Uri _wellKnown = Uri.parse(
+  '$_issuer/.well-known/openid-configuration',
+);
+final JsonWebKey _signingKey = JsonWebKey.generate('RS256');
+
+String _signIdToken({
+  String subject = 'user-1',
+  Duration expiresIn = const Duration(hours: 1),
+}) {
+  final now = clock.now().millisecondsSinceEpoch ~/ 1000;
+  return (JsonWebSignatureBuilder()
+        ..jsonContent = {
+          'iss': _issuer,
+          'sub': subject,
+          'aud': 'client-1',
+          'exp': now + expiresIn.inSeconds,
+          'iat': now,
+        }
+        ..addRecipient(_signingKey, algorithm: 'RS256'))
+      .build()
+      .toCompactSerialization();
+}
+
+Map<String, dynamic> _metadataJson() => {
+  'issuer': _issuer,
+  'authorization_endpoint': '$_issuer/authorize',
+  'token_endpoint': '$_issuer/token',
+  'userinfo_endpoint': '$_issuer/userinfo',
+  'id_token_signing_alg_values_supported': ['RS256'],
+};
+
+/// Duplicated from `cache_first_init_test.dart` (library-private there).
+class _Manager extends OidcUserManagerBase {
+  _Manager.lazy({
+    required super.discoveryDocumentUri,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    super.httpClient,
+    super.keyStore,
+  }) : super.lazy();
+
+  @override
+  bool get isWeb => false;
+
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+/// Answers discovery/userinfo, and ALWAYS fails `/token` with a
+/// [SocketException] — an offline-eligible error per
+/// `OidcOfflineAuthErrorHandler.categorizeError`.
+http.Client _alwaysOfflineClient() => MockClient((req) async {
+  final path = req.url.path;
+  if (path.endsWith('openid-configuration')) {
+    return http.Response(
+      jsonEncode(_metadataJson()),
+      200,
+      headers: const {'content-type': 'application/json'},
+    );
+  }
+  if (path.endsWith('/token')) {
+    throw const SocketException('offline');
+  }
+  return http.Response('{}', 404);
+});
+
+String _expiredCachedTokenJson() => jsonEncode(
+  OidcToken(
+    creationTime: clock.now().subtract(const Duration(hours: 2)).toUtc(),
+    idToken: _signIdToken(expiresIn: const Duration(hours: -1)),
+    accessToken: 'at-cached-stale',
+    tokenType: 'Bearer',
+    expiresIn: const Duration(hours: 1),
+    refreshToken: 'rt-1',
+  ).toJson(),
+);
+
+Future<_Manager> _offlineEligibleManager() async {
+  final store = OidcMemoryStore();
+  await store.init();
+  await store.setMany(
+    OidcStoreNamespace.discoveryDocument,
+    values: {
+      _wellKnown.toString(): jsonEncode(_metadataJson()),
+      '$_wellKnown::oidc_discovery_fetched_at': clock
+          .now()
+          .millisecondsSinceEpoch
+          .toString(),
+    },
+  );
+  await store.setMany(
+    OidcStoreNamespace.secureTokens,
+    values: {OidcConstants_Store.currentToken: _expiredCachedTokenJson()},
+  );
+
+  final manager = _Manager.lazy(
+    discoveryDocumentUri: _wellKnown,
+    clientCredentials: const OidcClientAuthentication.none(
+      clientId: 'client-1',
+    ),
+    store: store,
+    httpClient: _alwaysOfflineClient(),
+    keyStore: JsonWebKeyStore()..addKey(_signingKey),
+    settings: OidcUserManagerSettings(
+      redirectUri: Uri.parse('app://cb'),
+      // blockingValidate: this test is isolated to the offline
+      // classification advisory, not the cache-first join fix covered by
+      // cache_first_revalidation_join_test.dart.
+      initMode: OidcInitMode.blockingValidate,
+      supportOfflineAuth: true,
+      userInfoSettings: const OidcUserInfoSettings(
+        sendUserInfoRequest: false,
+      ),
+    ),
+  );
+  // init()'s own loadCachedTokens() also hits the (always-failing) refresh;
+  // with supportOfflineAuth it absorbs the failure via the raw _refreshToken
+  // path and retains the cached user — unaffected by this fix, already
+  // covered by cache_first_init_test.dart's "offline" TTL test.
+  await manager.init();
+  expect(manager.currentUser, isNotNull);
+  return manager;
+}
+
+void main() {
+  group(
+    'getAccessToken/signInSilent offline-mode classification '
+    '(PR #425 review advisory)',
+    () {
+      test(
+        'getAccessToken() returns the cached access token (no throw) when a '
+        'refresh fails offline-eligibly and supportOfflineAuth is enabled',
+        () async {
+          final manager = await _offlineEligibleManager();
+
+          // Before the fix, _performAutoRefresh always returned
+          // failureKind: transient on ANY failure, so this threw a kind-stamped
+          // OidcException even though handleOfflineEligibleFailure had already
+          // absorbed the identical error and entered offline mode.
+          final accessToken = await manager.getAccessToken();
+
+          expect(accessToken, 'at-cached-stale');
+          expect(manager.isInOfflineMode, isTrue);
+          await manager.dispose();
+        },
+      );
+
+      test(
+        'signInSilent() returns the retained user (no throw) when a refresh '
+        'fails offline-eligibly and supportOfflineAuth is enabled',
+        () async {
+          final manager = await _offlineEligibleManager();
+
+          final user = await manager.signInSilent();
+
+          expect(user, isNotNull);
+          expect(user!.token.accessToken, 'at-cached-stale');
+          expect(manager.isInOfflineMode, isTrue);
+          await manager.dispose();
+        },
+      );
+
+      test(
+        'getAccessToken() STILL throws a kind:transient OidcException when '
+        'the SAME failure occurs with supportOfflineAuth DISABLED (default) '
+        '— the fix only changes the offline-absorbed case',
+        () async {
+          final store = OidcMemoryStore();
+          await store.init();
+          await store.setMany(
+            OidcStoreNamespace.discoveryDocument,
+            values: {
+              _wellKnown.toString(): jsonEncode(_metadataJson()),
+              '$_wellKnown::oidc_discovery_fetched_at': clock
+                  .now()
+                  .millisecondsSinceEpoch
+                  .toString(),
+            },
+          );
+          await store.setMany(
+            OidcStoreNamespace.secureTokens,
+            values: {
+              OidcConstants_Store.currentToken: _expiredCachedTokenJson(),
+            },
+          );
+          final manager = _Manager.lazy(
+            discoveryDocumentUri: _wellKnown,
+            clientCredentials: const OidcClientAuthentication.none(
+              clientId: 'client-1',
+            ),
+            store: store,
+            httpClient: _alwaysOfflineClient(),
+            keyStore: JsonWebKeyStore()..addKey(_signingKey),
+            settings: OidcUserManagerSettings(
+              redirectUri: Uri.parse('app://cb'),
+              initMode: OidcInitMode.blockingValidate,
+              // supportOfflineAuth defaults to false: init()'s OWN refresh
+              // (loadCachedTokens, on the raw, unaffected-by-this-fix
+              // _refreshToken path) would otherwise also fail and forget the
+              // user before this test can even reach getAccessToken().
+              // isLoadedTokenAcceptable short-circuits that so the session
+              // survives init() unrefreshed, isolating getAccessToken()'s OWN
+              // (fixed) refresh attempt as the only failure in play.
+              isLoadedTokenAcceptable: (user, errors) => true,
+              userInfoSettings: const OidcUserInfoSettings(
+                sendUserInfoRequest: false,
+              ),
+            ),
+          );
+          await manager.init();
+          expect(manager.currentUser, isNotNull);
+          expect(manager.isInOfflineMode, isFalse);
+
+          await expectLater(
+            manager.getAccessToken(),
+            throwsA(
+              isA<OidcException>().having(
+                (e) => e.kind,
+                'kind',
+                OidcTokenRefreshFailureKind.transient,
+              ),
+            ),
+          );
+          // Not absorbed (offline auth disabled): offline mode is NOT entered.
+          expect(manager.isInOfflineMode, isFalse);
+          await manager.dispose();
+        },
+      );
+    },
+  );
+}

--- a/packages/oidc_core/test/login_dpop_flow_test.dart
+++ b/packages/oidc_core/test/login_dpop_flow_test.dart
@@ -33,9 +33,13 @@ class _CodeFlowManager extends OidcUserManagerBase {
   /// The metadata that accompanied [capturedAuthRequest].
   OidcProviderMetadata? capturedAuthMetadata;
 
-  /// Exposes the session DPoP key thumbprint (the `dpop_jkt` / `cnf.jkt`
-  /// source) for assertions; `dpopManager` is `@protected`, so surface it here.
-  String? get dpopThumbprint => dpopManager?.thumbprint;
+  // PR #425 review (source-breaking-for-subclassers advisory): this class
+  // used to declare its own `dpopThumbprint` getter here to surface the
+  // `@protected` `dpopManager`'s thumbprint for test assertions. #422 added a
+  // PUBLIC `dpopThumbprint` getter to `OidcUserManagerBase` itself with the
+  // identical implementation, which turned this declaration into a silent,
+  // un-annotated override (`annotate_overrides` lint) — removed in favor of
+  // the inherited one; see [OidcUserManagerBase.dpopThumbprint].
 
   @override
   Future<OidcAuthorizeResponse?> getAuthorizationResponse(


### PR DESCRIPTION
## Description

Implements the four "manager ↔ application boundary" findings as one PR — they all land on `packages/oidc_core/lib/src/managers/user_manager_base.dart`, so shipping them separately would just be a merge conflict.

Closes #422
Closes #423
Closes #424

**#421 is only partially addressed, and stays open.** The concurrency fix lands on the new `getAccessToken()` / `signInSilent()` entry points, but `refreshToken()` is deliberately left un-coalesced (see Design notes #1), so the N-parallel-401-retry stampede described in #421 remains on that entry point.

Everything here is **additive**: no signature changed, no behaviour of an existing public method changed, no version or CHANGELOG touched (that is `melos version`'s job).

---

### #424 — typed failure classification (foundational, everything else builds on it)

`OidcException` was the only exception class in the package and carried no classification, so the caller who has to decide *"re-login now vs. retry later"* had to re-derive it by string-comparing `errorResponse?.error == 'invalid_grant'` — logic the library already owns (it computes `OidcTokenRefreshFailureKind` for `OidcTokenRefreshFailedEvent` and then `rethrow`s the unclassified original).

* **`OidcException.kind`** — a new nullable `OidcTokenRefreshFailureKind?`. Null on every path that raised an `OidcException` before this PR, so nothing is retroactively "classified".
* **`OidcInteractionRequiredException extends OidcException`** — the `MsalUiRequiredException` equivalent. `kind` is always `terminal`. Since it is a *subclass*, **every existing `on OidcException` catch keeps matching it** (there is a test asserting exactly that).
* **`OidcException.raw`** — the generative constructor a subclass needs. The two existing constructors each hard-null one half of the state (the default one forces `errorResponse = null`, `.serverError` forces `internalException`/`internalStackTrace = null`), so neither can carry an OAuth error response *and* the original exception. `.raw` can, which is what wrap-and-rethrow requires to avoid losing diagnostics.
* **`OidcInteractionRequiredException.from(error, message:)`** — preserves `errorResponse`, `extra`, `rawRequest`/`rawResponse` and keeps the original exception as `internalException`.

Consumers can now write:

```dart
try {
  final accessToken = await manager.getAccessToken();
} on OidcInteractionRequiredException {
  await manager.loginAuthorizationCodeFlow();
}
```

### #421 — `getAccessToken({minValidity, forceRefresh})`

```dart
Future<String?> getAccessToken({
  Duration minValidity = const Duration(seconds: 30),
  bool forceRefresh = false,
});
```

Returns a token guaranteed valid for at least `minValidity`, refreshing only when it would not be.

**The concurrency fix is the substantive part.** The in-flight coalescing latch (`_autoRefreshInFlight`) was shared only by `handleTokenExpiring` / `handleTokenExpired`; `refreshToken()` bypassed it. `getAccessToken` and `signInSilent` now join that latch, so N parallel API calls that all discover a stale token perform **one** token exchange. They also join an in-flight `OidcInitMode.cacheFirst` background revalidation rather than racing it — `cacheFirst` is the default and `init()` returns before that background pass settles, so a call made immediately after `await manager.init()` would otherwise start a second, concurrent exchange.

That matters against an OP that rotates refresh tokens — [RFC 9700 §2.2.2](https://www.rfc-editor.org/rfc/rfc9700.html#section-2.2.2) requires rotation *or* sender-constraining for public clients — because rotation invalidates the previous refresh token on every exchange, so a second concurrent exchange presents an invalidated token and the AS *"will revoke the active refresh token"* ([§4.14.2](https://www.rfc-editor.org/rfc/rfc9700.html#section-4.14.2)).

Contract:

| Situation | Result |
| --- | --- |
| No signed-in user | returns `null` (a state, not an error) |
| Token valid for `minValidity` | returns it, **no network call** |
| Token stale, refresh succeeds | returns the NEW access token |
| Token has no `expires_in` | returned as-is (unknown != expired), mirroring `listenToTokenRefreshIfSupported`, which likewise declines to arm timers for such a token |
| Token stale, no refresh token / `invalid_grant` | throws `OidcInteractionRequiredException` |
| Refresh failed recoverably (network / 5xx), offline mode NOT absorbing it | throws `OidcException` with `kind == transient` |
| Refresh failed recoverably AND offline mode absorbs it (`supportOfflineAuth: true`) | returns the cached (stale) access token, no throw |

**`refreshToken()` is deliberately unchanged** — see Design notes below.

### #422 — public DPoP proof facade

The DPoP internals already existed (`OidcDPoPManager.createResourceProof`, the per-endpoint nonce cache) but the only handle to them, `dpopManager`, is `@protected`. So enabling `settings.dpop` sender-constrained the token and then forced the app to send it as a plain `Bearer`, discarding the guarantee it enabled DPoP for.

Rather than un-protect the manager, this adds a thin facade and leaves `OidcDPoPManager` encapsulated:

```dart
Future<String?> createDPoPProof({required Uri uri, String method = 'GET', String? accessToken});
void cacheDPoPNonce(Uri uri, String nonce);
String? get dpopThumbprint;
```

All three degrade to `null`/no-op when DPoP is disabled, so one call site works for both configurations.

### #423 — `signInSilent()`

```dart
Future<OidcUser?> signInSilent({
  Duration? timeout,
  List<String>? scopeOverride,
  Map<String, dynamic>? extraParameters,
});
```

Refresh-token grant first when one is available (through the same latch as `getAccessToken`), otherwise a hidden-iframe `prompt=none` request. The forced iframe options **preserve every other configured platform option** (broadcast channel, popup size, and all native sections) rather than resetting them, which the existing `reAuthorizeUser()` does not.

`login_required` / `interaction_required` / `consent_required` / `account_selection_required` (OIDC Core §3.1.2.6) map to `OidcInteractionRequiredException`; any other authorization error propagates untouched.

The platform matrix is documented honestly on the method and in the guide: the `prompt=none` half is web-only, and even on web it depends on a third-party-context cookie that Safari's ITP blocks.

`reAuthorizeUser()` is kept, still `@protected`, now `@Deprecated('use signInSilent')`. Its behaviour is byte-identical (the session-monitor reaction wants forget-on-error, not a throw).

---

## Design notes / deliberate deviations from the issue proposals

1. **#421 proposed routing `refreshToken()` through the shared latch too. This PR does not.** `refreshToken()` accepts `overrideRefreshToken` and `discoveryDocumentOverride`, so coalescing it with an in-flight refresh of a *different* token would return the wrong result; and the latch's outcome is non-throwing, so joining it would silently stop `refreshToken()` from throwing — a breaking change for existing callers. The same reasoning leaves it un-coalesced against the cache-first background revalidation. The stampede fix is delivered on the new entry points, and a test pins the old behaviour (`getAccessToken` skips a fresh token; `refreshToken()` still exchanges).
2. **#423 proposed `signInSilent` return `null` when interaction is required; #424 proposed it throw.** Resolved in favour of #424 (throw), because `getAccessToken`'s one-line contract depends on it and a silent `null` is exactly the un-typed signal these issues exist to remove. `null` is still returned for the non-error cases: no renewal happened out-of-band, or the manager was disposed mid-flight.
3. **`signInSilent` does not fall back to `prompt=none` after a *failed* refresh.** The issue specified "refresh_token first when one is available, **otherwise** `prompt=none`", so a dead refresh token throws `OidcInteractionRequiredException` rather than silently attempting a second mechanism.
4. **No new `OidcTokenRefreshSource` enum value.** A caller-initiated refresh from `getAccessToken`/`signInSilent` is reported as the existing `manual`. Adding an enum value would break consumers' exhaustive `switch`es — not acceptable for an "additive" PR.
5. `_performAutoRefresh` now takes the refresh `source` and returns the original `error`/`stackTrace` alongside the classification, so a caller that must *throw* can preserve diagnostics the automatic paths deliberately swallow. `source` labels the caller that **starts** the exchange; a caller that joins an in-flight one inherits its label, because there is only one exchange (and one failure event) to label.
6. **Adding public members to the extendable abstract `OidcUserManagerBase` can collide with a downstream subclass** that already declares a same-named member. This is an inherent cost of the API surface and argues for a MINOR (not patch) release under semver.

## Docs

`docs/oidc-usage-accesstoken.md` previously showed the freshness-unaware `currentUser?.token.accessToken` read in both the dio and http examples, and had no DPoP path at all. It now leads with `getAccessToken()`, documents `signInSilent()` with its platform caveats, and adds the DPoP request + `use_dpop_nonce` retry recipe.

## Testing

* `packages/oidc_core/test/app_boundary_api_test.dart` — 33 tests covering every new symbol, including the concurrency coalescing, the terminal/transient split, the `manual` refresh-source label, the option-preservation of the forced hidden iframe, and the backward-compatibility assertions (`on OidcException` still catches; pre-existing constructors still produce `kind == null`). Three concurrent callers are driven against a gated token endpoint asserting exactly one exchange.
* `packages/oidc_core/test/cache_first_revalidation_join_test.dart` — 4 tests pinning that `getAccessToken` and `signInSilent` join an in-flight cache-first revalidation (one exchange), that the no-call control stays at one, and that `refreshToken()` still exchanges independently by design.
* `packages/oidc_core/test/get_access_token_offline_test.dart` — 3 tests for the offline-mode classification: with `supportOfflineAuth: true` a recoverable failure returns the retained session instead of throwing, and the disabled-offline control still throws `kind == transient`.
* `packages/oidc_core/test/cache_first_revalidation_init_failure_test.dart` — 2 tests pinning that a failed `init()` cannot permanently poison the cache-first join: the revalidation gate is always cleared, so later `getAccessToken()` calls do not rethrow the stale init error and on-expiry auto-refresh stays armed.

Local runs (Flutter 3.44.0 / Dart 3.12.0, Windows):

* `packages/oidc_core`: full suite green (see the CI run on this PR for the current count)
* VM packages (`crypto_keys_plus`, `jose_plus`, `oidc_cli`, `oidc_loopback_listener`, `x509_plus`) — all passed
* Flutter packages (`oidc`, `oidc_platform_interface`, `oidc_default_store`, `oidc_desktop`, `oidc_linux`, `oidc_windows`) — all passed
* `melos run analyze`: SUCCESS · `melos run format`: SUCCESS

The browser (Chrome/Firefox) suites were **not** run locally and are left to CI. `melos run test:vm` could not be used directly on Windows (its POSIX `if [ ... ]` script body is not valid in cmd), so each VM package's `dart test` was run individually instead — the same command the melos script executes.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added freshness-aware access-token retrieval with automatic refresh and concurrent-request coordination.
  * Added silent sign-in support, including web-based `prompt=none` fallback.
  * Added DPoP proof creation, nonce handling, and thumbprint access.
  * Added typed refresh-failure classification and interaction-required errors.
  * Offline authentication can retain cached tokens during eligible transient failures.

* **Documentation**
  * Updated token usage examples to use asynchronous access-token retrieval.
  * Added DPoP-protected resource guidance and updated Dio and HTTP examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



