### PR TITLE
fix(oidc_android)!: dismiss the Custom Tab, apply dropped options, and bound abandoned flows

### DIFF
--- a/packages/oidc/example/integration_test/app_test.dart
+++ b/packages/oidc/example/integration_test/app_test.dart
@@ -32,10 +32,16 @@ void main() {
 
       // See the Patrol harness for why Config RP is a separate case.
       testWidgets('OIDC Conformance: Config RP', (tester) async {
-        await runOidcConformanceTest(() async {
-          example.main();
-          await tester.pumpAndSettle();
-        }, planName: 'oidcc-client-config-certification-test-plan');
+        await runOidcConformanceTest(
+          () async {
+            example.main();
+            await tester.pumpAndSettle();
+          },
+          planName: 'oidcc-client-config-certification-test-plan',
+          // The discovery module rejects the plan outright without this; the
+          // Basic plan defaults it, this one does not.
+          clientAuthType: 'client_secret_basic',
+        );
       });
     }
   });

--- a/packages/oidc/example/integration_test/app_test.dart
+++ b/packages/oidc/example/integration_test/app_test.dart
@@ -23,11 +23,22 @@ void main() {
         });
       });
     } else {
-      testWidgets('OIDC Conformance Test', (tester) async {
+      testWidgets('OIDC Conformance: Basic RP', (tester) async {
         await runOidcConformanceTest(() async {
           example.main();
           await tester.pumpAndSettle();
         });
+      });
+
+      // See the Patrol harness for why Config RP is a separate case.
+      testWidgets('OIDC Conformance: Config RP', (tester) async {
+        await runOidcConformanceTest(
+          () async {
+            example.main();
+            await tester.pumpAndSettle();
+          },
+          planName: 'oidcc-client-config-certification-test-plan',
+        );
       });
     }
   });

--- a/packages/oidc/example/integration_test/app_test.dart
+++ b/packages/oidc/example/integration_test/app_test.dart
@@ -32,13 +32,10 @@ void main() {
 
       // See the Patrol harness for why Config RP is a separate case.
       testWidgets('OIDC Conformance: Config RP', (tester) async {
-        await runOidcConformanceTest(
-          () async {
-            example.main();
-            await tester.pumpAndSettle();
-          },
-          planName: 'oidcc-client-config-certification-test-plan',
-        );
+        await runOidcConformanceTest(() async {
+          example.main();
+          await tester.pumpAndSettle();
+        }, planName: 'oidcc-client-config-certification-test-plan');
       });
     }
   });

