### PR TITLE
fix(oidc_core): log offline userinfo failures as WARNING, not SEVERE

### DIFF
--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -3087,12 +3087,30 @@ abstract class OidcUserManagerBase {
             exitOffline: false,
           );
         } on Object catch (e, st) {
-          logger.severe('UserInfo endpoint threw an exception!', e, st);
+          // #432: classify the error BEFORE logging so a plain offline hiccup
+          // (device offline, DNS failure, request timeout, or a transient
+          // 5xx) — all recoverable and expected once offline auth support
+          // exists — doesn't get logged as SEVERE. Reserve SEVERE for errors
+          // that indicate an actual auth/client/TLS problem or something this
+          // handler can't classify. This is the same classification the
+          // offline-mode block below reacts to, computed once and reused
+          // there instead of calling `categorizeError` twice.
+          final errorType = OidcOfflineAuthErrorHandler.categorizeError(e);
+          switch (errorType) {
+            case OfflineAuthErrorType.networkUnavailable:
+            case OfflineAuthErrorType.networkTimeout:
+            case OfflineAuthErrorType.serverError:
+              logger.warning('UserInfo endpoint threw an exception!', e, st);
+            case OfflineAuthErrorType.sslError:
+            case OfflineAuthErrorType.authenticationError:
+            case OfflineAuthErrorType.clientError:
+            case OfflineAuthErrorType.unknown:
+              logger.severe('UserInfo endpoint threw an exception!', e, st);
+          }
           userInfoFailed = true;
 
           // Check if this is a network/server error that should enter offline mode
           if (settings.supportOfflineAuth) {
-            final errorType = OidcOfflineAuthErrorHandler.categorizeError(e);
             if (errorType == OfflineAuthErrorType.networkUnavailable ||
                 errorType == OfflineAuthErrorType.networkTimeout) {
               enterOfflineMode(

--- a/packages/oidc_core/test/userinfo_offline_log_level_test.dart
+++ b/packages/oidc_core/test/userinfo_offline_log_level_test.dart
@@ -1,0 +1,188 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:clock/clock.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:jose_plus/jose.dart';
+import 'package:logging/logging.dart';
+import 'package:oidc_core/oidc_core.dart';
+import 'package:test/test.dart';
+
+const _issuer = 'https://op.example.com';
+final _signingKey = JsonWebKey.generate('RS256');
+
+String _signIdToken({
+  String subject = 'user-1',
+  Duration expiresIn = const Duration(hours: 1),
+  String issuer = _issuer,
+}) {
+  final now = clock.now().millisecondsSinceEpoch ~/ 1000;
+  return (JsonWebSignatureBuilder()
+        ..jsonContent = {
+          'iss': issuer,
+          'sub': subject,
+          'aud': 'client-1',
+          'exp': now + expiresIn.inSeconds,
+          'iat': now,
+        }
+        ..addRecipient(_signingKey, algorithm: 'RS256'))
+      .build()
+      .toCompactSerialization();
+}
+
+/// A concrete manager exposing the `@protected` `validateAndSaveUser` surface
+/// so the #432 UserInfo-failure log-level fix can be driven directly from a
+/// VM test, mirroring the harness in `userinfo_401_reaction_test.dart`.
+class _M extends OidcUserManagerBase {
+  _M({
+    required super.discoveryDocument,
+    required super.clientCredentials,
+    required super.store,
+    required super.settings,
+    super.httpClient,
+    super.keyStore,
+  });
+
+  /// Validates a freshly-issued login token; a UserInfo failure here is the
+  /// plain (non-401) path that #432 is about.
+  Future<OidcUser?> triggerValidate(OidcUser user) =>
+      validateAndSaveUser(user: user, metadata: discoveryDocument);
+
+  @override
+  bool get isWeb => false;
+  @override
+  Future<OidcAuthorizeResponse?> getAuthorizationResponse(
+    OidcProviderMetadata metadata,
+    OidcAuthorizeRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+  @override
+  Future<OidcEndSessionResponse?> getEndSessionResponse(
+    OidcProviderMetadata metadata,
+    OidcEndSessionRequest request,
+    OidcPlatformSpecificOptions options,
+    Map<String, dynamic> preparationResult,
+  ) async => null;
+  @override
+  Map<String, dynamic> prepareForRedirectFlow(
+    OidcPlatformSpecificOptions options,
+  ) => const {};
+  @override
+  Stream<OidcFrontChannelLogoutIncomingRequest>
+  listenToFrontChannelLogoutRequests(
+    Uri listenOn,
+    OidcFrontChannelRequestListeningOptions options,
+  ) => const Stream.empty();
+  @override
+  Stream<OidcMonitorSessionResult> monitorSessionStatus({
+    required Uri checkSessionIframe,
+    required OidcMonitorSessionStatusRequest request,
+  }) => const Stream.empty();
+}
+
+OidcProviderMetadata _metadata() => OidcProviderMetadata.fromJson({
+  'issuer': _issuer,
+  'authorization_endpoint': '$_issuer/authorize',
+  'token_endpoint': '$_issuer/token',
+  'userinfo_endpoint': '$_issuer/userinfo',
+});
+
+OidcToken _token() => OidcToken(
+  creationTime: clock.now(),
+  idToken: _signIdToken(),
+  accessToken: 'at-seed',
+  refreshToken: 'rt-seed',
+  tokenType: 'Bearer',
+  expiresIn: const Duration(hours: 1),
+);
+
+Future<OidcUser> _seedUser() => OidcUser.fromIdToken(token: _token());
+
+_M _make({required http.Client client}) => _M(
+  discoveryDocument: _metadata(),
+  clientCredentials: const OidcClientAuthentication.none(clientId: 'client-1'),
+  store: OidcMemoryStore(),
+  httpClient: client,
+  keyStore: JsonWebKeyStore()..addKey(_signingKey),
+  settings: OidcUserManagerSettings(
+    redirectUri: Uri.parse('com.example.app://cb'),
+  ),
+);
+
+void main() {
+  hierarchicalLoggingEnabled = true;
+  Logger('OidcUserManagerBase').level = Level.ALL;
+
+  group('UserInfo failure log level (#432)', () {
+    test(
+      'a SocketException (device offline) logs WARNING, not SEVERE',
+      () async {
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/userinfo')) {
+            throw const SocketException('Network is unreachable');
+          }
+          return http.Response('{}', 404);
+        });
+        final manager = _make(client: client);
+        await manager.init();
+
+        final records = <LogRecord>[];
+        final sub = Logger('OidcUserManagerBase').onRecord.listen(
+          records.add,
+        );
+
+        final result = await manager.triggerValidate(await _seedUser());
+        await pumpEventQueue();
+
+        expect(result, isNotNull);
+        expect(records.where((r) => r.level == Level.SEVERE), isEmpty);
+        expect(
+          records.where(
+            (r) =>
+                r.level == Level.WARNING &&
+                r.message.contains('UserInfo endpoint threw an exception!'),
+          ),
+          hasLength(1),
+        );
+
+        await sub.cancel();
+        await manager.dispose();
+      },
+    );
+
+    test('a FormatException (unclassified) still logs SEVERE', () async {
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/userinfo')) {
+          throw const FormatException('malformed response');
+        }
+        return http.Response('{}', 404);
+      });
+      final manager = _make(client: client);
+      await manager.init();
+
+      final records = <LogRecord>[];
+      final sub = Logger('OidcUserManagerBase').onRecord.listen(records.add);
+
+      final result = await manager.triggerValidate(await _seedUser());
+      await pumpEventQueue();
+
+      expect(result, isNotNull);
+      expect(
+        records.where(
+          (r) =>
+              r.level == Level.SEVERE &&
+              r.message.contains('UserInfo endpoint threw an exception!'),
+        ),
+        hasLength(1),
+      );
+
+      await sub.cancel();
+      await manager.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## What
`OidcUserManagerBase._` logged `SEVERE` unconditionally when the UserInfo request threw, one statement before `OidcOfflineAuthErrorHandler.categorizeError` classified the same error as benign-offline (network unavailable, timeout, transient server error).

## Why
A plain "device is offline" or a transient 5xx spams SEVERE logs for something expected and recoverable, drowning out real SEVERE alerts. See #432.

## How
- Compute `errorType = OidcOfflineAuthErrorHandler.categorizeError(e)` once at the top of the `userInfo` catch block in `packages/oidc_core/lib/src/managers/user_manager_base.dart`.
- Log `WARNING` for `networkUnavailable` / `networkTimeout` / `serverError`; keep `SEVERE` for `authenticationError` / `clientError` / `sslError` / `unknown`.
- Reuse `errorType` in the existing `supportOfflineAuth` block below instead of calling `categorizeError` twice.

Checked `oidc_desktop.dart` and `oidc_web_core.dart` for the same pattern — neither calls `categorizeError` or logs `SEVERE` gated on offline classification, so no change needed there.

## Verified
- New test `packages/oidc_core/test/userinfo_offline_log_level_test.dart`: confirmed failing against the old code (SocketException logged SEVERE), then passing after the fix; a `FormatException` (unclassified) still asserts SEVERE.
- Full `dart test` in `oidc_core`: 908 passed.
- `dart analyze`: 18 pre-existing issues, unchanged before/after.
- `dart format` on touched files: no changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UserInfo error logging so network-related issues are reported as warnings.
  * Continued reporting authentication, SSL, client, and unknown errors with severe logging.
  * Prevented duplicate or inconsistent log severity classification during offline handling.

* **Tests**
  * Added coverage for network-unavailable and unclassified UserInfo failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->