### PR TITLE
docs(oidc_android): state the minSdk 23 requirement, and stop instructing 21

### DIFF
--- a/docs/oidc-getting-started.md
+++ b/docs/oidc-getting-started.md
@@ -20,7 +20,8 @@ every platform you support has its own configuration and set up.
 Native browser handling is **first-party on every platform** (no third-party
 auth SDK):
 
-- **Android** — **Chrome Custom Tabs**.
+- **Android** — **Auth Tab**, falling back to **Chrome Custom Tabs** (requires
+  **minSdk 23+**).
 - **iOS** — **ASWebAuthenticationSession** (requires **iOS 13+**).
 - **macOS** — **ASWebAuthenticationSession** (requires **macOS 10.15+**).
 
@@ -47,7 +48,8 @@ go to `android/app/build.gradle`, and add the following under `defaultConfig`:
 ```diff
 defaultConfig {
     applicationId "com.my.app"
-    minSdkVersion flutter.minSdkVersion
+-   minSdkVersion flutter.minSdkVersion
++   minSdkVersion 23
     targetSdkVersion flutter.targetSdkVersion
     versionCode flutterVersionCode.toInteger()
     versionName flutterVersionName
@@ -56,6 +58,12 @@ defaultConfig {
 +   ]
 }
 ```
+
+`minSdkVersion` must be **23 or higher**. `oidc_android` depends on
+`androidx.browser:browser:1.10.0`, which declares `minSdk 23`; a lower value in
+your app fails the manifest merge at build time. If you are upgrading from
+`oidc_android` 1.0.1 or earlier, this is the one change that can break your
+build — its floor was 21.
 replace `com.my.app` with the scheme of your `redirect_uri` (a reverse-DNS
 scheme you own, per [RFC 8252 §7.1](https://datatracker.ietf.org/doc/html/rfc8252#section-7.1));
 your `redirect_uri` then looks like `com.my.app://oauth2redirect`.
@@ -83,13 +91,14 @@ your `redirect_uri` then looks like `com.my.app://oauth2redirect`.
 
 [Source](https://pub.dev/packages/flutter_secure_storage#configure-android-version)
 
-1. In `android/app/build.gradle` set `minSdkVersion` to >= 18.
+1. `flutter_secure_storage` needs `minSdkVersion` >= 18, which the 23 required
+   above already satisfies — no further change if you set it.
     ```diff
     defaultConfig {   
         
         applicationId "com.my_app"
     -   minSdkVersion flutter.minSdkVersion
-    +   minSdkVersion 21
+    +   minSdkVersion 23
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/oidc_android/README.md
+++ b/packages/oidc_android/README.md
@@ -11,6 +11,15 @@ The Android implementation of `package:oidc`.
 This package is [endorsed][endorsed_link], which means you can simply use `package:oidc`
 normally. This package will be automatically included in your app when you do.
 
+## Requirements
+
+`minSdkVersion` **23 or higher**, set in `android/app/build.gradle`. This plugin
+depends on `androidx.browser:browser:1.10.0`, which declares `minSdk 23`; a
+lower value in your app fails the manifest merge at build time.
+
+> Upgrading from 1.0.1 or earlier? Its floor was 21, so raising this is the one
+> change that can break your build.
+
 ## Redirect handling (native setup)
 
 This implementation opens the system browser via **Auth Tab** (falling back to


### PR DESCRIPTION
Follow-up to #419 / #418. Docs-only, no code.

## The problem

`docs/oidc-getting-started.md` instructed:

```diff
-   minSdkVersion flutter.minSdkVersion
+   minSdkVersion 21
```

Since `oidc_android` 2.0.0 that **fails the build**. The plugin depends on `androidx.browser:browser:1.10.0`, which declares `minSdk 23`:

```
$ unzip -p browser-1.10.0.aar AndroidManifest.xml
<uses-sdk android:minSdkVersion="23" />
```

so a lower value in the consuming app fails the manifest merge. Neither the guide nor `packages/oidc_android/README.md` stated the requirement anywhere — so someone hitting that failure had nothing to explain it, and the only copy-pasteable snippet in the guide was the one that caused it.

`oidc_android` 1.0.1 declared `minSdkVersion 21`, so this bites specifically on upgrade.

## Changes

- **`docs/oidc-getting-started.md`** — the Android snippet now sets `minSdkVersion 23` and explains why, flagged as the one change that can break a build when upgrading from 1.0.1.
- **`packages/oidc_android/README.md`** — new **Requirements** section stating the floor. pub.dev renders this README, so it is where someone hitting the merge failure is most likely to look.
- The `flutter_secure_storage` step asked for its own floor (`>= 18`, shown as 21). It now notes the 23 above already satisfies it, rather than offering a second conflicting number.
- The platform summary described Android as "Chrome Custom Tabs", which the next section of the same file contradicts — capture has been dual-path since 2.0.0 (Auth Tab, falling back to Custom Tabs).

## Verified

- `androidx.browser:browser:1.10.0` minSdk, from the published AAR's own manifest (above).
- `oidc_android-v1.0.1` build.gradle: `minSdkVersion 21`; `oidc_android-v2.0.0`: `minSdkVersion 23`.
- iOS 13.0 / macOS 10.15 in the same doc check out against `oidc_darwin.podspec` — left alone.
- No sub-23 `minSdk` instruction remains in any markdown file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android setup guidance to require `minSdkVersion` 23 or higher.
  * Clarified redirect handling through Auth Tab, with Chrome Custom Tabs fallback.
  * Added upgrade guidance for users moving from earlier plugin versions.
  * Explained related dependency requirements and potential build issues with lower Android SDK versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->