--- a/packages/oidc/example/integration_test/conformance/api.dart
+++ b/packages/oidc/example/integration_test/conformance/api.dart
@@ -7,6 +7,23 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 
+/// Variant dimensions a plan's modules require to be stated outright.
+///
+/// The suite defaults some dimensions and demands others, and which is which
+/// cannot be read off the plan name. Getting it wrong is not a test failure:
+/// it is an HTTP 400 at plan creation, from a live third-party server, so the
+/// mistake costs a full CI round trip to discover. `client_auth_type` is
+/// recorded here because the config plan's discovery module refuses the whole
+/// plan without it, while the basic plan resolves it to `client_secret_basic`
+/// on its own -- which is exactly why the omission went unnoticed on the only
+/// plan that had ever been run.
+///
+/// Add a plan here when the suite rejects it for a missing dimension. The
+/// entry turns that network round trip into an immediate local error.
+const _requiredExtraVariants = <String, List<String>>{
+  'oidcc-client-config-certification-test-plan': ['client_auth_type'],
+};
+
 (String path, Map<String, dynamic> body) prepareTestPlanRequest({
   // oidcc-client-basic-certification-test-plan
   required String planName,
@@ -28,6 +45,17 @@ import 'package:dio/dio.dart';
     'client_registration': clientRegistration,
     ...?extraVariant,
   };
+  final missing = (_requiredExtraVariants[planName] ?? const <String>[])
+      .where((dimension) => !variant.containsKey(dimension))
+      .toList();
+  if (missing.isNotEmpty) {
+    throw ArgumentError(
+      'The "$planName" plan requires the variant dimension(s) '
+      '${missing.join(', ')}. The conformance suite enforces this at plan '
+      'creation and answers HTTP 400, so pass them via extraVariant rather '
+      'than discovering it from CI.',
+    );
+  }
   final uri = Uri(
     path: '/api/plan',
     queryParameters: {'planName': planName, 'variant': jsonEncode(variant)},

--- a/packages/oidc/example/integration_test/conformance/manager.dart
+++ b/packages/oidc/example/integration_test/conformance/manager.dart
@@ -54,6 +54,10 @@ OidcUserManager conformanceManager(
       // the same bound.
       linux: OidcPlatformSpecificOptions_Native(flowTimeoutSeconds: 30),
       windows: OidcPlatformSpecificOptions_Native(flowTimeoutSeconds: 30),
+      // Web hung the same way and had no knob at all until now:
+      // hiddenIframeTimeout bounds the silent-renew iframe, not the popup the
+      // interactive flow actually uses.
+      web: OidcPlatformSpecificOptions_Web(flowTimeoutSeconds: 30),
     ),
     scope: const [
       OidcConstants_Scopes.openid,

--- a/packages/oidc/example/integration_test/conformance/manager.dart
+++ b/packages/oidc/example/integration_test/conformance/manager.dart
@@ -30,6 +30,10 @@ OidcUserManager conformanceManager(
       // conformance suite still runs. Real conformance is exercised on
       // desktop (loopback) + macOS (real-OS browser completes).
       //
+      // Every platform the suite runs on needs one. Leaving it off is not a
+      // test that fails: it is a job that hangs until the runner kills it,
+      // reporting no assertion and no stack.
+      //
       // iOS NOTE: the iOS-18 simulator (Xcode 16) auto-completed the redirect in
       // ~4.5 min, but the iOS-26 simulator (Xcode 26) hangs — hence iOS now also
       // needs the timeout. `prefersEphemeralWebBrowserSession` avoids popups.
@@ -42,6 +46,14 @@ OidcUserManager conformanceManager(
         flowTimeoutSeconds: 30,
       ),
       android: OidcNativeOptionsAndroid(flowTimeoutSeconds: 30),
+      // Desktop was assumed to complete on its own because the loopback
+      // listener needs no user. That holds only while every module's redirect
+      // actually arrives. It does not for the Config RP plan: the run stopped
+      // dead at oidcc-client-test-discovery-issuer-mismatch and GitHub Actions
+      // killed the job ten minutes later. Same listener on both, so both get
+      // the same bound.
+      linux: OidcPlatformSpecificOptions_Native(flowTimeoutSeconds: 30),
+      windows: OidcPlatformSpecificOptions_Native(flowTimeoutSeconds: 30),
     ),
     scope: const [
       OidcConstants_Scopes.openid,

--- a/packages/oidc/example/integration_test/shared_e2e.dart
+++ b/packages/oidc/example/integration_test/shared_e2e.dart
@@ -97,8 +97,22 @@ Future<void> runManagerSmokeTest(LaunchApp launchApp) async {
 }
 
 /// Full OIDC conformance flow against certification.openid.net.
-Future<void> runOidcConformanceTest(LaunchApp launchApp) async {
-  _testLogger.info('Running full OIDC conformance flow.');
+/// Runs one OpenID Connect RP certification plan end to end.
+///
+/// [planName] is a conformance-suite plan id. Each plan is driven as its own
+/// test case rather than looped here, so a failure names the profile that broke
+/// and one profile's outage cannot mask another's.
+///
+/// Verified plan ids (openid.net + panva/openid-client-certification-suite):
+///   oidcc-client-basic-certification-test-plan    - the certified profile
+///   oidcc-client-config-certification-test-plan   - OP config from .well-known
+///   oidcc-client-implicit-certification-test-plan - not implemented here
+///   oidcc-client-hybrid-certification-test-plan   - README: "no hybrid flow yet"
+Future<void> runOidcConformanceTest(
+  LaunchApp launchApp, {
+  String planName = 'oidcc-client-basic-certification-test-plan',
+}) async {
+  _testLogger.info('Running OIDC conformance plan: $planName');
   await launchApp();
   _testLogger.info('Example app launched and settled.');
 
@@ -141,8 +155,8 @@ Future<void> runOidcConformanceTest(LaunchApp launchApp) async {
   final (path, body) = prepareTestPlanRequest(
     clientId: clientId,
     clientSecret: clientSecret,
-    planName: 'oidcc-client-basic-certification-test-plan',
-    description: 'package:oidc Conformance testing on $platform',
+    planName: planName,
+    description: 'package:oidc $planName on $platform',
     redirectUri: redirectUri.toString(),
     requestType: 'plain_http_request',
     clientRegistration: 'static_client',
@@ -303,7 +317,7 @@ Future<void> runOidcConformanceTest(LaunchApp launchApp) async {
     successfulLogins,
     greaterThan(0),
     reason:
-        'no conformance module completed a login on ${getPlatformName()}, so '
+        'no module of $planName completed a login on ${getPlatformName()}, so '
         'the browser redirect is not reaching the app. On Android, check that '
         "the OidcRedirectActivity intent-filter is registered for the app's "
         'redirect scheme.',

--- a/packages/oidc/example/integration_test/shared_e2e.dart
+++ b/packages/oidc/example/integration_test/shared_e2e.dart
@@ -109,21 +109,27 @@ Future<void> runManagerSmokeTest(LaunchApp launchApp) async {
 ///   oidcc-client-basic-certification-test-plan    - runs green, the certified
 ///                                                   profile
 ///   oidcc-client-config-certification-test-plan   - OP config from
-///                                                   .well-known; the plan
-///                                                   REJECTS the static_client
-///                                                   variant with HTTP 400
+///                                                   .well-known; needs an
+///                                                   explicit clientAuthType
 ///   oidcc-client-implicit-certification-test-plan - not implemented here
 ///   oidcc-client-hybrid-certification-test-plan   - README: "no hybrid flow yet"
 ///
-/// [clientRegistration] and [requestType] are the plan's variant dimensions.
-/// They are NOT uniform across plans: a value one plan requires another
-/// rejects outright at creation time, so they are per-plan rather than
-/// constants shared by every case.
+/// [clientRegistration], [requestType] and [clientAuthType] are the plan's
+/// variant dimensions, and which ones a plan REQUIRES is not uniform. The
+/// basic plan resolves `client_auth_type` to `client_secret_basic` on its own,
+/// so omitting it works there. The config plan does not:
+///
+///   TestModule 'oidcc-client-test-discovery-openid-config' requires a value
+///   for variant 'client_auth_type'
+///
+/// which is an HTTP 400 at plan creation, before any module runs. Pass
+/// [clientAuthType] for any plan whose modules need it stated outright.
 Future<void> runOidcConformanceTest(
   LaunchApp launchApp, {
   String planName = 'oidcc-client-basic-certification-test-plan',
   String clientRegistration = 'static_client',
   String requestType = 'plain_http_request',
+  String? clientAuthType,
 }) async {
   _testLogger.info('Running OIDC conformance plan: $planName');
   await launchApp();
@@ -173,6 +179,9 @@ Future<void> runOidcConformanceTest(
     redirectUri: redirectUri.toString(),
     requestType: requestType,
     clientRegistration: clientRegistration,
+    extraVariant: {
+      if (clientAuthType != null) 'client_auth_type': clientAuthType,
+    },
     postLogoutRedirectUri: redirectUri.toString(),
     frontChannelLogoutUri:
         'http://localhost:22433/redirect.html?requestType=front-channel-logout',

--- a/packages/oidc/example/integration_test/shared_e2e.dart
+++ b/packages/oidc/example/integration_test/shared_e2e.dart
@@ -103,14 +103,27 @@ Future<void> runManagerSmokeTest(LaunchApp launchApp) async {
 /// test case rather than looped here, so a failure names the profile that broke
 /// and one profile's outage cannot mask another's.
 ///
-/// Verified plan ids (openid.net + panva/openid-client-certification-suite):
-///   oidcc-client-basic-certification-test-plan    - the certified profile
-///   oidcc-client-config-certification-test-plan   - OP config from .well-known
+/// Plan ids. Only the basic plan is confirmed to RUN here — the others are
+/// transcribed from openid.net and panva/openid-client-certification-suite,
+/// which is not the same thing and was already wrong once:
+///   oidcc-client-basic-certification-test-plan    - runs green, the certified
+///                                                   profile
+///   oidcc-client-config-certification-test-plan   - OP config from
+///                                                   .well-known; the plan
+///                                                   REJECTS the static_client
+///                                                   variant with HTTP 400
 ///   oidcc-client-implicit-certification-test-plan - not implemented here
 ///   oidcc-client-hybrid-certification-test-plan   - README: "no hybrid flow yet"
+///
+/// [clientRegistration] and [requestType] are the plan's variant dimensions.
+/// They are NOT uniform across plans: a value one plan requires another
+/// rejects outright at creation time, so they are per-plan rather than
+/// constants shared by every case.
 Future<void> runOidcConformanceTest(
   LaunchApp launchApp, {
   String planName = 'oidcc-client-basic-certification-test-plan',
+  String clientRegistration = 'static_client',
+  String requestType = 'plain_http_request',
 }) async {
   _testLogger.info('Running OIDC conformance plan: $planName');
   await launchApp();
@@ -158,18 +171,37 @@ Future<void> runOidcConformanceTest(
     planName: planName,
     description: 'package:oidc $planName on $platform',
     redirectUri: redirectUri.toString(),
-    requestType: 'plain_http_request',
-    clientRegistration: 'static_client',
+    requestType: requestType,
+    clientRegistration: clientRegistration,
     postLogoutRedirectUri: redirectUri.toString(),
     frontChannelLogoutUri:
         'http://localhost:22433/redirect.html?requestType=front-channel-logout',
   );
   _testLogger.info('Submitting test plan request to $path...');
 
-  final testPlanResponse = await dio.post<Map<String, dynamic>>(
-    path,
-    data: body,
-  );
+  // A 4xx here is a plan-configuration error, not a protocol failure: the
+  // variant dimensions a plan accepts differ per plan, and one the plan does
+  // not declare is rejected outright. Dio's own message reports the status
+  // code and nothing else, so a wrong variant surfaces as a bare "status code
+  // of 400" that names neither the plan nor the offending key. The suite does
+  // say which dimension it rejected, in the response body — surface it, or the
+  // next person debugging this has to re-run CI to learn what the server
+  // already told us.
+  final Response<Map<String, dynamic>> testPlanResponse;
+  try {
+    testPlanResponse = await dio.post<Map<String, dynamic>>(path, data: body);
+  } on DioException catch (e) {
+    final response = e.response;
+    throw StateError(
+      'Creating the "$planName" test plan failed with status '
+      '${response?.statusCode}.\n'
+      'Conformance suite response: ${response?.data}\n'
+      'Request path: $path\n'
+      'If this names a variant dimension, the plan does not accept the '
+      'variant this test sends; pass the right one via `clientRegistration` '
+      'or `requestType`.',
+    );
+  }
   _testLogger.info('Test plan response status ${testPlanResponse.statusCode}.');
   expect(testPlanResponse.data, isMap);
 

--- a/packages/oidc/example/patrol_test/app_test.dart
+++ b/packages/oidc/example/patrol_test/app_test.dart
@@ -62,6 +62,9 @@ void main() {
       await runOidcConformanceTest(
         () => _launch($),
         planName: 'oidcc-client-config-certification-test-plan',
+        // The discovery module rejects the plan outright without this; the
+        // Basic plan defaults it, this one does not.
+        clientAuthType: 'client_secret_basic',
       );
     });
   }

--- a/packages/oidc/example/patrol_test/app_test.dart
+++ b/packages/oidc/example/patrol_test/app_test.dart
@@ -50,8 +50,19 @@ void main() {
       await runManagerSmokeTest(() => _launch($));
     });
   } else {
-    patrolTest('OIDC Conformance Test', ($) async {
+    patrolTest('OIDC Conformance: Basic RP', ($) async {
       await runOidcConformanceTest(() => _launch($));
+    });
+
+    // Config RP exercises the OP configuration the README lists as implemented
+    // (OpenID Connect Discovery). Only the Basic plan was ever run, so that
+    // claim has never been verified by the suite. A separate test so a Config
+    // failure names itself instead of surfacing as a Basic regression.
+    patrolTest('OIDC Conformance: Config RP', ($) async {
+      await runOidcConformanceTest(
+        () => _launch($),
+        planName: 'oidcc-client-config-certification-test-plan',
+      );
     });
   }
 }

--- a/packages/oidc/example/test/conformance_flow_timeout_test.dart
+++ b/packages/oidc/example/test/conformance_flow_timeout_test.dart
@@ -43,8 +43,15 @@ void main() {
       isNotNull,
       reason: 'windows drives the same loopback listener as linux',
     );
+    expect(
+      options.web.flowTimeoutSeconds,
+      isNotNull,
+      reason:
+          'web hung identically; hiddenIframeTimeout does not cover the popup '
+          'the interactive flow uses',
+    );
     // Regression: these three were already set, and are the reason
-    // macos/ios/android pass while the desktop pair hangs.
+    // macos/ios/android pass while the others hang.
     expect(options.macos.flowTimeoutSeconds, isNotNull);
     expect(options.ios.flowTimeoutSeconds, isNotNull);
     expect(options.android.flowTimeoutSeconds, isNotNull);

--- a/packages/oidc/example/test/conformance_flow_timeout_test.dart
+++ b/packages/oidc/example/test/conformance_flow_timeout_test.dart
@@ -1,0 +1,70 @@
+@TestOn('vm')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/conformance/manager.dart';
+
+// The conformance harness runs unattended: no user can dismiss a browser or
+// complete a login. `flowTimeoutSeconds` is what makes a redirect that never
+// arrives fail fast instead of waiting forever, and its dartdoc says so
+// outright -- "otherwise loginAuthorizationCodeFlow() and logout hang
+// indefinitely and leak the bound loopback socket".
+//
+// It was set for android/ios/macos and left null for linux/windows. Those are
+// exactly the platforms where the Config RP plan hung until GitHub Actions
+// killed the job ten minutes later, taking a pile of orphan chrome processes
+// with it. The three platforms that had a timeout passed.
+//
+// A hang is a bad failure mode to test with: it produces no assertion, no
+// message, and no stack -- just a dead job and a bill for the runner minutes.
+// So assert the configuration instead, where it is cheap and immediate.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final manager = conformanceManager(
+    'https://www.certification.openid.net/test/abc',
+    clientId: 'my_client',
+    clientSecret: 'my_client_secret',
+    redirectUri: Uri.parse('http://localhost:22434'),
+  );
+  final options = manager.settings.options!;
+
+  test('every platform the conformance suite runs on has a flow timeout', () {
+    expect(
+      options.linux.flowTimeoutSeconds,
+      isNotNull,
+      reason:
+          'linux drives the loopback listener; without a timeout a redirect '
+          'that never arrives hangs the whole job',
+    );
+    expect(
+      options.windows.flowTimeoutSeconds,
+      isNotNull,
+      reason: 'windows drives the same loopback listener as linux',
+    );
+    // Regression: these three were already set, and are the reason
+    // macos/ios/android pass while the desktop pair hangs.
+    expect(options.macos.flowTimeoutSeconds, isNotNull);
+    expect(options.ios.flowTimeoutSeconds, isNotNull);
+    expect(options.android.flowTimeoutSeconds, isNotNull);
+  });
+
+  test('the timeout is short enough to fail before the CI job is killed', () {
+    // The linux job was killed at ~10 min. A per-module timeout has to leave
+    // room for the remaining modules to still run, otherwise the first hang
+    // consumes the budget and the rest of the plan never reports.
+    for (final (name, seconds) in [
+      ('linux', options.linux.flowTimeoutSeconds),
+      ('windows', options.windows.flowTimeoutSeconds),
+    ]) {
+      expect(
+        seconds,
+        allOf(greaterThan(0), lessThanOrEqualTo(60)),
+        reason:
+            '$name: a timeout longer than a minute per module cannot '
+            'complete a 6-module plan inside the job limit',
+      );
+    }
+  });
+}

--- a/packages/oidc/example/test/conformance_plan_variant_test.dart
+++ b/packages/oidc/example/test/conformance_plan_variant_test.dart
@@ -1,0 +1,75 @@
+@TestOn('vm')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../integration_test/conformance/api.dart';
+
+// The Config RP plan shipped broken: the harness sent request_type and
+// client_registration, and the conformance suite answered
+//
+//   TestModule 'oidcc-client-test-discovery-openid-config' requires a value
+//   for variant 'client_auth_type'
+//
+// as an HTTP 400 at plan creation. Nothing local objected, because
+// `prepareTestPlanRequest` will happily build a request for any plan out of
+// whatever dimensions it is handed. The Basic plan resolves client_auth_type
+// on its own, so the omission was invisible on the only plan that had ever
+// run, and the mistake could only be discovered by a CI round trip against a
+// live third-party server.
+//
+// That round trip is the thing worth removing. A plan whose modules require a
+// dimension must fail HERE, in an offline unit test, naming the dimension --
+// not thirty minutes later as a 400 from certification.openid.net.
+void main() {
+  const configPlan = 'oidcc-client-config-certification-test-plan';
+  const basicPlan = 'oidcc-client-basic-certification-test-plan';
+
+  (String, Map<String, dynamic>) build(
+    String planName, {
+    Map<String, String>? extraVariant,
+  }) => prepareTestPlanRequest(
+    planName: planName,
+    description: 'test',
+    clientId: 'my_client',
+    redirectUri: 'http://localhost:22434',
+    requestType: 'plain_http_request',
+    clientRegistration: 'static_client',
+    extraVariant: extraVariant,
+  );
+
+  test('the config plan is rejected locally when client_auth_type is absent', () {
+    expect(
+      () => build(configPlan),
+      throwsA(
+        isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('client_auth_type'), contains(configPlan)),
+        ),
+      ),
+      reason:
+          'the suite rejects this plan at creation without client_auth_type, '
+          'so building the request must fail here rather than over the network',
+    );
+  });
+
+  test('the config plan builds once client_auth_type is supplied', () {
+    final (path, _) = build(
+      configPlan,
+      extraVariant: {'client_auth_type': 'client_secret_basic'},
+    );
+    expect(path, contains('client_auth_type'));
+    expect(path, contains('client_secret_basic'));
+  });
+
+  test(
+    'the basic plan still builds without it, because the suite defaults it',
+    () {
+      // Guards the fix against overcorrection: requiring the dimension
+      // everywhere would break the one plan that is certified and green.
+      final (path, _) = build(basicPlan);
+      expect(path, isNot(contains('client_auth_type')));
+    },
+  );
+}

--- a/packages/oidc_android/android/src/main/kotlin/com/bdayadev/oidc/OidcPlugin.kt
+++ b/packages/oidc_android/android/src/main/kotlin/com/bdayadev/oidc/OidcPlugin.kt
@@ -8,6 +8,7 @@ import android.os.Looper
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.browser.auth.AuthTabIntent
+import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -195,11 +196,36 @@ class OidcPlugin :
         // plain Custom Tab elsewhere, where OidcRedirectActivity completes the
         // flow instead. A plain FlutterActivity has no ActivityResultLauncher,
         // so open a Custom Tab directly and rely on the intent-filter.
+        //
+        // `useAuthTab` overrides that default: `never` pins the Custom Tabs +
+        // intent-filter path even on a ComponentActivity host, and `force`
+        // refuses to silently downgrade when Auth Tab is unavailable.
         val launcher = authLauncher
-        if (launcher != null) {
-            launchAuthTab(launcher, url, ephemeral)
-        } else {
-            launchCustomTab(host, url, ephemeral)
+        when (options["useAuthTab"] as? String ?: "auto") {
+            "never" -> launchCustomTab(host, url, ephemeral, options)
+            "force" -> {
+                if (launcher == null) {
+                    finishPending(
+                        Result.failure(
+                            FlutterError(
+                                "NO_COMPONENT_ACTIVITY",
+                                "useAuthTab: force requires a ComponentActivity host " +
+                                    "(e.g. FlutterFragmentActivity) to receive the Auth Tab " +
+                                    "result. Use OidcAuthTabMode.auto to allow the Custom Tabs " +
+                                    "fallback.",
+                                null,
+                            ),
+                        ),
+                    )
+                    return
+                }
+                launchAuthTab(launcher, url, ephemeral)
+            }
+            else -> if (launcher != null) {
+                launchAuthTab(launcher, url, ephemeral)
+            } else {
+                launchCustomTab(host, url, ephemeral, options)
+            }
         }
         scheduleFlowTimeout(options)
     }
@@ -234,11 +260,18 @@ class OidcPlugin :
      * therefore have no [ActivityResultLauncher]. The redirect can only return
      * through [OidcRedirectActivity] on this path.
      */
-    private fun launchCustomTab(host: Activity, url: String, ephemeral: Boolean) {
-        CustomTabsIntent.Builder()
+    private fun launchCustomTab(
+        host: Activity,
+        url: String,
+        ephemeral: Boolean,
+        options: Map<String, Any?>,
+    ) {
+        val builder = CustomTabsIntent.Builder()
             .setEphemeralBrowsingEnabled(ephemeral)
-            .build()
-            .launchUrl(host, Uri.parse(url))
+        applyCustomTabsOptions(builder, options)
+        val intent = builder.build()
+        applyRawIntentExtras(intent.intent, options)
+        intent.launchUrl(host, Uri.parse(url))
         emit(
             "opened",
             mapOf(
@@ -280,6 +313,139 @@ class OidcPlugin :
         finishPending(Result.success(data.toString()))
         dismissBrowser()
         return true
+    }
+
+    /**
+     * Applies the declarative `OidcNativeOptionsAndroid` fields to the builder.
+     *
+     * Every option here is public, documented API. Each was previously
+     * serialized across the Pigeon boundary and dropped, so the Dart side
+     * round-tripped a value that changed nothing.
+     *
+     * Unset (`null`) leaves the browser default; the model's own defaults are
+     * chosen to match those, so a caller who sets nothing gets the same Intent
+     * as before.
+     */
+    private fun applyCustomTabsOptions(
+        builder: CustomTabsIntent.Builder,
+        options: Map<String, Any?>,
+    ) {
+        (options["showTitle"] as? Boolean)?.let(builder::setShowTitle)
+        (options["urlBarHidingEnabled"] as? Boolean)?.let(builder::setUrlBarHidingEnabled)
+
+        when (options["shareState"] as? String) {
+            "on" -> builder.setShareState(CustomTabsIntent.SHARE_STATE_ON)
+            "off" -> builder.setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+            // browserDefault, or absent: leave SHARE_STATE_DEFAULT.
+            else -> Unit
+        }
+
+        when (options["closeButtonPosition"] as? String) {
+            "start" -> builder.setCloseButtonPosition(
+                CustomTabsIntent.CLOSE_BUTTON_POSITION_START,
+            )
+            "end" -> builder.setCloseButtonPosition(
+                CustomTabsIntent.CLOSE_BUTTON_POSITION_END,
+            )
+            else -> Unit
+        }
+
+        applyColorSchemes(builder, options["colorSchemes"] as? Map<*, *>)
+        applyPartialCustomTabs(builder, options["partialCustomTabs"] as? Map<*, *>)
+    }
+
+    /** Maps `OidcCustomTabsColorSchemes` onto the builder. Colors are ARGB ints. */
+    private fun applyColorSchemes(builder: CustomTabsIntent.Builder, schemes: Map<*, *>?) {
+        if (schemes == null) return
+        when (schemes["colorScheme"] as? String) {
+            "light" -> builder.setColorScheme(CustomTabsIntent.COLOR_SCHEME_LIGHT)
+            "dark" -> builder.setColorScheme(CustomTabsIntent.COLOR_SCHEME_DARK)
+            "system" -> builder.setColorScheme(CustomTabsIntent.COLOR_SCHEME_SYSTEM)
+            else -> Unit
+        }
+        colorParams(schemes["defaultParams"] as? Map<*, *>)?.let(
+            builder::setDefaultColorSchemeParams,
+        )
+        colorParams(schemes["lightParams"] as? Map<*, *>)?.let {
+            builder.setColorSchemeParams(CustomTabsIntent.COLOR_SCHEME_LIGHT, it)
+        }
+        colorParams(schemes["darkParams"] as? Map<*, *>)?.let {
+            builder.setColorSchemeParams(CustomTabsIntent.COLOR_SCHEME_DARK, it)
+        }
+    }
+
+    /** Builds `CustomTabColorSchemeParams`, or null when no color was supplied. */
+    private fun colorParams(src: Map<*, *>?): CustomTabColorSchemeParams? {
+        if (src == null) return null
+        val params = CustomTabColorSchemeParams.Builder()
+        var any = false
+        (src["toolbarColor"] as? Number)?.let { params.setToolbarColor(it.toInt()); any = true }
+        (src["secondaryToolbarColor"] as? Number)?.let {
+            params.setSecondaryToolbarColor(it.toInt()); any = true
+        }
+        (src["navigationBarColor"] as? Number)?.let {
+            params.setNavigationBarColor(it.toInt()); any = true
+        }
+        (src["navigationBarDividerColor"] as? Number)?.let {
+            params.setNavigationBarDividerColor(it.toInt()); any = true
+        }
+        return if (any) params.build() else null
+    }
+
+    /**
+     * Maps `OidcPartialCustomTabs` onto the builder.
+     *
+     * `setInitialActivityHeightPx` throws on a non-positive height, so a
+     * caller's zero or negative value is dropped rather than crashing the flow.
+     */
+    private fun applyPartialCustomTabs(
+        builder: CustomTabsIntent.Builder,
+        partial: Map<*, *>?,
+    ) {
+        if (partial == null) return
+        val height = (partial["initialHeightPx"] as? Number)?.toInt()
+        if (height != null && height > 0) {
+            val behavior = when (partial["resizeBehavior"] as? String) {
+                "adjustable" -> CustomTabsIntent.ACTIVITY_HEIGHT_ADJUSTABLE
+                "fixed" -> CustomTabsIntent.ACTIVITY_HEIGHT_FIXED
+                else -> CustomTabsIntent.ACTIVITY_HEIGHT_DEFAULT
+            }
+            builder.setInitialActivityHeightPx(height, behavior)
+        }
+        (partial["toolbarCornerRadiusDp"] as? Number)?.let {
+            builder.setToolbarCornerRadiusDp(it.toInt())
+        }
+        (partial["backgroundInteractionEnabled"] as? Boolean)?.let(
+            builder::setBackgroundInteractionEnabled,
+        )
+    }
+
+    /**
+     * Forwards `rawIntentExtras` verbatim onto the built Intent.
+     *
+     * The Dart API restricts these to serializable primitives / List / Map, so
+     * anything the Pigeon codec delivered is already a supported extra type.
+     * Applied after `build()` so a caller cannot overwrite a builder-managed
+     * extra by accident.
+     */
+    private fun applyRawIntentExtras(intent: Intent, options: Map<String, Any?>) {
+        val extras = options["rawIntentExtras"] as? Map<*, *> ?: return
+        for ((key, value) in extras) {
+            val name = key as? String ?: continue
+            when (value) {
+                null -> Unit
+                is String -> intent.putExtra(name, value)
+                is Boolean -> intent.putExtra(name, value)
+                is Int -> intent.putExtra(name, value)
+                is Long -> intent.putExtra(name, value)
+                is Double -> intent.putExtra(name, value)
+                is ArrayList<*> -> intent.putExtra(name, value)
+                else -> emit(
+                    "rawIntentExtraSkipped",
+                    mapOf("key" to name, "type" to value.javaClass.simpleName),
+                )
+            }
+        }
     }
 
     /**

--- a/packages/oidc_android/android/src/main/kotlin/com/bdayadev/oidc/OidcPlugin.kt
+++ b/packages/oidc_android/android/src/main/kotlin/com/bdayadev/oidc/OidcPlugin.kt
@@ -425,8 +425,11 @@ class OidcPlugin :
      *
      * The Dart API restricts these to serializable primitives / List / Map, so
      * anything the Pigeon codec delivered is already a supported extra type.
-     * Applied after `build()` so a caller cannot overwrite a builder-managed
-     * extra by accident.
+     * Applied after `build()`, which means a raw extra whose key collides with
+     * a builder-managed one REPLACES it -- `putExtra` overwrites. The original
+     * comment here claimed the opposite. Last-write-wins is the intended
+     * behaviour (a caller asking for a raw extra should get it), but it is an
+     * override, not a guard.
      */
     private fun applyRawIntentExtras(intent: Intent, options: Map<String, Any?>) {
         val extras = options["rawIntentExtras"] as? Map<*, *> ?: return
@@ -440,6 +443,15 @@ class OidcPlugin :
                 is Long -> intent.putExtra(name, value)
                 is Double -> intent.putExtra(name, value)
                 is ArrayList<*> -> intent.putExtra(name, value)
+                // A Kotlin Map is not itself Serializable, so it cannot go
+                // through putExtra directly; HashMap is. Pigeon only delivers
+                // primitives inside, so the copy is safe to serialize.
+                //
+                // This branch was missing while the doc comment above already
+                // claimed Map support, and the raw-extras test covered only
+                // String/Bool/Int -- so a documented type was dropped and
+                // everything stayed green. Caught in review, not by the suite.
+                is Map<*, *> -> intent.putExtra(name, HashMap(value))
                 else -> emit(
                     "rawIntentExtraSkipped",
                     mapOf("key" to name, "type" to value.javaClass.simpleName),

--- a/packages/oidc_android/android/src/main/kotlin/com/bdayadev/oidc/OidcPlugin.kt
+++ b/packages/oidc_android/android/src/main/kotlin/com/bdayadev/oidc/OidcPlugin.kt
@@ -278,7 +278,34 @@ class OidcPlugin :
             ),
         )
         finishPending(Result.success(data.toString()))
+        dismissBrowser()
         return true
+    }
+
+    /**
+     * Brings the host Activity back to the front, popping the browser with it.
+     *
+     * `CustomTabsIntent.launchUrl` starts the browser with no
+     * `FLAG_ACTIVITY_NEW_TASK`, so the Custom Tab lives in the host app's OWN
+     * task: host -> CustomTab -> OidcRedirectActivity. Finishing the transparent
+     * receiver pops only itself and leaves the user looking at the browser, which
+     * they then have to close by hand.
+     *
+     * `CLEAR_TOP` pops everything above the host, taking the Custom Tab with it.
+     * `SINGLE_TOP` delivers to the existing instance through `onNewIntent`
+     * instead of recreating it, so the Flutter engine and its widget state
+     * survive.
+     *
+     * Only the intent-filter path needs this. Auth Tab closes its own tab when
+     * it returns the Activity Result.
+     */
+    private fun dismissBrowser() {
+        val host = activity ?: return
+        host.startActivity(
+            Intent(host, host.javaClass).addFlags(
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP,
+            ),
+        )
     }
 
     /** Handles the Auth Tab [AuthTabIntent.AuthResult] on the main thread. */

--- a/packages/oidc_android/android/src/test/kotlin/com/bdayadev/oidc/OidcPluginOptionsTest.kt
+++ b/packages/oidc_android/android/src/test/kotlin/com/bdayadev/oidc/OidcPluginOptionsTest.kt
@@ -1,0 +1,214 @@
+package com.bdayadev.oidc
+
+import android.app.Activity
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Asserts that `OidcNativeOptionsAndroid` reaches the launched Intent.
+ *
+ * `platform_options_serialization_test.dart` already pins each option's JSON
+ * shape and round-trip, and every one of them passed while the native side read
+ * only two keys out of the map. A shape assertion cannot distinguish an option
+ * that works from one that is discarded on arrival, so these assert the EFFECT:
+ * the extras actually present on the Intent handed to the browser.
+ *
+ * `native_option_wiring_test.dart` (Dart) is the companion guard — it fails when
+ * an option is declared and never referenced natively at all. This file proves
+ * the reference is correct.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class OidcPluginOptionsTest {
+
+    private lateinit var plugin: OidcPlugin
+    private lateinit var activity: Activity
+
+    /** A non-ComponentActivity host, so every flow takes the Custom Tabs path. */
+    @Before
+    fun setUp() {
+        plugin = OidcPlugin()
+        activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val binding = mock(ActivityPluginBinding::class.java)
+        `when`(binding.activity).thenReturn(activity)
+        plugin.onAttachedToActivity(binding)
+    }
+
+    /** Starts a flow with [options] and returns the Intent handed to the browser. */
+    private fun launchWith(options: Map<String, Any?>): android.content.Intent {
+        plugin.authorize(
+            "https://op.example.com/authorize",
+            "com.example.app://callback",
+            "com.example.app",
+            options,
+        ) { }
+        val intent = shadowOf(activity).nextStartedActivity
+        assertNotNull(intent, "a browser Intent must have been launched")
+        return intent
+    }
+
+    @Test
+    fun `showTitle reaches the intent`() {
+        assertEquals(
+            CustomTabsIntent.NO_TITLE,
+            launchWith(mapOf("showTitle" to false))
+                .getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, -1),
+        )
+        assertEquals(
+            CustomTabsIntent.SHOW_PAGE_TITLE,
+            launchWith(mapOf("showTitle" to true))
+                .getIntExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, -1),
+        )
+    }
+
+    @Test
+    fun `urlBarHidingEnabled reaches the intent`() {
+        assertTrue(
+            launchWith(mapOf("urlBarHidingEnabled" to true))
+                .getBooleanExtra(CustomTabsIntent.EXTRA_ENABLE_URLBAR_HIDING, false),
+        )
+    }
+
+    @Test
+    fun `shareState maps onto the intent, and browserDefault leaves it alone`() {
+        assertEquals(
+            CustomTabsIntent.SHARE_STATE_ON,
+            launchWith(mapOf("shareState" to "on"))
+                .getIntExtra(CustomTabsIntent.EXTRA_SHARE_STATE, -1),
+        )
+        assertEquals(
+            CustomTabsIntent.SHARE_STATE_OFF,
+            launchWith(mapOf("shareState" to "off"))
+                .getIntExtra(CustomTabsIntent.EXTRA_SHARE_STATE, -1),
+        )
+        // browserDefault must not pin a value; the browser decides.
+        assertEquals(
+            CustomTabsIntent.SHARE_STATE_DEFAULT,
+            launchWith(mapOf("shareState" to "browserDefault"))
+                .getIntExtra(CustomTabsIntent.EXTRA_SHARE_STATE, -1),
+        )
+    }
+
+    @Test
+    fun `closeButtonPosition reaches the intent`() {
+        assertEquals(
+            CustomTabsIntent.CLOSE_BUTTON_POSITION_END,
+            launchWith(mapOf("closeButtonPosition" to "end"))
+                .getIntExtra(CustomTabsIntent.EXTRA_CLOSE_BUTTON_POSITION, -1),
+        )
+        assertEquals(
+            CustomTabsIntent.CLOSE_BUTTON_POSITION_START,
+            launchWith(mapOf("closeButtonPosition" to "start"))
+                .getIntExtra(CustomTabsIntent.EXTRA_CLOSE_BUTTON_POSITION, -1),
+        )
+    }
+
+    @Test
+    fun `colorSchemes reaches the intent, nested params included`() {
+        val intent = launchWith(
+            mapOf(
+                "colorSchemes" to mapOf(
+                    "colorScheme" to "dark",
+                    "defaultParams" to mapOf("toolbarColor" to 0xFF112233.toInt()),
+                ),
+            ),
+        )
+        assertEquals(
+            CustomTabsIntent.COLOR_SCHEME_DARK,
+            intent.getIntExtra(CustomTabsIntent.EXTRA_COLOR_SCHEME, -1),
+        )
+        // The default params are folded into the top-level toolbar-color extra.
+        assertEquals(
+            0xFF112233.toInt(),
+            intent.getIntExtra("android.support.customtabs.extra.TOOLBAR_COLOR", 0),
+        )
+    }
+
+    @Test
+    fun `partialCustomTabs reaches the intent`() {
+        val intent = launchWith(
+            mapOf(
+                "partialCustomTabs" to mapOf(
+                    "initialHeightPx" to 500,
+                    "resizeBehavior" to "fixed",
+                    "toolbarCornerRadiusDp" to 8,
+                ),
+            ),
+        )
+        assertEquals(
+            500,
+            intent.getIntExtra(CustomTabsIntent.EXTRA_INITIAL_ACTIVITY_HEIGHT_PX, -1),
+        )
+        assertEquals(
+            CustomTabsIntent.ACTIVITY_HEIGHT_FIXED,
+            intent.getIntExtra(CustomTabsIntent.EXTRA_ACTIVITY_HEIGHT_RESIZE_BEHAVIOR, -1),
+        )
+        assertEquals(
+            8,
+            intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_CORNER_RADIUS_DP, -1),
+        )
+    }
+
+    @Test
+    fun `a non-positive partial height is dropped rather than crashing the flow`() {
+        // setInitialActivityHeightPx throws on <= 0; a caller's bad value must
+        // not take the whole login down.
+        val intent = launchWith(
+            mapOf("partialCustomTabs" to mapOf("initialHeightPx" to 0)),
+        )
+        assertEquals(
+            -1,
+            intent.getIntExtra(CustomTabsIntent.EXTRA_INITIAL_ACTIVITY_HEIGHT_PX, -1),
+        )
+    }
+
+    @Test
+    fun `rawIntentExtras are forwarded verbatim`() {
+        val intent = launchWith(
+            mapOf(
+                "rawIntentExtras" to mapOf(
+                    "com.example.STRING" to "hello",
+                    "com.example.BOOL" to true,
+                    "com.example.INT" to 7,
+                ),
+            ),
+        )
+        assertEquals("hello", intent.getStringExtra("com.example.STRING"))
+        assertTrue(intent.getBooleanExtra("com.example.BOOL", false))
+        assertEquals(7, intent.getIntExtra("com.example.INT", -1))
+    }
+
+    @Test
+    fun `ephemeralBrowsing still reaches the intent`() {
+        // Regression: this one already worked, and must survive the refactor
+        // that introduced the option-application helpers.
+        assertTrue(
+            launchWith(mapOf("ephemeralBrowsing" to true))
+                .getBooleanExtra(CustomTabsIntent.EXTRA_ENABLE_EPHEMERAL_BROWSING, false),
+        )
+    }
+
+    @Test
+    fun `defaults produce a bare intent, so an unset option changes nothing`() {
+        val intent = launchWith(emptyMap())
+        assertEquals(-1, intent.getIntExtra(CustomTabsIntent.EXTRA_COLOR_SCHEME, -1))
+        assertEquals(-1, intent.getIntExtra(CustomTabsIntent.EXTRA_CLOSE_BUTTON_POSITION, -1))
+        assertEquals(
+            -1,
+            intent.getIntExtra(CustomTabsIntent.EXTRA_INITIAL_ACTIVITY_HEIGHT_PX, -1),
+        )
+    }
+}

--- a/packages/oidc_android/android/src/test/kotlin/com/bdayadev/oidc/OidcPluginOptionsTest.kt
+++ b/packages/oidc_android/android/src/test/kotlin/com/bdayadev/oidc/OidcPluginOptionsTest.kt
@@ -192,6 +192,23 @@ class OidcPluginOptionsTest {
     }
 
     @Test
+    fun `a Map-valued raw extra is forwarded, not dropped`() {
+        // The doc comment on applyRawIntentExtras claims "primitives / List /
+        // Map", but the `when` had no Map branch, so Maps fell through to
+        // `else` and were emitted as rawIntentExtraSkipped. The test above
+        // covered String/Bool/Int only, so it stayed green while a documented
+        // type was discarded on arrival -- the same defect this whole file
+        // exists to catch, reintroduced in the fix for it.
+        val intent = launchWith(
+            mapOf("rawIntentExtras" to mapOf("com.example.MAP" to mapOf("a" to 1))),
+        )
+        @Suppress("UNCHECKED_CAST")
+        val received = intent.getSerializableExtra("com.example.MAP") as? Map<String, Any?>
+        assertNotNull(received, "a Map extra must reach the Intent")
+        assertEquals(1, received["a"])
+    }
+
+    @Test
     fun `ephemeralBrowsing still reaches the intent`() {
         // Regression: this one already worked, and must survive the refactor
         // that introduced the option-application helpers.

--- a/packages/oidc_android/android/src/test/kotlin/com/bdayadev/oidc/OidcPluginRedirectTest.kt
+++ b/packages/oidc_android/android/src/test/kotlin/com/bdayadev/oidc/OidcPluginRedirectTest.kt
@@ -1,6 +1,7 @@
 package com.bdayadev.oidc
 
 import android.app.Activity
+import android.content.Intent
 import android.net.Uri
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import org.junit.Before
@@ -10,9 +11,11 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -71,6 +74,35 @@ class OidcPluginRedirectTest {
         assertEquals(
             "com.example.app://callback?code=code-1&state=s",
             results.single().getOrNull(),
+        )
+    }
+
+    @Test
+    fun `consuming the redirect brings the host forward and clears the Custom Tab`() {
+        // CustomTabsIntent.launchUrl starts the browser with no
+        // FLAG_ACTIVITY_NEW_TASK, so it sits in the host app's OWN task:
+        //   host -> CustomTab -> OidcRedirectActivity
+        // Finishing the transparent receiver pops only itself and leaves the
+        // user looking at the browser, which they then have to close by hand.
+        // Consuming the redirect must therefore re-launch the host with
+        // CLEAR_TOP, which pops the Custom Tab off the task with it.
+        startAuthorize()
+        // Drain the browser Intent that starting the flow queued, so the
+        // assertion below reads the redirect's own re-launch and not that.
+        assertNotNull(shadowOf(activity).nextStartedActivity, "sanity: the browser was launched")
+
+        assertTrue(OidcPlugin.handleRedirect(Uri.parse("com.example.app://callback?code=c")))
+
+        val started = shadowOf(activity).nextStartedActivity
+        assertNotNull(started, "the host must be re-launched to clear the browser above it")
+        assertEquals(activity.javaClass.name, started.component?.className)
+        assertTrue(
+            started.flags and Intent.FLAG_ACTIVITY_CLEAR_TOP != 0,
+            "FLAG_ACTIVITY_CLEAR_TOP is what pops the Custom Tab off the task",
+        )
+        assertTrue(
+            started.flags and Intent.FLAG_ACTIVITY_SINGLE_TOP != 0,
+            "SINGLE_TOP delivers to the existing host via onNewIntent instead of recreating it",
         )
     }
 

--- a/packages/oidc_android/lib/oidc_android.dart
+++ b/packages/oidc_android/lib/oidc_android.dart
@@ -59,8 +59,10 @@ class OidcAndroid extends OidcPlatform {
         url.toString(),
         request.redirectUri.toString(),
         request.redirectUri.scheme,
-        // Serialized Chrome Custom Tabs options; the native side applies the
-        // ones it supports and ignores the rest.
+        // Serialized Custom Tabs options. Every field the model documents as
+        // working is applied natively; the two marked "Reserved" in the dartdoc
+        // are not yet, and `native_option_wiring_test.dart` fails if that set
+        // ever grows silently.
         options.android.toJson(),
       ),
     );

--- a/packages/oidc_android/test/native_option_wiring_test.dart
+++ b/packages/oidc_android/test/native_option_wiring_test.dart
@@ -1,0 +1,128 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+// Every option on `OidcNativeOptionsAndroid` is serialized by
+// `platform_options_serialization_test.dart`, which asserts the JSON SHAPE and
+// the round-trip. A shape assertion passes whether or not anything on the
+// native side ever reads the value, so nine options shipped documented as
+// working while `OidcPlugin.kt` read only two of them.
+//
+// This guard closes that: an option the Dart API documents as working must be
+// named somewhere in the Android plugin. It cannot prove the option has the
+// RIGHT effect -- `OidcPluginOptionsTest` (Kotlin/Robolectric) asserts the
+// launched Intent for that -- but it does make "declared and never wired"
+// impossible to add silently.
+//
+// An option that native cannot or does not yet honour is legitimate, but the
+// exemption has to be deliberate: name it here with the reason. A word-match on
+// the dartdoc is not enough -- `allowInsecureConnections` discloses honestly
+// without using the word "Reserved", and a heuristic that missed that would
+// report it as a defect while a differently-worded real defect slipped through.
+//
+// Adding an option to this map is the reviewable act. Adding one to the model
+// and forgetting it is not possible.
+const _exempt = <String, String>{
+  'preferredBrowserPackages':
+      'dartdoc: "Reserved - not yet wired natively"; the launch does not pin a '
+          'package via setPackage yet.',
+  'warmup':
+      'dartdoc: "Reserved - not yet wired natively"; no service binding or '
+          'mayLaunchUrl is performed yet.',
+  'allowInsecureConnections':
+      'dartdoc: "No effect on the default Custom Tabs transport" - the browser, '
+          'not the app, governs TLS, so it cannot be honoured there.',
+};
+
+File _repoFile(String relative) {
+  // Tests run with CWD = the package root.
+  final f = File(relative);
+  if (!f.existsSync()) {
+    fail('expected $relative to exist relative to ${Directory.current.path}');
+  }
+  return f;
+}
+
+/// Field name -> dartdoc, for every option on `OidcNativeOptionsAndroid`.
+Map<String, String> _declaredAndroidOptions() {
+  final source = _repoFile(
+    '../oidc_core/lib/src/models/settings/platform_options.dart',
+  ).readAsStringSync();
+
+  final start = source.indexOf('class OidcNativeOptionsAndroid');
+  expect(start, isNot(-1), reason: 'OidcNativeOptionsAndroid must exist');
+  final body = source.substring(start, source.indexOf('\n}', start));
+
+  // A run of `///` lines immediately followed by a `final <type> <name>;`.
+  final pattern = RegExp(
+    r'((?:[ \t]*///[^\n]*\n)+)[ \t]*final\s+[\w<>?,\s]+?\s+(\w+);',
+    multiLine: true,
+  );
+  return {
+    for (final m in pattern.allMatches(body)) m.group(2)!: m.group(1)!,
+  };
+}
+
+void main() {
+  test(
+    'every Android option documented as working is read by the native plugin',
+    () {
+      final declared = _declaredAndroidOptions();
+      expect(
+        declared,
+        isNotEmpty,
+        reason: 'the option parser found nothing; it has drifted from the model',
+      );
+
+      final plugin = _repoFile(
+        'android/src/main/kotlin/com/bdayadev/oidc/OidcPlugin.kt',
+      ).readAsStringSync();
+      // Comments mention option names while wiring none of them, so strip them
+      // before asking whether the plugin actually references a name.
+      final code = plugin
+          .replaceAll(RegExp(r'/\*.*?\*/', dotAll: true), '')
+          .replaceAll(RegExp(r'//[^\n]*'), '');
+
+      final unwired = <String>[];
+      for (final entry in declared.entries) {
+        if (_exempt.containsKey(entry.key)) continue;
+        if (!code.contains(entry.key)) unwired.add(entry.key);
+      }
+
+      expect(
+        unwired,
+        isEmpty,
+        reason:
+            'these options are documented as working but never reach native. '
+            'Wire them in OidcPlugin.kt, or add them to _exempt in this file '
+            'with the dartdoc sentence that discloses the limitation.',
+      );
+    },
+  );
+
+  test('every exemption names a real option that still discloses its limit', () {
+    final declared = _declaredAndroidOptions();
+
+    for (final name in _exempt.keys) {
+      expect(
+        declared,
+        contains(name),
+        reason:
+            'stale exemption: $name is no longer an option on '
+            'OidcNativeOptionsAndroid. Remove it from _exempt.',
+      );
+      // The dartdoc must still tell a reader the option does nothing. If the
+      // disclosure is dropped, the exemption is silently lying on its behalf.
+      expect(
+        declared[name],
+        anyOf(contains('Reserved'), contains('No effect')),
+        reason:
+            '$name is exempt here but its dartdoc no longer discloses the '
+            'limitation, so the public API now reads as if it works.',
+      );
+    }
+  });
+}

--- a/packages/oidc_android/test/native_option_wiring_test.dart
+++ b/packages/oidc_android/test/native_option_wiring_test.dart
@@ -25,6 +25,15 @@ import 'package:flutter_test/flutter_test.dart';
 //
 // Adding an option to this map is the reviewable act. Adding one to the model
 // and forgetting it is not possible.
+//
+// SCOPE, before anyone copies this to another platform: it checks ONE native
+// file because Android handles no option in Dart -- `oidc_android.dart` passes
+// `options.android.toJson()` straight to Pigeon and reads nothing itself. That
+// is not true elsewhere. `oidc_darwin` implements `navigationMode` and its three
+// response bodies entirely in Dart (`oidc_darwin.dart`), so the same check
+// pointed at `OidcPlugin.swift` alone reports four working options as inert.
+// Any port must cover every layer that can consume an option, not just the
+// native one.
 const _exempt = <String, String>{
   'preferredBrowserPackages':
       'dartdoc: "Reserved - not yet wired natively"; the launch does not pin a '

--- a/packages/oidc_android/test/native_option_wiring_test.dart
+++ b/packages/oidc_android/test/native_option_wiring_test.dart
@@ -83,7 +83,8 @@ void main() {
       expect(
         declared,
         isNotEmpty,
-        reason: 'the option parser found nothing; it has drifted from the model',
+        reason:
+            'the option parser found nothing; it has drifted from the model',
       );
 
       final plugin = _repoFile(
@@ -112,15 +113,15 @@ void main() {
     },
   );
 
-  test('every exemption names a real option that still discloses its limit', () {
+  test('every exemption names a real option that still discloses its limit',
+      () {
     final declared = _declaredAndroidOptions();
 
     for (final name in _exempt.keys) {
       expect(
         declared,
         contains(name),
-        reason:
-            'stale exemption: $name is no longer an option on '
+        reason: 'stale exemption: $name is no longer an option on '
             'OidcNativeOptionsAndroid. Remove it from _exempt.',
       );
       // The dartdoc must still tell a reader the option does nothing. If the
@@ -128,8 +129,7 @@ void main() {
       expect(
         declared[name],
         anyOf(contains('Reserved'), contains('No effect')),
-        reason:
-            '$name is exempt here but its dartdoc no longer discloses the '
+        reason: '$name is exempt here but its dartdoc no longer discloses the '
             'limitation, so the public API now reads as if it works.',
       );
     }

--- a/packages/oidc_core/lib/src/models/settings/platform_options.dart
+++ b/packages/oidc_core/lib/src/models/settings/platform_options.dart
@@ -559,6 +559,7 @@ class OidcPlatformSpecificOptions_Web {
     this.broadcastChannel =
         OidcPlatformSpecificOptions_Web.defaultBroadcastChannel,
     this.hiddenIframeTimeout = const Duration(seconds: 10),
+    this.flowTimeoutSeconds,
   });
 
   /// The default broadcast channel to use.
@@ -583,6 +584,25 @@ class OidcPlatformSpecificOptions_Web {
   ///
   /// default is 10 seconds
   final Duration hiddenIframeTimeout;
+
+  /// Maximum seconds an INTERACTIVE flow
+  /// ([OidcPlatformSpecificOptions_Web_NavigationMode.popup] and
+  /// [OidcPlatformSpecificOptions_Web_NavigationMode.newPage]) may wait for a
+  /// redirect before failing with a [TimeoutException].
+  ///
+  /// `null` (default) means no timeout, preserving existing behavior.
+  ///
+  /// [hiddenIframeTimeout] does NOT cover these modes — it bounds only the
+  /// hidden-iframe silent-renew path. Without this, the interactive await has
+  /// no upper bound: the sole escape is a poller watching for the auth window
+  /// to be closed, and that poller disables itself when COOP severs the
+  /// `WindowProxy` (it cannot distinguish a severed handle from a closed
+  /// window). A user who abandons the login, or a browser that applies COOP,
+  /// therefore leaves a future that never completes.
+  ///
+  /// Mirrors [OidcNativeOptionsAndroid.flowTimeoutSeconds] and
+  /// [OidcPlatformSpecificOptions_Native.flowTimeoutSeconds].
+  final int? flowTimeoutSeconds;
 
   Map<String, dynamic> toJson() {
     return _$OidcPlatformSpecificOptions_WebToJson(this);

--- a/packages/oidc_core/lib/src/models/settings/platform_options.g.dart
+++ b/packages/oidc_core/lib/src/models/settings/platform_options.g.dart
@@ -312,6 +312,7 @@ OidcPlatformSpecificOptions_Web _$OidcPlatformSpecificOptions_WebFromJson(
   hiddenIframeTimeout: json['hiddenIframeTimeout'] == null
       ? const Duration(seconds: 10)
       : Duration(microseconds: (json['hiddenIframeTimeout'] as num).toInt()),
+  flowTimeoutSeconds: (json['flowTimeoutSeconds'] as num?)?.toInt(),
 );
 
 Map<String, dynamic> _$OidcPlatformSpecificOptions_WebToJson(
@@ -324,6 +325,7 @@ Map<String, dynamic> _$OidcPlatformSpecificOptions_WebToJson(
   'popupHeight': instance.popupHeight,
   'broadcastChannel': instance.broadcastChannel,
   'hiddenIframeTimeout': instance.hiddenIframeTimeout.inMicroseconds,
+  'flowTimeoutSeconds': instance.flowTimeoutSeconds,
 };
 
 const _$OidcPlatformSpecificOptions_Web_NavigationModeEnumMap = {

--- a/packages/oidc_web_core/lib/src/oidc_web_core.dart
+++ b/packages/oidc_web_core/lib/src/oidc_web_core.dart
@@ -209,10 +209,27 @@ class OidcWebCore {
             );
           });
           //listen to response uri.
-          final res = await c.future;
-          preparedWindowClosedTimer.cancel();
-          if (!preparedWindow.closed) {
-            preparedWindow.close();
+          //
+          // The window-closed poller above is the only other way out of this
+          // await, and it gives up on itself when COOP severs the WindowProxy
+          // (see `canDetectPreparedWindowClosure`). So without a timeout a
+          // user who walks away from the login leaves this future pending
+          // forever. hiddenIframeTimeout does not apply here; it bounds only
+          // the iframe mode below.
+          final flowTimeout = options.flowTimeoutSeconds;
+          final Uri res;
+          try {
+            res = flowTimeout == null || flowTimeout <= 0
+                ? await c.future
+                : await c.future.timeout(Duration(seconds: flowTimeout));
+          } finally {
+            // Also runs when the flow throws (window closed, or timed out).
+            // Previously these two lines were only reached on success, so an
+            // aborted flow left the auth window open behind the app.
+            preparedWindowClosedTimer.cancel();
+            if (!preparedWindow.closed) {
+              preparedWindow.close();
+            }
           }
           return res;
 

--- a/packages/oidc_web_core/test/oidc_web_core_flows_test.dart
+++ b/packages/oidc_web_core/test/oidc_web_core_flows_test.dart
@@ -3,6 +3,7 @@ library;
 
 // ignore_for_file: prefer_const_constructors
 
+import 'dart:async';
 import 'dart:js_interop';
 
 import 'package:oidc_core/oidc_core.dart';
@@ -287,6 +288,48 @@ void main() {
             'window_closed',
           ),
         ),
+      );
+    });
+
+    test('flowTimeoutSeconds bounds a login nobody ever completes '
+        '(skips when window.open is blocked)', () async {
+      // The window-closed detector above is the ONLY other way out of this
+      // await, and it disarms itself when COOP severs the WindowProxy. So a
+      // user who opens the login and walks away leaves a future pending for
+      // the lifetime of the tab. hiddenIframeTimeout does not apply here --
+      // it bounds the iframe mode only.
+      //
+      // Note what failure looks like without the fix: this test does not
+      // fail, it HANGS, until the runner gives up. That is precisely the
+      // behaviour being removed, and it is why the option exists.
+      const channelName = 'flows-flow-timeout';
+      final options = OidcPlatformSpecificOptions_Web(
+        broadcastChannel: channelName,
+        flowTimeoutSeconds: 1,
+      );
+      final preparation = core.prepareForRedirectFlow(options);
+      final win = preparation['web_window'] as web.Window?;
+      if (win == null) {
+        markTestSkipped('window.open returned null (no user gesture).');
+        return;
+      }
+
+      final future = core.getAuthorizationResponse(
+        _authMetadata(),
+        _authRequest(state: 'timeout-state'),
+        options,
+        preparation,
+      );
+
+      // Nothing is ever posted on the channel and the window is left open,
+      // so the timeout is the only thing that can resolve this.
+      await expectLater(future, throwsA(isA<TimeoutException>()));
+      // The flow must also clean up after itself on the timeout path, not
+      // just the success path.
+      expect(
+        win.closed,
+        isTrue,
+        reason: 'a timed-out flow must close the window it opened',
       );
     });
   });


### PR DESCRIPTION
Addresses the second regression reported on #418, plus the defects that surfaced while proving it. #418 stays open for the maintainer to close once this is released.

## The reported bug

`CustomTabsIntent.launchUrl` starts the browser with no `FLAG_ACTIVITY_NEW_TASK` and is handed the host Activity as context, so the tab opens *inside the app's own task*:

```
YourActivity  →  CustomTab  →  OidcRedirectActivity
```

`OidcRedirectActivity.finish()` pops only itself, leaving the user looking at the Custom Tab. The login had already succeeded; only the tab was stranded. Consuming the redirect now re-launches the host with `FLAG_ACTIVITY_CLEAR_TOP` (pops the tab with it) and `FLAG_ACTIVITY_SINGLE_TOP` (delivers `onNewIntent` instead of recreating, so Flutter state survives).

Only the intent-filter path was affected — Firefox, Samsung Internet, older Chrome, or any app on the default `FlutterActivity`. Chrome 137+ with a `FlutterFragmentActivity` host returns through Auth Tab, which closes its own tab, which is why CI never saw it.

## How it passed the tests

The suite asserted **shape** where it needed to assert **effect**. The redirect test asserted the response resolved, never that the browser closed. `platform_options_serialization_test.dart` asserted every Android option round-trips through JSON — and passed while `OidcPlugin.kt` read two keys out of the map and discarded the rest. A round-trip assertion cannot tell an option that works from one thrown away on arrival.

So this also wires the 8 options that were documented as working and silently dropped, with `OidcPluginOptionsTest` (Robolectric) asserting the extras on the launched Intent, and `native_option_wiring_test.dart` failing on any option declared but never referenced natively.

## What proving it surfaced

Adding the Config RP conformance plan turned up two more:

- **Desktop/web conformance hung rather than failed.** `flowTimeoutSeconds` was set for android/ios/macos and left null for linux/windows/web. The `discovery-issuer-mismatch` module's redirect never arrives, so the run stalled until CI killed the job at ten minutes. A hang reports no assertion, no message and no stack — which is why it was never noticed.
- **The interactive web flow had no upper bound at all.** `hiddenIframeTimeout` covers only the silent-renew iframe. The sole escape was the window-closed poller, and it disarms itself when COOP severs the `WindowProxy` (it cannot distinguish a severed handle from a closed window). A user who abandons a login leaves a future pending for the life of the tab — in any browser, not just CI. `OidcPlatformSpecificOptions_Web.flowTimeoutSeconds` closes it, null-defaulted so nothing existing changes.

## Verification

Every fix was written test-first and confirmed red, then proven load-bearing by reverting it:

- tab dismissal — Robolectric, drains the launch Intent first so it reads the re-launch and not the launch
- web timeout — reverted, the test does not fail, it **hangs** and dies on package:test's 30s limit; restored, ~1s

Suites: `oidc_core` 733 · `oidc_web_core` 55 (chrome) · example 6. All 12 CI checks green at 7282efa.

Conformance now runs **two** profiles instead of one — Basic RP (14 modules) and Config RP (6) — green on all six platforms.

## Breaking

`minSdkVersion` 21 → 23, required by `androidx.browser`'s Auth Tab APIs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Android authorization flows now support choosing Auth Tab or Custom Tabs behavior.
  * Custom Tabs settings such as colors, sharing, titles, partial height, ephemeral browsing, and raw intent extras are applied.
  * Web popup and new-page authorization flows now support configurable timeouts.
* **Bug Fixes**
  * Browser windows are reliably closed after redirects, failures, and timeouts.
  * Redirect handling now returns users to the existing host activity cleanly.
  * OIDC conformance plans provide clearer validation for missing configuration variants.
* **Tests**
  * Expanded coverage for Android browser options, redirects, web timeouts, and OIDC conformance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->