### PR TITLE
Fix ID token validation for valid multi-audience tokens

### DIFF
--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -361,9 +361,7 @@ abstract class OidcUserManagerBase {
   @protected
   Map<String, dynamic> getSerializableOptions(
     OidcPlatformSpecificOptions options,
-  ) => {
-    if (isWeb) 'webLaunchMode': options.web.navigationMode.name,
-  };
+  ) => {if (isWeb) 'webLaunchMode': options.web.navigationMode.name};
 
   /// Returns the authorization response.
   /// may throw an [OidcException].
@@ -571,10 +569,7 @@ abstract class OidcUserManagerBase {
           extra: {...?settings.extraTokenParameters, ...?extraBodyFields},
         ),
         credentials: clientCredentials,
-        headers: {
-          ...?settings.extraTokenHeaders,
-          ...?extraTokenHeaders,
-        },
+        headers: {...?settings.extraTokenHeaders, ...?extraTokenHeaders},
         client: httpClient,
         options: settings.options,
       ),
@@ -669,10 +664,7 @@ abstract class OidcUserManagerBase {
               },
             ),
             credentials: clientCredentials,
-            headers: {
-              ...?settings.extraTokenHeaders,
-              ...?extraTokenHeaders,
-            },
+            headers: {...?settings.extraTokenHeaders, ...?extraTokenHeaders},
             client: httpClient,
             options: settings.options,
           ),
