### PR TITLE
fix(oidc_core): allow valid multi-audience ID tokens by default (#433 continuation)

### DIFF
--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -2884,13 +2884,24 @@ abstract class OidcUserManagerBase {
     // the id_token carries more than one audience, `azp` is REQUIRED.
     final azp = claims['azp'];
     final audiences = claims.audience ?? const <String>[];
-    if (azp != null && azp != clientCredentials.clientId) {
-      errors.add(
-        JoseException(
-          'id token `azp` (`$azp`) does not match the client_id '
-          '(`${clientCredentials.clientId}`).',
-        ),
-      );
+    if (azp != null) {
+      if (azp is! String || azp.isEmpty) {
+        // A malformed `azp` cannot identify any party, so it can never satisfy
+        // the match below; reject it on its own terms rather than reporting a
+        // confusing "does not match the client_id" for a non-identifier value.
+        errors.add(
+          JoseException(
+            'id token `azp` must be a non-empty string when present.',
+          ),
+        );
+      } else if (azp != clientCredentials.clientId) {
+        errors.add(
+          JoseException(
+            'id token `azp` (`$azp`) does not match the client_id '
+            '(`${clientCredentials.clientId}`).',
+          ),
+        );
+      }
     }
     if (audiences.length > 1 && azp == null) {
       errors.add(
@@ -2914,23 +2925,47 @@ abstract class OidcUserManagerBase {
       );
     }
 
-    // aud strictness (§3.1.3.7): the client_id is always trusted, and
-    // `settings.allowedAudiences` extends the trust list. Any OTHER audience
-    // means the token was minted for someone else and MUST be rejected.
-    final trustedAudiences = <String>{
-      clientCredentials.clientId,
-      ...?settings.allowedAudiences,
-    };
-    final untrustedAudiences = audiences
-        .where((a) => !trustedAudiences.contains(a))
-        .toList();
-    if (untrustedAudiences.isNotEmpty) {
+    // `aud` (§3.1.3.7): the token MUST be intended for this RP, so `aud` MUST
+    // contain this client_id. Additional audiences do NOT invalidate it: a
+    // token may legitimately be minted for several parties at once. What keeps
+    // token substitution closed is the `azp` rule above — a multi-audience
+    // token is rejected unless `azp` is present AND identifies this client, so
+    // a token minted for someone else can never be replayed here.
+    //
+    // This repeats the check jose_plus already performs in `validate()`
+    // (jose_plus-1.0.0 lib/src/jwt.dart:89) on purpose: `validate()` is skipped
+    // entirely on the missing-`exp` early-return path above, and dropping the
+    // audience check there would leave a malformed token unvalidated for `aud`.
+    if (!audiences.contains(clientCredentials.clientId)) {
       errors.add(
         JoseException(
-          'id token contains untrusted audience(s) $untrustedAudiences, not '
-          'in the client_id or settings.allowedAudiences.',
+          'id token `aud` does not contain this client_id '
+          '(`${clientCredentials.clientId}`).',
         ),
       );
+    }
+
+    // `allowedAudiences` is an OPT-IN stricter deployment policy: when it is
+    // non-null, every audience must be one this RP was told about. It stays
+    // opt-in because demanding an RP enumerate every other audience of an
+    // otherwise-valid token couples independent applications together.
+    final allowedAudiences = settings.allowedAudiences;
+    if (allowedAudiences != null) {
+      final trustedAudiences = <String>{
+        clientCredentials.clientId,
+        ...allowedAudiences,
+      };
+      final unexpectedAudiences = audiences
+          .where((audience) => !trustedAudiences.contains(audience))
+          .toList();
+      if (unexpectedAudiences.isNotEmpty) {
+        errors.add(
+          JoseException(
+            'id token contains audience(s) outside the configured strict '
+            'allowlist: $unexpectedAudiences.',
+          ),
+        );
+      }
     }
 
     // `at_hash` (§3.2.2.9): when present alongside an access_token, it MUST be

--- a/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
+++ b/packages/oidc_core/lib/src/models/settings/user_manager_settings.dart
@@ -301,11 +301,21 @@ class OidcUserManagerSettings {
   /// tokens to that key. Null (the default) disables DPoP.
   final OidcDPoPSettings? dpop;
 
-  /// Additional audiences (beyond the `client_id`, which is always trusted)
-  /// that an id_token's `aud` claim is allowed to contain.
+  /// Optional strict allowlist for additional ID-token audiences.
   ///
-  /// OpenID Connect Core §3.1.3.7 requires rejecting an id_token whose `aud`
-  /// contains audiences not trusted by the client; this is the trust list.
+  /// The current client's `client_id` is always required to be present in the
+  /// ID token's `aud` claim.
+  ///
+  /// When this value is `null` (the default), additional audiences are allowed.
+  /// This follows OpenID Connect Core §3.1.3.7: an RP must verify that its own
+  /// `client_id` is in `aud`; a token may contain multiple audiences.
+  ///
+  /// When non-null, this enables a stricter deployment policy: every audience
+  /// in the ID token must be either this client's `client_id` or one of these
+  /// configured values.
+  ///
+  /// For multi-audience ID tokens, the manager also requires `azp` to be
+  /// present and equal to this client's `client_id`.
   final List<String>? allowedAudiences;
 
   /// RFC 8707 Resource Indicators: the protected resource(s) the issued tokens

--- a/packages/oidc_core/test/id_token_extra_validation_test.dart
+++ b/packages/oidc_core/test/id_token_extra_validation_test.dart
@@ -198,32 +198,184 @@ void main() {
     });
   });
 
-  group('validateUser aud strictness (§3.1.3.7)', () {
-    test('rejects an untrusted extra audience', () async {
+  group('validateUser multi-audience ID tokens (§3.1.3.7)', () {
+    test(
+      'accepts additional audiences by default when aud contains this client '
+      'and azp identifies this client',
+      () async {
+        final user = await _user({
+          ..._baseClaims(),
+          'aud': ['client-1', 'other-rp'],
+          'azp': 'client-1',
+        });
+
+        final errors = _manager().run(user, _metadata);
+
+        expect(
+          errors.where(
+            (e) =>
+                e.toString().contains('aud') ||
+                e.toString().contains('audience') ||
+                e.toString().contains('azp'),
+          ),
+          isEmpty,
+        );
+      },
+    );
+
+    test('rejects a token whose aud does not contain this client_id', () async {
       final user = await _user({
         ..._baseClaims(),
-        'aud': ['client-1', 'other-rp'],
+        'aud': ['other-rp', 'another-rp'],
+        'azp': 'other-rp',
       });
+
       final errors = _manager().run(user, _metadata);
+
       expect(
-        errors.any((e) => e.toString().contains('untrusted audience')),
+        errors.any(
+          (e) => e.toString().contains(
+            'id token `aud` does not contain this client_id',
+          ),
+        ),
         isTrue,
       );
     });
 
-    test('accepts an extra audience listed in allowedAudiences', () async {
-      final user = await _user({
+    test('rejects a multi-audience token without azp', () async {
+      final claims = {
         ..._baseClaims(),
-        'aud': ['client-1', 'trusted-api'],
-      });
-      final errors = _manager(
-        allowedAudiences: ['trusted-api'],
-      ).run(user, _metadata);
+        'aud': ['client-1', 'other-rp'],
+      }..remove('azp');
+
+      final user = await _user(claims);
+      final errors = _manager().run(user, _metadata);
+
       expect(
-        errors.any((e) => e.toString().contains('untrusted audience')),
-        isFalse,
+        errors.any(
+          (e) => e.toString().contains(
+            'multiple audiences but is missing the required `azp`',
+          ),
+        ),
+        isTrue,
       );
     });
+
+    test(
+      'rejects a multi-audience token whose azp identifies another client',
+      () async {
+        final user = await _user({
+          ..._baseClaims(),
+          'aud': ['client-1', 'other-rp'],
+          'azp': 'other-rp',
+        });
+
+        final errors = _manager().run(user, _metadata);
+
+        expect(
+          errors.any(
+            (e) => e.toString().contains(
+              'id token `azp` (`other-rp`) does not match the client_id',
+            ),
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('rejects a malformed non-string azp claim', () async {
+      final user = await _user({
+        ..._baseClaims(),
+        'aud': ['client-1', 'other-rp'],
+        'azp': 123,
+      });
+
+      final errors = _manager().run(user, _metadata);
+
+      expect(
+        errors.any(
+          (e) => e.toString().contains(
+            'id token `azp` must be a non-empty string when present',
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'strict allowedAudiences mode rejects an unknown additional audience',
+      () async {
+        final user = await _user({
+          ..._baseClaims(),
+          'aud': ['client-1', 'other-rp'],
+          'azp': 'client-1',
+        });
+
+        // Non-null empty list means strict mode with no extra audiences
+        // permitted.
+        final errors = _manager(
+          allowedAudiences: const [],
+        ).run(user, _metadata);
+
+        expect(
+          errors.any(
+            (e) => e.toString().contains(
+              'outside the configured strict allowlist',
+            ),
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'strict allowedAudiences mode accepts a configured additional audience',
+      () async {
+        final user = await _user({
+          ..._baseClaims(),
+          'aud': ['client-1', 'trusted-api'],
+          'azp': 'client-1',
+        });
+
+        final errors = _manager(
+          allowedAudiences: const ['trusted-api'],
+        ).run(user, _metadata);
+
+        expect(
+          errors.where(
+            (e) =>
+                e.toString().contains('aud') ||
+                e.toString().contains('audience') ||
+                e.toString().contains('azp'),
+          ),
+          isEmpty,
+        );
+      },
+    );
+
+    test(
+      'strict allowedAudiences mode still requires this client_id in aud',
+      () async {
+        final user = await _user({
+          ..._baseClaims(),
+          'aud': ['trusted-api'],
+          'azp': 'client-1',
+        });
+
+        final errors = _manager(
+          allowedAudiences: const ['trusted-api'],
+        ).run(user, _metadata);
+
+        expect(
+          errors.any(
+            (e) => e.toString().contains(
+              'id token `aud` does not contain this client_id',
+            ),
+          ),
+          isTrue,
+        );
+      },
+    );
   });
 
   group('validateUser at_hash (§3.2.2.9)', () {


### PR DESCRIPTION
Supersedes #433. Same fix, re-applied onto current `main`. Credit to @rk54rk, kept as `Co-authored-by` on the commit.

## What changed

`oidc_core` rejected any id_token whose `aud` carried an audience other than the current `client_id`, unless every extra one was pre-listed in `settings.allowedAudiences`. OIDC Core §3.1.3.7 only requires the RP to verify its own `client_id` is in `aud`, so valid multi-audience tokens were being refused.

Default validation now requires `aud` to contain this `client_id`. `settings.allowedAudiences` becomes an opt-in strict allowlist rather than the only path to acceptance.

Token substitution stays closed by the `azp` rule that already sits directly above: a multi-audience token is rejected unless `azp` is present and equals this `client_id`.

## Deltas from #433

- Implements the `azp` type guard that #433's tests asserted but its lib code never added — a present-but-non-string `azp` is now rejected as such. Their `rejects a malformed non-string azp claim` test passes here; it did not in #433.
- Drops the ~200 lines of formatter churn #433 carried from a stale base. Diff is the ~15 real lines plus tests.

## Verified

- `dart test` in `packages/oidc_core`: 912 passed (was 906; 8 tests added, 2 replaced).
- TDD: the 8 tests were ported first; 5 failed against the old strict default, then went green after the lib change.
- `dart analyze`: 18 issues before, 18 after — output byte-identical, zero new.
- `dart format` applied only to the three touched files, all of which were already format-clean at HEAD.
