### PR TITLE
fix(oidc_core)!: drop the legacy in-payload code_verifier (#404)

### DIFF
--- a/packages/oidc_core/lib/src/endpoints/authorize/resp.dart
+++ b/packages/oidc_core/lib/src/endpoints/authorize/resp.dart
@@ -19,7 +19,6 @@ class OidcAuthorizeResponse extends JsonBasedResponse {
   ///
   OidcAuthorizeResponse({
     required super.src,
-    this.codeVerifier,
     this.redirectUri,
     this.code,
     this.sessionState,
@@ -65,8 +64,6 @@ class OidcAuthorizeResponse extends JsonBasedResponse {
   /// The client MUST NOT use the authorization code
   @JsonKey(name: OidcConstants_AuthParameters.code)
   String? code;
-  @JsonKey(name: OidcConstants_AuthParameters.codeVerifier)
-  String? codeVerifier;
   @JsonKey(name: OidcConstants_AuthParameters.nonce)
   String? nonce;
   @JsonKey(name: OidcConstants_AuthParameters.redirectUri)

--- a/packages/oidc_core/lib/src/endpoints/authorize/resp.g.dart
+++ b/packages/oidc_core/lib/src/endpoints/authorize/resp.g.dart
@@ -10,7 +10,6 @@ OidcAuthorizeResponse _$OidcAuthorizeResponseFromJson(
   Map<String, dynamic> json,
 ) => OidcAuthorizeResponse(
   src: readSrcMap(json, '') as Map<String, dynamic>,
-  codeVerifier: json['code_verifier'] as String?,
   redirectUri: json['redirect_uri'] == null
       ? null
       : Uri.parse(json['redirect_uri'] as String),

--- a/packages/oidc_core/lib/src/endpoints/authorize/state.dart
+++ b/packages/oidc_core/lib/src/endpoints/authorize/state.dart
@@ -14,7 +14,6 @@ class OidcAuthorizeState extends OidcState {
   ///
   OidcAuthorizeState({
     required this.redirectUri,
-    required this.codeVerifier,
     required this.codeChallenge,
     required this.originalUri,
     required this.nonce,
@@ -49,11 +48,6 @@ class OidcAuthorizeState extends OidcState {
   /// via PKCE.
   @JsonKey(name: OidcConstants_AuthParameters.codeChallenge)
   String? codeChallenge;
-
-  /// The same code_verifier that was used to obtain the authorization_code
-  /// via PKCE.
-  @JsonKey(name: OidcConstants_AuthParameters.codeVerifier)
-  String? codeVerifier;
 
   /// The redirectUri that was passed.
   @JsonKey(name: OidcConstants_AuthParameters.redirectUri)

--- a/packages/oidc_core/lib/src/endpoints/authorize/state.g.dart
+++ b/packages/oidc_core/lib/src/endpoints/authorize/state.g.dart
@@ -9,7 +9,6 @@ part of 'state.dart';
 OidcAuthorizeState _$OidcAuthorizeStateFromJson(Map<String, dynamic> json) =>
     OidcAuthorizeState(
       redirectUri: Uri.parse(json['redirect_uri'] as String),
-      codeVerifier: json['code_verifier'] as String?,
       codeChallenge: json['code_challenge'] as String?,
       originalUri: json['original_uri'] == null
           ? null
@@ -44,7 +43,6 @@ Map<String, dynamic> _$OidcAuthorizeStateToJson(OidcAuthorizeState instance) =>
       'extraTokenParams': instance.extraTokenParams,
       'options': instance.options,
       'code_challenge': instance.codeChallenge,
-      'code_verifier': instance.codeVerifier,
       'redirect_uri': instance.redirectUri.toString(),
       'client_id': instance.clientId,
       'original_uri': instance.originalUri?.toString(),

--- a/packages/oidc_core/lib/src/endpoints/facade.dart
+++ b/packages/oidc_core/lib/src/endpoints/facade.dart
@@ -190,7 +190,6 @@ class OidcEndpoints {
     final stateData = OidcAuthorizeState(
       id: const Uuid().v4(),
       createdAt: clock.now(),
-      codeVerifier: codeVerifier,
       codeChallenge: codeChallenge,
       redirectUri: input.redirectUri,
       clientId: input.clientId,
@@ -210,15 +209,12 @@ class OidcEndpoints {
       // exchange (RFC 7636 §1) — so it must not sit in the plaintext `state`
       // namespace. Persist it in the `secureTokens` namespace (encrypted at
       // rest on web, secure-storage-backed on mobile/desktop) keyed by the
-      // state id, and strip it from the state payload before persisting.
-      // `handleSuccessfulAuthResponse` reads it back from there, falling back
-      // to the in-payload value for one release so any flow already in flight
-      // across an app upgrade still completes.
+      // state id; `handleSuccessfulAuthResponse` reads it back from there, and
+      // from nowhere else.
       await store.setStateCodeVerifier(
         state: stateData.id,
         codeVerifier: codeVerifier,
       );
-      stateData.codeVerifier = null;
       await store.setStateData(
         state: stateData.id,
         stateData: stateData.toStorageString(),
@@ -308,7 +304,6 @@ class OidcEndpoints {
     final stateData = OidcAuthorizeState(
       id: const Uuid().v4(),
       createdAt: clock.now(),
-      codeVerifier: null,
       codeChallenge: null,
       redirectUri: input.redirectUri,
       clientId: input.clientId,

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -1606,12 +1606,13 @@ abstract class OidcUserManagerBase {
         );
       }
 
-      // #324 item 20: the PKCE `code_verifier` now lives in the `secureTokens`
-      // namespace (encrypted / secure-storage-backed) keyed by the state id,
-      // not in the plaintext `state` payload. Fall back to the value embedded
-      // in the payload for a flow that was started by a version which still
-      // wrote it there — a one-release compatibility window so in-flight logins
-      // survive an app upgrade.
+      // #324 item 20: the PKCE `code_verifier` lives in the `secureTokens`
+      // namespace (encrypted / secure-storage-backed) keyed by the state id.
+      // #404: the plaintext `state` payload is no longer a source for it —
+      // reading the secret back out of the namespace it was moved off of would
+      // undo the fix. Absent (a flow started before 2.0.0 and still inside the
+      // stale-state window) means no `code_verifier` is sent and the OP answers
+      // `invalid_grant`, which surfaces as a clean re-login.
       final storedCodeVerifier = await store.getStateCodeVerifier(
         receivedStateKey,
       );
@@ -1626,10 +1627,7 @@ abstract class OidcUserManagerBase {
           headers: stateData.extraTokenHeaders,
           request: OidcTokenRequest.authorizationCode(
             redirectUri: response.redirectUri ?? stateData.redirectUri,
-            codeVerifier:
-                response.codeVerifier ??
-                storedCodeVerifier ??
-                stateData.codeVerifier,
+            codeVerifier: response.codeVerifier ?? storedCodeVerifier,
             extra: stateData.extraTokenParams,
             clientId: credentials.clientId,
             code: code,

--- a/packages/oidc_core/lib/src/managers/user_manager_base.dart
+++ b/packages/oidc_core/lib/src/managers/user_manager_base.dart
@@ -1608,11 +1608,14 @@ abstract class OidcUserManagerBase {
 
       // #324 item 20: the PKCE `code_verifier` lives in the `secureTokens`
       // namespace (encrypted / secure-storage-backed) keyed by the state id.
-      // #404: the plaintext `state` payload is no longer a source for it —
-      // reading the secret back out of the namespace it was moved off of would
-      // undo the fix. Absent (a flow started before 2.0.0 and still inside the
-      // stale-state window) means no `code_verifier` is sent and the OP answers
-      // `invalid_grant`, which surfaces as a clean re-login.
+      // #404: that is its only source. Neither the plaintext `state` payload
+      // nor the authorization response may supply it — the response arrives as
+      // redirect parameters, so honoring one there would let whoever shaped the
+      // redirect pick the verifier that completes the exchange, which is the
+      // binding PKCE exists to enforce (RFC 7636 §1). Absent (a flow started
+      // before 2.0.0 and still inside the stale-state window) means no
+      // `code_verifier` is sent and the OP answers `invalid_grant`, which
+      // surfaces as a clean re-login.
       final storedCodeVerifier = await store.getStateCodeVerifier(
         receivedStateKey,
       );
@@ -1627,7 +1630,7 @@ abstract class OidcUserManagerBase {
           headers: stateData.extraTokenHeaders,
           request: OidcTokenRequest.authorizationCode(
             redirectUri: response.redirectUri ?? stateData.redirectUri,
-            codeVerifier: response.codeVerifier ?? storedCodeVerifier,
+            codeVerifier: storedCodeVerifier,
             extra: stateData.extraTokenParams,
             clientId: credentials.clientId,
             code: code,

--- a/packages/oidc_core/lib/src/state_store.dart
+++ b/packages/oidc_core/lib/src/state_store.dart
@@ -107,13 +107,15 @@ extension OidcReadOnlyStoreExt on OidcReadOnlyStore {
   /// Gets the PKCE `code_verifier` for an in-flight authorization [state] from
   /// the [OidcStoreNamespace.secureTokens] namespace.
   ///
-  /// Returns null when absent — an unknown state, a flow whose verifier was
-  /// already consumed, or one started by a pre-2.0.0 version that embedded it
-  /// in the (plaintext) [OidcStoreNamespace.state] payload instead. Callers
-  /// MUST NOT substitute that embedded value: reading the secret back out of
-  /// the namespace it was deliberately moved off of undoes the protection
-  /// [OidcStoreExt.setStateCodeVerifier] documents. Null simply means no
-  /// `code_verifier` goes on the token request.
+  /// This is the only source of the `code_verifier`. Returns null when absent —
+  /// an unknown state, a flow whose verifier was already consumed, or one
+  /// started by a pre-2.0.0 version that embedded it in the (plaintext)
+  /// [OidcStoreNamespace.state] payload instead. Callers MUST NOT substitute a
+  /// value from the state payload (reading the secret back out of the namespace
+  /// it was deliberately moved off of undoes what
+  /// [OidcStoreExt.setStateCodeVerifier] protects) nor from the authorization
+  /// response (redirect parameters are shaped by whoever sent the redirect).
+  /// Null simply means no `code_verifier` goes on the token request.
   Future<String?> getStateCodeVerifier(String state) => get(
     OidcStoreNamespace.secureTokens,
     key: _stateCodeVerifierKey(state),

--- a/packages/oidc_core/lib/src/state_store.dart
+++ b/packages/oidc_core/lib/src/state_store.dart
@@ -107,11 +107,13 @@ extension OidcReadOnlyStoreExt on OidcReadOnlyStore {
   /// Gets the PKCE `code_verifier` for an in-flight authorization [state] from
   /// the [OidcStoreNamespace.secureTokens] namespace.
   ///
-  /// Returns null when absent — e.g. for a flow that was started by a version
-  /// which still embedded the `code_verifier` inside the (plaintext)
-  /// [OidcStoreNamespace.state] payload. Callers must fall back to that
-  /// embedded value for one release; see [OidcStoreExt.setStateCodeVerifier]
-  /// for the rationale and the compatibility window.
+  /// Returns null when absent — an unknown state, a flow whose verifier was
+  /// already consumed, or one started by a pre-2.0.0 version that embedded it
+  /// in the (plaintext) [OidcStoreNamespace.state] payload instead. Callers
+  /// MUST NOT substitute that embedded value: reading the secret back out of
+  /// the namespace it was deliberately moved off of undoes the protection
+  /// [OidcStoreExt.setStateCodeVerifier] documents. Null simply means no
+  /// `code_verifier` goes on the token request.
   Future<String?> getStateCodeVerifier(String state) => get(
     OidcStoreNamespace.secureTokens,
     key: _stateCodeVerifierKey(state),

--- a/packages/oidc_core/test/code_verifier_at_rest_test.dart
+++ b/packages/oidc_core/test/code_verifier_at_rest_test.dart
@@ -2,10 +2,11 @@
 library;
 
 // Audit #324 item 20: the PKCE `code_verifier` must not be persisted in the
-// plaintext `state` namespace. It now lives in the `secureTokens` namespace
+// plaintext `state` namespace. It lives in the `secureTokens` namespace
 // (encrypted at rest on web, secure-storage-backed on mobile/desktop) keyed by
-// the state id, with a one-release read fallback to the (legacy) in-payload
-// value so flows already in flight across an app upgrade still complete.
+// the state id, and that is now the ONLY place it is read from (#404): the
+// legacy in-payload fallback is gone, so a plaintext `state` payload can no
+// longer supply the secret that completes a token exchange.
 
 import 'dart:convert';
 
@@ -208,10 +209,10 @@ void main() {
     );
   });
 
-  group('backward compatibility (legacy in-payload code_verifier)', () {
+  group('legacy in-payload code_verifier (#404, no longer read)', () {
     test(
-      'a flow whose code_verifier is still embedded in the state payload '
-      '(no secureTokens entry) completes via the fallback',
+      'a state payload that still embeds code_verifier does not feed the '
+      'token request',
       () async {
         final posts = <http.Request>[];
         final client = MockClient((req) async {
@@ -239,32 +240,33 @@ void main() {
         );
         await manager.init();
 
-        // Simulate a state written by a version that still embedded the
-        // code_verifier in the (plaintext) state payload, with nothing in
-        // secureTokens — an in-flight flow captured mid app-upgrade.
-        final legacyState = OidcAuthorizeState(
-          id: 'legacy-state-1',
-          codeVerifier: 'legacy-verifier',
-          codeChallenge: OidcPkcePair.generateS256Challenge('legacy-verifier'),
-          redirectUri: Uri.parse('com.example.app://cb'),
-          clientId: 'client-1',
-          nonce: 'hashed-nonce',
-          originalUri: null,
-          extraTokenParams: null,
-          extraTokenHeaders: null,
-          options: null,
-        );
+        // A state payload exactly as a pre-2.0.0 version wrote it: the
+        // code_verifier sitting in the plaintext `state` namespace, nothing in
+        // secureTokens. Hand-built rather than via OidcAuthorizeState so it
+        // keeps describing the old on-disk shape after the field is dropped.
+        const legacyStateId = 'legacy-state-1';
         await store.setStateData(
-          state: legacyState.id,
-          stateData: legacyState.toStorageString(),
+          state: legacyStateId,
+          stateData: jsonEncode({
+            'id': legacyStateId,
+            'operationDiscriminator':
+                OidcConstants_OperationDiscriminators.authorize,
+            'code_verifier': 'legacy-verifier',
+            'code_challenge': OidcPkcePair.generateS256Challenge(
+              'legacy-verifier',
+            ),
+            'redirect_uri': 'com.example.app://cb',
+            'client_id': 'client-1',
+            'nonce': 'hashed-nonce',
+          }),
         );
-        expect(await store.getStateCodeVerifier(legacyState.id), isNull);
+        expect(await store.getStateCodeVerifier(legacyStateId), isNull);
 
         try {
           await manager.exposeHandleSuccess(
             OidcAuthorizeResponse.fromJson({
               'code': 'auth-code-1',
-              'state': legacyState.id,
+              'state': legacyStateId,
             }),
             _metadata(),
           );
@@ -274,8 +276,10 @@ void main() {
 
         expect(posts, hasLength(1));
         final body = Uri.splitQueryString(posts.single.body);
-        // The token exchange used the embedded (legacy) verifier.
-        expect(body['code_verifier'], 'legacy-verifier');
+        // The plaintext payload is not a source of the secret any more, so the
+        // request carries no code_verifier at all (the token model omits a null
+        // one). The OP answers invalid_grant and the app re-logs in.
+        expect(body.containsKey('code_verifier'), isFalse);
       },
     );
   });

--- a/packages/oidc_core/test/code_verifier_at_rest_test.dart
+++ b/packages/oidc_core/test/code_verifier_at_rest_test.dart
@@ -31,6 +31,11 @@ class _CodeFlowManager extends OidcUserManagerBase {
 
   OidcAuthorizeRequest? lastAuthRequest;
 
+  /// Extra parameters folded into the simulated authorization response, so a
+  /// test can model an OP — or anyone able to shape the redirect — putting a
+  /// `code_verifier` on the response.
+  Map<String, dynamic> extraResponseParams = const {};
+
   @override
   bool get isWeb => false;
 
@@ -45,6 +50,7 @@ class _CodeFlowManager extends OidcUserManagerBase {
     return OidcAuthorizeResponse.fromJson({
       'code': 'auth-code-1',
       'state': request.state,
+      ...extraResponseParams,
     });
   }
 
@@ -183,6 +189,36 @@ void main() {
         expect(body['code_verifier'], isNotNull);
         // The verifier that reached the token endpoint is the one behind the
         // challenge that went out on the authorization request.
+        expect(
+          OidcPkcePair.generateS256Challenge(body['code_verifier']!),
+          manager.lastAuthRequest!.codeChallenge,
+        );
+      },
+    );
+
+    test(
+      'a code_verifier on the authorization response never outranks the '
+      'stored one',
+      () async {
+        final posts = <http.Request>[];
+        final manager = await build(posts)
+          // The authorization response arrives over redirect parameters, so
+          // its contents are attacker-influenced. A `code_verifier` there must
+          // not be able to displace the one this client generated and stored.
+          ..extraResponseParams = const {
+            'code_verifier': 'response-supplied-verifier',
+          };
+        try {
+          await manager.loginAuthorizationCodeFlow();
+        } on Object {
+          // User creation fails (no id_token); see above.
+        }
+
+        expect(posts, hasLength(1));
+        final body = Uri.splitQueryString(posts.single.body);
+        expect(body['code_verifier'], isNot('response-supplied-verifier'));
+        // What went out is still the verifier behind the challenge this client
+        // put on the authorization request.
         expect(
           OidcPkcePair.generateS256Challenge(body['code_verifier']!),
           manager.lastAuthRequest!.codeChallenge,


### PR DESCRIPTION
Half A of #404. Two commits, the second is independently droppable.

**1. Drop the in-payload fallback.** `handleSuccessfulAuthResponse` still fell back to the `code_verifier` embedded in the plaintext `state` payload, which re-opens what moving it to `secureTokens` closed. `OidcAuthorizeState.codeVerifier` is removed so it has nowhere to live there.

**2. Drop the response-side read.** `OidcAuthorizeResponse` is parsed from redirect parameters, so a `code_verifier` there is attacker-influenced and must never outrank the stored one. Field removed.

Both are breaking: `OidcAuthorizeState.codeVerifier` and `OidcAuthorizeResponse.codeVerifier` are gone. Runtime impact is limited to a pre-`2.0.0` flow still in flight inside the 24h stale-state window (`clearUnusedStates`, `Duration(days: 1)`) — it now reaches the token endpoint with no `code_verifier` and the OP answers `invalid_grant`, i.e. a clean re-login.

## Verified

- TDD both ways in `packages/oidc_core/test/code_verifier_at_rest_test.dart`: the legacy-compat test was inverted first and failed against `main` (`code_verifier` present, expected absent); the response-side test failed with `Actual: 'response-supplied-verifier'`. Both green after.
- `dart test` in `packages/oidc_core`: 907 passing (906 before, +1 new).
- `dart analyze` in `packages/oidc_core`: 18 issues before and after, identical set, line numbers shifted only.
- `flutter analyze` across the workspace: zero errors/warnings — no other consumer of either removed field.