@@ -881,16 +873,10 @@ abstract class OidcUserManagerBase {
   /// NOTE: this is different than [logout], since this method doesn't initiate
   /// any logout flows.
   Future<void> forgetUser() async {
-    await cleanUpStore(
-      toDelete: {
-        OidcStoreNamespace.secureTokens,
-      },
-    );
+    await cleanUpStore(toDelete: {OidcStoreNamespace.secureTokens});
     final currentUser = this.currentUser;
     if (currentUser != null) {
-      emitEvent(
-        OidcPreLogoutEvent.now(currentUser: currentUser),
-      );
+      emitEvent(OidcPreLogoutEvent.now(currentUser: currentUser));
       userSubject.add(null);
     }
   }
@@ -963,18 +949,12 @@ abstract class OidcUserManagerBase {
         metadata: discoveryDocument,
         revocationEndpoint: revocationEndpoint,
         credentials: clientCredentials,
-        headers: {
-          ...?settings.extraRevocationHeaders,
-          ...?headers,
-        },
+        headers: {...?settings.extraRevocationHeaders, ...?headers},
         request: OidcRevocationRequest(
           token: token,
           tokenTypeHint:
               OidcConstants_RevocationParameters_TokenType.accessToken,
-          extra: {
-            ...?extraBodyFields,
-            ...?settings.extraRevocationParameters,
-          },
+          extra: {...?extraBodyFields, ...?settings.extraRevocationParameters},
         ),
         options: getPlatformOptions(options),
         client: httpClient,
@@ -1067,18 +1047,12 @@ abstract class OidcUserManagerBase {
         metadata: discoveryDocument,
         revocationEndpoint: revocationEndpoint,
         credentials: clientCredentials,
-        headers: {
-          ...?settings.extraRevocationHeaders,
-          ...?headers,
-        },
+        headers: {...?settings.extraRevocationHeaders, ...?headers},
         request: OidcRevocationRequest(
           token: token,
           tokenTypeHint:
               OidcConstants_RevocationParameters_TokenType.refreshToken,
-          extra: {
-            ...?extraBodyFields,
-            ...?settings.extraRevocationParameters,
-          },
+          extra: {...?extraBodyFields, ...?settings.extraRevocationParameters},
         ),
         options: getPlatformOptions(options),
         client: httpClient,
@@ -1325,9 +1299,7 @@ abstract class OidcUserManagerBase {
 
       final tokenEndpoint = metadata.tokenEndpoint;
       if (tokenEndpoint == null) {
-        logAndThrow(
-          "This provider doesn't provide a token endpoint",
-        );
+        logAndThrow("This provider doesn't provide a token endpoint");
       }
       // an authorization code flow MUST have a code as a response,
       // otherwise an OidcException should have been thrown before entering
@@ -1626,10 +1598,7 @@ abstract class OidcUserManagerBase {
     lastSuccessfulServerContact = clock.now();
     consecutiveRefreshFailures = 0;
     if (exitOffline && isInOfflineMode) {
-      exitOfflineMode(
-        networkRestored: true,
-        newToken: newToken,
-      );
+      exitOfflineMode(networkRestored: true, newToken: newToken);
     }
   }
 
@@ -1998,9 +1967,7 @@ abstract class OidcUserManagerBase {
 
   @protected
   Future<void> handleTokenExpiring(OidcToken event) async {
-    emitEvent(
-      OidcTokenExpiringEvent.now(currentToken: event),
-    );
+    emitEvent(OidcTokenExpiringEvent.now(currentToken: event));
     // Automatic refresh-on-expiry is gated on POSSESSION of a refresh_token, not
     // on the OP advertising `refresh_token` in grant_types_supported (OPTIONAL
     // metadata, RFC 8414 §2; refresh is tied to the token per RFC 6749 §6).
@@ -2122,12 +2089,7 @@ abstract class OidcUserManagerBase {
           'Auto-refresh succeeded after the manager was disposed; '
           'ignoring the new token.',
         );
-        return (
-          user: null,
-          failureKind: null,
-          error: null,
-          stackTrace: null,
-        );
+        return (user: null, failureKind: null, error: null, stackTrace: null);
       }
       newUser = await createUserFromToken(
         token: OidcToken.fromResponse(
@@ -2144,12 +2106,7 @@ abstract class OidcUserManagerBase {
       // Successful refresh - update last server contact and exit offline mode
       recordSuccessfulServerContact(newToken: newUser?.token);
       logger.fine('Refreshed a token and got a new user: ${newUser?.uid}');
-      return (
-        user: newUser,
-        failureKind: null,
-        error: null,
-        stackTrace: null,
-      );
+      return (user: newUser, failureKind: null, error: null, stackTrace: null);
     } on Object catch (e, st) {
       // Post-dispose safety: a refresh that FAILS after the manager was torn
       // down must also be a COMPLETE no-op — no failure event, no offline
@@ -2161,12 +2118,7 @@ abstract class OidcUserManagerBase {
           e,
           st,
         );
-        return (
-          user: null,
-          failureKind: null,
-          error: null,
-          stackTrace: null,
-        );
+        return (user: null, failureKind: null, error: null, stackTrace: null);
       }
       // #120: a transient failure that offline handling will absorb schedules a
       // retry; a terminal failure (e.g. invalid_grant) or a disabled offline
@@ -2310,9 +2262,7 @@ abstract class OidcUserManagerBase {
 
   @protected
   void handleTokenExpired(OidcToken event) {
-    emitEvent(
-      OidcTokenExpiredEvent.now(currentToken: event),
-    );
+    emitEvent(OidcTokenExpiredEvent.now(currentToken: event));
 
     if (!settings.supportOfflineAuth) {
       // #154: do NOT forget a still-refreshable session on expiry. On resume
@@ -2613,14 +2563,10 @@ abstract class OidcUserManagerBase {
       errors.removeWhere(_isJwtExpiredError);
     }
     if (claims.subject == null) {
-      errors.add(
-        JoseException('id token is missing a `sub` claim.'),
-      );
+      errors.add(JoseException('id token is missing a `sub` claim.'));
     }
     if (claims.issuedAt == null) {
-      errors.add(
-        JoseException('id token is missing an `iat` claim.'),
-      );
+      errors.add(JoseException('id token is missing an `iat` claim.'));
     }
 
     // Additional OpenID Connect Core §3.1.3.7 id_token checks not covered by
@@ -2660,23 +2606,52 @@ abstract class OidcUserManagerBase {
       );
     }
 
-    // aud strictness (§3.1.3.7): the client_id is always trusted, and
-    // `settings.allowedAudiences` extends the trust list. Any OTHER audience
-    // means the token was minted for someone else and MUST be rejected.
-    final trustedAudiences = <String>{
-      clientCredentials.clientId,
-      ...?settings.allowedAudiences,
-    };
-    final untrustedAudiences = audiences
-        .where((a) => !trustedAudiences.contains(a))
-        .toList();
-    if (untrustedAudiences.isNotEmpty) {
+    // OpenID Connect Core §3.1.3.7:
+    //
+    // The ID token MUST be intended for this relying party, meaning its `aud`
+    // claim MUST contain this manager's client_id.
+    //
+    // A token may legitimately have multiple audiences. Additional audiences
+    // do not invalidate the token for this RP as long as:
+    //
+    //   * this RP's client_id is present in `aud`; and
+    //   * when `azp` is present, it identifies this RP.
+    //
+    // `azp` validation is performed above.
+    if (!audiences.contains(clientCredentials.clientId)) {
       errors.add(
         JoseException(
-          'id token contains untrusted audience(s) $untrustedAudiences, not '
-          'in the client_id or settings.allowedAudiences.',
+          'id token `aud` does not contain this client_id '
+          '(`${clientCredentials.clientId}`).',
         ),
       );
+    }
+
+    // `allowedAudiences`, when explicitly configured, enables an additional
+    // stricter deployment policy: every audience must be known to this RP.
+    //
+    // Keep this optional. Requiring an RP to know every other audience in a
+    // valid multi-audience token is unnecessarily restrictive and makes
+    // independent applications coupled to one another.
+    final allowedAudiences = settings.allowedAudiences;
+    if (allowedAudiences != null) {
+      final trustedAudiences = <String>{
+        clientCredentials.clientId,
+        ...allowedAudiences,
+      };
+
+      final unexpectedAudiences = audiences
+          .where((audience) => !trustedAudiences.contains(audience))
+          .toList();
+
+      if (unexpectedAudiences.isNotEmpty) {
+        errors.add(
+          JoseException(
+            'id token contains audience(s) outside the configured strict '
+            'allowlist: $unexpectedAudiences.',
+          ),
+        );
+      }
     }
 
     // `at_hash` (§3.2.2.9): when present alongside an access_token, it MUST be
@@ -2927,10 +2902,7 @@ abstract class OidcUserManagerBase {
 
       // If validation passed with no errors and we were in offline mode, exit it
       if (errors.isEmpty && offlineModeStartedAt != null && !userInfoFailed) {
-        exitOfflineMode(
-          networkRestored: true,
-          newToken: actualUser.token,
-        );
+        exitOfflineMode(networkRestored: true, newToken: actualUser.token);
       }
 
       // Emit warning if token validation was skipped
@@ -2975,19 +2947,10 @@ abstract class OidcUserManagerBase {
   }
 
   @protected
-  Future<void> cleanUpStore({
-    required Set<OidcStoreNamespace> toDelete,
-  }) async {
+  Future<void> cleanUpStore({required Set<OidcStoreNamespace> toDelete}) async {
     for (final element in toDelete) {
-      final keys = await store.getAllKeys(
-        element,
-        managerId: id,
-      );
-      await store.removeMany(
-        element,
-        keys: keys,
-        managerId: id,
-      );
+      final keys = await store.getAllKeys(element, managerId: id);
+      await store.removeMany(element, keys: keys, managerId: id);
     }
   }
 
@@ -3152,9 +3115,7 @@ abstract class OidcUserManagerBase {
           "Couldn't fetch the discoveryDocument",
           error: e,
           stackTrace: st,
-          extra: {
-            OidcConstants_Exception.discoveryDocumentUri: uri,
-          },
+          extra: {OidcConstants_Exception.discoveryDocumentUri: uri},
         );
       }
       // Keep the cached document as an offline fallback (do NOT re-persist or
@@ -3196,9 +3157,7 @@ abstract class OidcUserManagerBase {
           '(RFC 8414 §2.1); refusing to use the document.',
           error: e,
           stackTrace: st,
-          extra: {
-            OidcConstants_Exception.discoveryDocumentUri: uri,
-          },
+          extra: {OidcConstants_Exception.discoveryDocumentUri: uri},
         );
       }
     }
@@ -3259,10 +3218,7 @@ abstract class OidcUserManagerBase {
       keys: {key, '$key$discoveryFetchedAtSuffix'},
       managerId: id,
     );
-    final cachedMetadata = await _parseCachedDiscovery(
-      key,
-      cachedValues[key],
-    );
+    final cachedMetadata = await _parseCachedDiscovery(key, cachedValues[key]);
     // Keep the cached document as the offline fallback for the network fetch.
     currentDiscoveryDocument = cachedMetadata;
 
@@ -3323,9 +3279,7 @@ abstract class OidcUserManagerBase {
         logAndThrow(
           'Discovery document is missing the required `issuer` member '
           '(OIDC Discovery §3 / RFC 8414 §2).',
-          extra: {
-            OidcConstants_Exception.discoveryDocumentUri: uri,
-          },
+          extra: {OidcConstants_Exception.discoveryDocumentUri: uri},
         );
       }
       logger.warning(
@@ -3342,9 +3296,7 @@ abstract class OidcUserManagerBase {
       logAndThrow(
         'Issuer mismatch (OIDC Discovery §4.3 / RFC 8414 §3.3): discovery '
         'issuer ($actual) != expected issuer ($expected).',
-        extra: {
-          OidcConstants_Exception.discoveryDocumentUri: uri,
-        },
+        extra: {OidcConstants_Exception.discoveryDocumentUri: uri},
       );
     }
     logger.warning(
@@ -3601,10 +3553,7 @@ abstract class OidcUserManagerBase {
 
   @protected
   Future<void> clearUnusedStates() async {
-    await OidcState.clearStaleState(
-      store: store,
-      age: const Duration(days: 1),
-    );
+    await OidcState.clearStaleState(store: store, age: const Duration(days: 1));
   }
 
   /// Registers the id_token verification keys with [keyStore] from the current

--- a/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
+++ b/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
@@ -24,8 +24,10 @@ Duration? defaultRefreshBefore(OidcToken token) {
 ///   [OidcShouldRemoveInvalidTokenCallback]).
 /// - `null`  → apply the default policy (the current, unchanged behavior:
 ///   refresh when expired, then re-validate).
-typedef OidcIsLoadedTokenAcceptableCallback =
-    bool? Function(OidcUser user, List<Exception> validationErrors);
+typedef OidcIsLoadedTokenAcceptableCallback = bool? Function(
+  OidcUser user,
+  List<Exception> validationErrors,
+);
 
 /// The callback used by [OidcUserManagerSettings.shouldRemoveInvalidToken] to
 /// decide whether a loaded-but-invalid token is removed from the [OidcStore].
@@ -38,8 +40,10 @@ typedef OidcIsLoadedTokenAcceptableCallback =
 /// - `false` → keep the cached tokens (e.g. for a bespoke offline policy).
 /// - `null`  → apply the default policy, which removes the tokens unless
 ///   [OidcUserManagerSettings.supportOfflineAuth] is enabled.
-typedef OidcShouldRemoveInvalidTokenCallback =
-    bool? Function(OidcUser user, List<Exception> validationErrors);
+typedef OidcShouldRemoveInvalidTokenCallback = bool? Function(
+  OidcUser user,
+  List<Exception> validationErrors,
+);
 
 /// Controls how [OidcUserManagerBase.init] restores a previously-cached user.
 ///
@@ -89,10 +93,9 @@ enum OidcInitMode {
 }
 
 /// The callback used to determine the retry delay for offline mode refresh attempts.
-typedef OidcOfflineRefreshRetryDelayCallback =
-    Duration Function(
-      int consecutiveFailures,
-    );
+typedef OidcOfflineRefreshRetryDelayCallback = Duration Function(
+  int consecutiveFailures,
+);
 
 /// Default threshold for emitting repeat refresh failure warnings.
 
@@ -300,11 +303,21 @@ class OidcUserManagerSettings {
   /// tokens to that key. Null (the default) disables DPoP.
   final OidcDPoPSettings? dpop;
 
-  /// Additional audiences (beyond the `client_id`, which is always trusted)
-  /// that an id_token's `aud` claim is allowed to contain.
+  /// Optional strict allowlist for additional ID-token audiences.
   ///
-  /// OpenID Connect Core §3.1.3.7 requires rejecting an id_token whose `aud`
-  /// contains audiences not trusted by the client; this is the trust list.
+  /// The current client's `client_id` is always required to be present in the
+  /// ID token's `aud` claim.
+  ///
+  /// When this value is `null` (the default), additional audiences are allowed.
+  /// This follows OpenID Connect Core §3.1.3.7: an RP must verify that its own
+  /// `client_id` is in `aud`; a token may contain multiple audiences.
+  ///
+  /// When non-null, this enables a stricter deployment policy: every audience
+  /// in the ID token must be either this client's `client_id` or one of these
+  /// configured values.
+  ///
+  /// For multi-audience ID tokens, the manager also requires `azp` to be
+  /// present and equal to this client's `client_id`.
   final List<String>? allowedAudiences;
 
   /// RFC 8707 Resource Indicators: the protected resource(s) the issued tokens

--- a/packages/oidc_core/test/id_token_extra_validation_test.dart
+++ b/packages/oidc_core/test/id_token_extra_validation_test.dart
@@ -123,9 +123,7 @@ _ValidationManager _manager({
   OidcProviderMetadata? discoveryDocument,
 }) => _ValidationManager(
   discoveryDocument: discoveryDocument ?? _metadata,
-  clientCredentials: const OidcClientAuthentication.none(
-    clientId: 'client-1',
-  ),
+  clientCredentials: const OidcClientAuthentication.none(clientId: 'client-1'),
   store: OidcMemoryStore(),
   httpClient: httpClient,
   keyStore: keyStore,
@@ -198,32 +196,181 @@ void main() {
     });
   });
 
-  group('validateUser aud strictness (§3.1.3.7)', () {
-    test('rejects an untrusted extra audience', () async {
+  group('validateUser multi-audience ID tokens (§3.1.3.7)', () {
+    test(
+      'accepts additional audiences by default when aud contains this client '
+      'and azp identifies this client',
+      () async {
+        final user = await _user({
+          ..._baseClaims(),
+          'aud': ['client-1', 'other-rp'],
+          'azp': 'client-1',
+        });
+
+        final errors = _manager().run(user, _metadata);
+
+        expect(
+          errors.where(
+            (e) =>
+                e.toString().contains('aud') ||
+                e.toString().contains('audience') ||
+                e.toString().contains('azp'),
+          ),
+          isEmpty,
+        );
+      },
+    );
+
+    test('rejects a token whose aud does not contain this client_id', () async {
       final user = await _user({
         ..._baseClaims(),
-        'aud': ['client-1', 'other-rp'],
+        'aud': ['other-rp', 'another-rp'],
+        'azp': 'other-rp',
       });
+
       final errors = _manager().run(user, _metadata);
+
       expect(
-        errors.any((e) => e.toString().contains('untrusted audience')),
+        errors.any(
+          (e) => e.toString().contains(
+            'id token `aud` does not contain this client_id',
+          ),
+        ),
         isTrue,
       );
     });
 
-    test('accepts an extra audience listed in allowedAudiences', () async {
-      final user = await _user({
+    test('rejects a multi-audience token without azp', () async {
+      final claims = {
         ..._baseClaims(),
-        'aud': ['client-1', 'trusted-api'],
-      });
-      final errors = _manager(
-        allowedAudiences: ['trusted-api'],
-      ).run(user, _metadata);
+        'aud': ['client-1', 'other-rp'],
+      }..remove('azp');
+
+      final user = await _user(claims);
+      final errors = _manager().run(user, _metadata);
+
       expect(
-        errors.any((e) => e.toString().contains('untrusted audience')),
-        isFalse,
+        errors.any(
+          (e) => e.toString().contains(
+            'multiple audiences but is missing the required `azp`',
+          ),
+        ),
+        isTrue,
       );
     });
+
+    test(
+      'rejects a multi-audience token whose azp identifies another client',
+      () async {
+        final user = await _user({
+          ..._baseClaims(),
+          'aud': ['client-1', 'other-rp'],
+          'azp': 'other-rp',
+        });
+
+        final errors = _manager().run(user, _metadata);
+
+        expect(
+          errors.any(
+            (e) => e.toString().contains(
+              'id token `azp` (`other-rp`) does not match the client_id',
+            ),
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('rejects a malformed non-string azp claim', () async {
+      final user = await _user({
+        ..._baseClaims(),
+        'aud': ['client-1', 'other-rp'],
+        'azp': 123,
+      });
+
+      final errors = _manager().run(user, _metadata);
+
+      expect(
+        errors.any(
+          (e) => e.toString().contains(
+            'id token `azp` must be a non-empty string when present',
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'strict allowedAudiences mode rejects an unknown additional audience',
+      () async {
+        final user = await _user({
+          ..._baseClaims(),
+          'aud': ['client-1', 'other-rp'],
+          'azp': 'client-1',
+        });
+
+        // Non-null empty list means strict mode with no extra audiences
+        // permitted.
+        final errors = _manager(allowedAudiences: const [])
+            .run(user, _metadata);
+
+        expect(
+          errors.any(
+            (e) => e.toString().contains(
+              'outside the configured strict allowlist',
+            ),
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'strict allowedAudiences mode accepts a configured additional audience',
+      () async {
+        final user = await _user({
+          ..._baseClaims(),
+          'aud': ['client-1', 'trusted-api'],
+          'azp': 'client-1',
+        });
+
+        final errors = _manager(allowedAudiences: const ['trusted-api'])
+            .run(user, _metadata);
+
+        expect(
+          errors.where(
+            (e) =>
+                e.toString().contains('aud') ||
+                e.toString().contains('audience') ||
+                e.toString().contains('azp'),
+          ),
+          isEmpty,
+        );
+      },
+    );
+
+    test(
+      'strict allowedAudiences mode still requires this client_id in aud',
+      () async {
+        final user = await _user({
+          ..._baseClaims(),
+          'aud': ['trusted-api'],
+          'azp': 'client-1',
+        });
+
+        final errors = _manager(allowedAudiences: const ['trusted-api'])
+            .run(user, _metadata);
+
+        expect(
+          errors.any(
+            (e) => e.toString().contains(
+              'id token `aud` does not contain this client_id',
+            ),
+          ),
+          isTrue,
+        );
+      },
+    );
   });
 
   group('validateUser at_hash (§3.2.2.9)', () {
@@ -234,19 +381,19 @@ void main() {
       final atHash = base64Url
           .encode(full.sublist(0, full.length ~/ 2))
           .replaceAll('=', '');
-      final user = await _user(
-        {..._baseClaims(), 'at_hash': atHash},
-        accessToken: accessToken,
-      );
+      final user = await _user({
+        ..._baseClaims(),
+        'at_hash': atHash,
+      }, accessToken: accessToken);
       final errors = _manager().run(user, _metadata);
       expect(errors.any((e) => e.toString().contains('at_hash')), isFalse);
     });
 
     test('rejects a mismatched at_hash', () async {
-      final user = await _user(
-        {..._baseClaims(), 'at_hash': 'totally-wrong'},
-        accessToken: 'access-token-xyz',
-      );
+      final user = await _user({
+        ..._baseClaims(),
+        'at_hash': 'totally-wrong',
+      }, accessToken: 'access-token-xyz');
       final errors = _manager().run(user, _metadata);
       expect(errors.any((e) => e.toString().contains('at_hash')), isTrue);
     });
@@ -298,10 +445,7 @@ void main() {
           _metadata,
           maxAge: const Duration(minutes: 5),
         );
-        expect(
-          errors.any((e) => e.toString().contains('auth_time')),
-          isTrue,
-        );
+        expect(errors.any((e) => e.toString().contains('auth_time')), isTrue);
       },
     );
 
@@ -350,10 +494,7 @@ void main() {
         // Must not throw a raw TypeError out of validateUser; the missing `exp`
         // is collected as a normal validation error.
         final errors = _manager().run(user, _metadata);
-        expect(
-          errors.any((e) => e.toString().contains('exp')),
-          isTrue,
-        );
+        expect(errors.any((e) => e.toString().contains('exp')), isTrue);
       },
     );
   });
@@ -379,57 +520,46 @@ void main() {
       'passes when expectedIssuer pins the concrete tenant issuer',
       () async {
         final user = await concreteTenantUser();
-        final errors = _manager(
-          expectedIssuer: Uri.parse(concreteIssuer),
-        ).run(user, templateMetadata);
+        final errors = _manager(expectedIssuer: Uri.parse(concreteIssuer))
+            .run(user, templateMetadata);
         // The concrete `iss` now matches the pinned expectedIssuer, so the
         // otherwise-valid token produces no validation errors at all.
         expect(errors, isEmpty);
       },
     );
 
-    test(
-      'fails with an issuer mismatch when expectedIssuer is unset '
-      '(regression pin: default behavior is unchanged)',
-      () async {
-        final user = await concreteTenantUser();
-        // No expectedIssuer -> the advertised template `metadata.issuer` is used
-        // exactly as before, and the concrete `iss` fails the exact-match check.
-        final errors = _manager().run(user, templateMetadata);
-        expect(
-          errors.any((e) => e.toString().contains('Issuer does not match')),
-          isTrue,
-        );
-      },
-    );
+    test('fails with an issuer mismatch when expectedIssuer is unset '
+        '(regression pin: default behavior is unchanged)', () async {
+      final user = await concreteTenantUser();
+      // No expectedIssuer -> the advertised template `metadata.issuer` is used
+      // exactly as before, and the concrete `iss` fails the exact-match check.
+      final errors = _manager().run(user, templateMetadata);
+      expect(
+        errors.any((e) => e.toString().contains('Issuer does not match')),
+        isTrue,
+      );
+    });
 
-    test(
-      'rejects a DIFFERENT concrete tenant iss when expectedIssuer pins '
-      'tenant A (security pin: the pin is an exact match, not merely '
-      '"anything but the template")',
-      () async {
-        // expectedIssuer pins concrete tenant A; the token carries a DIFFERENT
-        // concrete tenant B (B != A, and B is not the template metadata issuer
-        // either). §3.1.3.7 demands an EXACT match, so pinning tenant A MUST
-        // still reject tenant B — the pin does not turn into "accept any
-        // non-template issuer". This is the negative counterpart the reviewer
-        // mutation-tested for.
-        const otherConcreteIssuer =
-            'https://login.microsoftonline.com/'
-            '99999999-0000-4000-8000-000000000000/v2.0';
-        final user = await _user({
-          ..._baseClaims(),
-          'iss': otherConcreteIssuer,
-        });
-        final errors = _manager(
-          expectedIssuer: Uri.parse(concreteIssuer),
-        ).run(user, templateMetadata);
-        expect(
-          errors.any((e) => e.toString().contains('Issuer does not match')),
-          isTrue,
-        );
-      },
-    );
+    test('rejects a DIFFERENT concrete tenant iss when expectedIssuer pins '
+        'tenant A (security pin: the pin is an exact match, not merely '
+        '"anything but the template")', () async {
+      // expectedIssuer pins concrete tenant A; the token carries a DIFFERENT
+      // concrete tenant B (B != A, and B is not the template metadata issuer
+      // either). §3.1.3.7 demands an EXACT match, so pinning tenant A MUST
+      // still reject tenant B — the pin does not turn into "accept any
+      // non-template issuer". This is the negative counterpart the reviewer
+      // mutation-tested for.
+      const otherConcreteIssuer =
+          'https://login.microsoftonline.com/'
+          '99999999-0000-4000-8000-000000000000/v2.0';
+      final user = await _user({..._baseClaims(), 'iss': otherConcreteIssuer});
+      final errors = _manager(expectedIssuer: Uri.parse(concreteIssuer))
+          .run(user, templateMetadata);
+      expect(
+        errors.any((e) => e.toString().contains('Issuer does not match')),
+        isTrue,
+      );
+    });
   });
 
   group('signed UserInfo iss uses resolveExpectedIssuer (#168 advisory, '
@@ -451,10 +581,8 @@ void main() {
 
     // A user whose id_token already carries the concrete tenant issuer and an
     // access token (so the UserInfo request is actually sent).
-    Future<OidcUser> concreteTenantUserWithAccessToken() => _user(
-      {..._baseClaims(), 'iss': concreteIssuer},
-      accessToken: 'at',
-    );
+    Future<OidcUser> concreteTenantUserWithAccessToken() =>
+        _user({..._baseClaims(), 'iss': concreteIssuer}, accessToken: 'at');
 
     int exp() =>
         clock.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/
@@ -493,37 +621,34 @@ void main() {
       },
     );
 
-    test(
-      'rejects (does not apply) a signed UserInfo whose iss is a WRONG '
-      'concrete issuer even when expectedIssuer is set',
-      () async {
-        const wrongConcreteIssuer =
-            'https://login.microsoftonline.com/'
-            '99999999-0000-4000-8000-000000000000/v2.0';
-        final fixture = _signedUserInfoFixture({
-          'sub': 'user-1',
-          'iss': wrongConcreteIssuer,
-          'aud': 'client-1',
-          'exp': exp(),
-          'name': 'from-userinfo',
-        });
-        final manager = _manager(
-          expectedIssuer: Uri.parse(concreteIssuer),
-          httpClient: fixture.client,
-          keyStore: fixture.keyStore,
-          discoveryDocument: templateMetadataWithUserInfo,
-        );
-        await manager.init();
-        final result = await manager.runValidateAndSave(
-          await concreteTenantUserWithAccessToken(),
-          templateMetadataWithUserInfo,
-        );
-        // The id_token itself is valid (its `iss` matches the pin), so a user is
-        // still returned — but the §5.3.4 iss mismatch means the forged UserInfo
-        // is rejected and never merged in, so its claim is absent.
-        expect(result, isNotNull);
-        expect(result!.userInfo.containsKey('name'), isFalse);
-      },
-    );
+    test('rejects (does not apply) a signed UserInfo whose iss is a WRONG '
+        'concrete issuer even when expectedIssuer is set', () async {
+      const wrongConcreteIssuer =
+          'https://login.microsoftonline.com/'
+          '99999999-0000-4000-8000-000000000000/v2.0';
+      final fixture = _signedUserInfoFixture({
+        'sub': 'user-1',
+        'iss': wrongConcreteIssuer,
+        'aud': 'client-1',
+        'exp': exp(),
+        'name': 'from-userinfo',
+      });
+      final manager = _manager(
+        expectedIssuer: Uri.parse(concreteIssuer),
+        httpClient: fixture.client,
+        keyStore: fixture.keyStore,
+        discoveryDocument: templateMetadataWithUserInfo,
+      );
+      await manager.init();
+      final result = await manager.runValidateAndSave(
+        await concreteTenantUserWithAccessToken(),
+        templateMetadataWithUserInfo,
+      );
+      // The id_token itself is valid (its `iss` matches the pin), so a user is
+      // still returned — but the §5.3.4 iss mismatch means the forged UserInfo
+      // is rejected and never merged in, so its claim is absent.
+      expect(result, isNotNull);
+      expect(result!.userInfo.containsKey('name'), isFalse);
+    });
   });
 }


### PR DESCRIPTION
## Description

Fix ID token audience validation to follow OpenID Connect Core §3.1.3.7.

Previously, ID tokens were rejected when they contained any audience other than the current client ID. This rejects valid multi-audience ID tokens, even when the current client's client_id is present in aud and azp.

For example, a token like this gets rejected if the current clientId is 383855105961832497, when it should be accepted:

```json
{
  "aud": [
    "383855194618463281",
    "383855105961832497",
    "383993030477207708"
  ],
  "azp": "383855105961832497",
  "client_id": "383855105961832497"
}
```

This change makes the default validation behavior accept a token when its aud claim contains the current client ID. The existing allowedAudiences setting remains available as an optional strict allowlist policy for applications that want to reject any additional audiences.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Strengthened validation of token issuers, audiences, and authorized-party claims.
  - Added stricter support for configured audience allowlists and signed UserInfo responses.
  - Improved handling of authorization errors from unexpected issuers.

- **Reliability**
  - Improved refresh coordination and behavior when sessions are disposed or temporarily offline.
  - Enhanced cache and discovery lifecycle handling.

- **Documentation**
  - Clarified audience configuration defaults and validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->