### PR TITLE
test(example): claim fragment and form_post conformance on linux/windows

### DIFF
--- a/packages/oidc/example/integration_test/conformance/api.dart
+++ b/packages/oidc/example/integration_test/conformance/api.dart
@@ -214,6 +214,10 @@ String? webFingerIdentifierFor({
   String? clientSecret,
   String? postLogoutRedirectUri,
   String? frontChannelLogoutUri,
+  // OIDC Registration 1.0 section 2 client metadata; the suite defaults an
+  // omitted value to `web`, whose redirect_uri rules then reject a loopback
+  // http redirect for any non-code response type. A native RP must say so.
+  String? applicationType,
   Map<String, String>? extraVariant,
   String publish = 'everything',
 }) {
@@ -252,6 +256,7 @@ String? webFingerIdentifierFor({
     'client': {
       'client_id': clientId,
       if (clientSecret != null) 'client_secret': clientSecret,
+      if (applicationType != null) 'application_type': applicationType,
       'redirect_uri': redirectUri,
       if (postLogoutRedirectUri != null)
         'post_logout_redirect_uri': postLogoutRedirectUri,

--- a/packages/oidc/example/integration_test/shared_e2e.dart
+++ b/packages/oidc/example/integration_test/shared_e2e.dart
@@ -135,6 +135,25 @@ bool isBackChannelLogoutPlan(String planName) =>
 /// origin for `session_state` to be computed from in the first place.
 bool canGenerateSessionState(Uri redirectUri) => redirectUri.host.isNotEmpty;
 
+/// The OIDC Registration 1.0 section 2 `application_type` this platform's RP
+/// truthfully is.
+///
+/// The suite defaults an omitted value to `web`, and a web client "using the
+/// OAuth Implicit Grant Type MUST only register URLs using the https scheme as
+/// redirect_uris; they MUST NOT use localhost as the hostname" -- which is how
+/// the first live run of the hybrid and implicit plans on linux produced 36
+/// suite-side rejections of the loopback redirect before any browser was
+/// involved.
+///
+/// Every non-web platform here is a native client, and the same section
+/// sanctions exactly their redirect shapes: "Native Clients MUST only register
+/// redirect_uris using custom URI schemes or loopback URLs using the http
+/// scheme; loopback URLs use localhost or the IP loopback literals". Declaring
+/// `native` is not a workaround for the check; it is the metadata that was
+/// always true and simply never sent.
+String applicationTypeForPlatform(String platform) =>
+    platform.toLowerCase() == 'web' ? 'web' : 'native';
+
 /// Whether [planName] uses `response_mode=form_post`.
 bool isFormPostConformancePlan(String planName) =>
     planName.contains('-formpost-');
@@ -428,6 +447,7 @@ Future<void> runOidcConformanceTest(
     redirectUri: redirectUri.toString(),
     requestType: requestType,
     clientRegistration: clientRegistration,
+    applicationType: applicationTypeForPlatform(platform),
     extraVariant: {
       if (clientAuthType != null) 'client_auth_type': clientAuthType,
       ...extraPlanVariant,

--- a/packages/oidc/example/integration_test/shared_e2e.dart
+++ b/packages/oidc/example/integration_test/shared_e2e.dart
@@ -43,40 +43,14 @@ final Logger _testLogger = Logger('oidc.conformance');
 bool isLogoutConformancePlan(String planName) =>
     planName.contains('-logout-') || planName.contains('-session-management-');
 
-/// Whether [planName] returns tokens in the URL FRAGMENT.
-///
-/// `code id_token` (hybrid) and `id_token`/`id_token token` (implicit) default
-/// to `response_mode=fragment`.
-/// A formpost plan is NOT one of these even though its id contains `-hybrid-`
-/// or `-implicit-`: `response_mode=form_post` overrides the default, so the
-/// response arrives as a POST body, not a fragment.
-bool isFragmentResponsePlan(String planName) =>
-    !isFormPostConformancePlan(planName) &&
-    (planName.contains('-hybrid-') || planName.contains('-implicit-'));
-
-/// Whether a response delivered in the URL fragment can reach the app on
-/// [platform].
-///
-/// A fragment is never sent to a server -- the browser strips it before the
-/// request goes out. So a bare loopback HTTP listener cannot observe one:
-///   * custom scheme (iOS/macOS/Android) -- ASWebAuthenticationSession and
-///     Custom Tabs hand back the WHOLE callback URL, fragment included. OK.
-///   * web (`http://localhost:.../redirect.html`) -- the page reads
-///     `location.hash` in JS and relays it over the BroadcastChannel. OK.
-///   * loopback (`http://localhost:<port>` on linux/windows) --
-///     `OidcLoopbackListener` is a plain HTTP server with no page script, so
-///     the fragment never arrives. NOT OK.
-///
-/// Observed: the hybrid plan's 48 modules pass on macOS in ~2.5 min total and
-/// time out at ~31.5s EACH on linux, which is `flowTimeoutSeconds` firing
-/// because no redirect the listener can see ever arrives.
-///
-/// This is a real library limitation, not a test artifact. Supporting it would
-/// mean the loopback listener serving a page that reads `location.hash` and
-/// posts it back to itself -- the trick CLI OAuth tools use -- which is a
-/// change to `oidc_loopback_listener`, not to this harness.
-bool canReceiveFragmentResponse(String platform) =>
-    !(platform == 'linux' || platform == 'windows');
+// There is deliberately no fragment gate any more. A fragment never reaches a
+// server, so a bare loopback listener could not observe one and linux/windows
+// skipped the hybrid and implicit plans. oidc_loopback_listener 1.1.0 serves a
+// relay page that promotes `location.hash` into the query string -- the trick
+// CLI OAuth tools use -- and oidc_desktop 1.1.0 turns it on exactly when the
+// flow's response mode calls for it (responseArrivesInFragment). Every
+// platform can now receive a fragment response, and a universally-true gate is
+// dead code.
 
 /// Whether [planName] is the third-party-initiated login profile.
 ///
@@ -165,42 +139,32 @@ bool canGenerateSessionState(Uri redirectUri) => redirectUri.host.isNotEmpty;
 bool isFormPostConformancePlan(String planName) =>
     planName.contains('-formpost-');
 
-/// Whether an authorization response can be delivered to [redirectUri] as a
-/// form POST.
+/// Whether an authorization response can be delivered as a form POST to
+/// [redirectUri] on [platform].
 ///
-/// `response_mode=form_post` has the OP deliver the response as an HTTP POST
-/// body to the redirect URI. A custom scheme -- `com.bdayadev.oidc.example:/`
-/// on iOS/macOS/Android -- is not an HTTP endpoint at all, so no browser can
-/// POST to it. The formpost plans are therefore not merely failing on those
-/// platforms; they cannot be delivered there by construction, whatever the
-/// library does.
+/// `response_mode=form_post` has the browser deliver the response as an HTTP
+/// POST body to the redirect URI. Per transport:
+///   * loopback (linux/windows) -- YES since oidc_loopback_listener 1.1.0,
+///     which reads an application/x-www-form-urlencoded body and folds it into
+///     the returned Uri's query parameters. Earlier versions answered 405 to
+///     every non-GET, and an earlier version of this predicate returned false
+///     everywhere because of it.
+///   * custom scheme (iOS/macOS/Android) -- NO: not an HTTP endpoint at all,
+///     so no browser can POST to it. Caught by the scheme check.
+///   * web -- NO: redirect.html reads location.hash/search in JS, and a page
+///     script has no access to the request body that delivered it. This is why
+///     [platform] is a parameter: the web page and the desktop listener are
+///     both http(s), so the URI alone cannot tell them apart.
 ///
-/// This is NOT the loopback listener's 405-on-non-GET
-/// (`oidc_loopback_listener.dart`). That one is real and does block form_post
-/// on desktop, but macOS never reaches it: it redirects to a custom scheme via
-/// ASWebAuthenticationSession. Chasing the 405 first was a wrong lead.
-bool canReceiveFormPost(Uri redirectUri) {
-  // No transport this example has can receive one today:
-  //   * custom scheme (iOS/macOS/Android) -- not an HTTP endpoint, so nothing
-  //     can POST to it.
-  //   * loopback (linux/windows) -- OidcLoopbackListener answers 405 to every
-  //     non-GET (oidc_loopback_listener.dart), so the POST never becomes a
-  //     captured redirect.
-  //   * web -- redirect.html reads location.hash/search in JS; a POST body is
-  //     not readable from the page.
-  //
-  // The first version returned `scheme == http || https`, which made this
-  // answer true on loopback and web. That was the implementation asserted back
-  // at itself: an http scheme says nothing about whether the receiver handles
-  // POST. The consequence was concrete -- the three formpost plans ran on
-  // linux/windows, hit the 405, burned the full flowTimeoutSeconds on every
-  // module, and failed with an Android-specific "check the OidcRedirectActivity
-  // intent-filter" message on a platform that has no such thing.
-  //
-  // Flip this to a real capability check when the loopback listener learns to
-  // accept POST and parse the form body; that is a change to
-  // oidc_loopback_listener, not to this harness.
-  return false;
+/// The predicate stays a real capability statement rather than
+/// `scheme == http`: that earlier shortcut ran the formpost plans into the
+/// listener's 405, burned flowTimeoutSeconds per module, and reported an
+/// Android-specific failure message on Linux.
+bool canReceiveFormPost(Uri redirectUri, String platform) {
+  if (platform.toLowerCase() == 'web') {
+    return false;
+  }
+  return redirectUri.isScheme('http') || redirectUri.isScheme('https');
 }
 
 bool _planIdsLogged = false;
@@ -392,16 +356,6 @@ Future<void> runOidcConformanceTest(
     return;
   }
 
-  if (isFragmentResponsePlan(planName) &&
-      !canReceiveFragmentResponse(platform)) {
-    markTestSkipped(
-      '$planName returns tokens in the URL fragment, which a loopback HTTP '
-      'listener cannot observe; $platform uses one. Runs on macOS/iOS/Android '
-      '(full callback URL) and web (redirect.html reads location.hash).',
-    );
-    return;
-  }
-
   if (planNeedsHostedRequestUri(planName)) {
     markTestSkipped(
       '$planName pins request_type=request_uri for every module and the suite '
@@ -443,12 +397,17 @@ Future<void> runOidcConformanceTest(
   }
 
   if (isFormPostConformancePlan(planName) &&
-      !canReceiveFormPost(getPlatformRedirectUri())) {
-    // Not a skipped failure: the OP cannot POST to a custom scheme, so there is
-    // no outcome to observe on this platform.
+      !canReceiveFormPost(getPlatformRedirectUri(), platform)) {
+    // Not a skipped failure: nothing on this platform can observe a POST body,
+    // so there is no outcome to test. Two distinct reasons share this gate:
+    // a custom scheme is not an HTTP endpoint (no browser can POST to it), and
+    // a web page script cannot read the request body that delivered it.
     markTestSkipped(
-      '$planName needs an http(s) redirect to receive a form POST; '
-      '$platform redirects to ${getPlatformRedirectUri().scheme}: scheme.',
+      '$planName delivers the response as a form POST, which $platform cannot '
+      'receive: ${platform.toLowerCase() == 'web' ? 'redirect.html reads '
+                'location.hash/search, and a page script has no access to a '
+                'POST body' : '${getPlatformRedirectUri().scheme}: is not an '
+                'HTTP endpoint, so no browser can POST to it'}.',
     );
     return;
   }

--- a/packages/oidc/example/test/conformance_plan_variant_test.dart
+++ b/packages/oidc/example/test/conformance_plan_variant_test.dart
@@ -241,6 +241,48 @@ void main() {
     });
   });
 
+  group('the registered client declares its application_type', () {
+    // Registration 1.0 section 2: application_type "The default, if omitted,
+    // is web". A desktop RP registering http://localhost with hybrid/implicit
+    // response types is therefore judged as a WEB client and refused:
+    //
+    //   [FAILURE] redirect_uri is one of the registered uris but uses http
+    //   scheme which is not allowed when application_type is web and response
+    //   type is not code
+    //
+    // 36 of those on the first live linux run (PR #447), one per fragment-mode
+    // module. The same section sanctions our exact shape for native clients:
+    // "Native Clients MUST only register redirect_uris using custom URI
+    // schemes or loopback URLs using the http scheme; loopback URLs use
+    // localhost or the IP loopback literals". The fix is telling the truth:
+    // every non-web platform here IS a native client.
+    test('the plan request carries application_type when given', () {
+      final (_, body) = prepareTestPlanRequest(
+        planName: basicPlan,
+        description: 'test',
+        clientId: 'my_client',
+        redirectUri: 'http://localhost:22434',
+        requestType: 'plain_http_request',
+        clientRegistration: 'static_client',
+        applicationType: 'native',
+      );
+      expect((body['client']! as Map)['application_type'], 'native');
+    });
+
+    test('omitted means absent, not defaulted here', () {
+      // The suite owns the default; the harness must not invent one silently.
+      final (_, body) = build(basicPlan);
+      expect((body['client']! as Map).containsKey('application_type'), isFalse);
+    });
+
+    test('every non-web platform is native; web is web', () {
+      for (final p in ['linux', 'windows', 'macos', 'ios', 'android']) {
+        expect(applicationTypeForPlatform(p), 'native', reason: p);
+      }
+      expect(applicationTypeForPlatform('Web'), 'web');
+    });
+  });
+
   // The fragment gate (canReceiveFragmentResponse) is gone, deliberately.
   // oidc_loopback_listener 1.1.0 recovers a fragment via its JS relay page and
   // oidc_desktop 1.1.0 enables it exactly when the flow's response mode needs

--- a/packages/oidc/example/test/conformance_plan_variant_test.dart
+++ b/packages/oidc/example/test/conformance_plan_variant_test.dart
@@ -183,35 +183,45 @@ void main() {
     }
   });
 
-  group('form_post needs an http(s) redirect', () {
+  group('form_post needs a transport that can read a POST body', () {
     test('custom scheme cannot receive a form POST', () {
       expect(
         canReceiveFormPost(
           Uri.parse('com.bdayadev.oidc.example:/oauth2redirect'),
+          'macos',
         ),
         isFalse,
         reason: 'a custom scheme is not an HTTP endpoint; no browser can POST',
       );
     });
 
-    test('no transport in this harness can — not loopback, not web', () {
-      // This test used to assert loopback and web COULD. That was the
-      // predicate's implementation asserted back at itself, not a capability:
-      //   * loopback — oidc_loopback_listener.dart:70 answers 405 to every
-      //     non-GET, so a form POST never becomes a captured redirect.
-      //   * web — redirect.html reads location.hash/search in JS; a POST body
-      //     is not readable from the page at all.
-      //   * custom scheme — not an HTTP endpoint; nothing can POST to it.
-      // Until the loopback listener accepts POST, false everywhere is the
-      // honest answer, and the plans skip with a reason instead of burning
-      // 30s per module and failing with an Android-specific message on Linux.
-      expect(canReceiveFormPost(Uri.parse('http://localhost:22434')), isFalse);
+    test('the desktop loopback listener can, as of 1.1.0', () {
+      // An earlier version of this test asserted the loopback listener could
+      // NOT (oidc_loopback_listener answered 405 to every non-GET), and for a
+      // while that assertion was honest. oidc_loopback_listener 1.1.0 reads an
+      // application/x-www-form-urlencoded POST body and folds it into the
+      // returned Uri's query parameters, so the capability is real now --
+      // OAuth 2.0 Form Post Response Mode is deliverable to linux and windows.
       expect(
-        canReceiveFormPost(Uri.parse('http://localhost:22433/redirect.html')),
-        isFalse,
+        canReceiveFormPost(Uri.parse('http://localhost:22434'), 'linux'),
+        isTrue,
       );
       expect(
-        canReceiveFormPost(Uri.parse('com.bdayadev.oidc.example:/cb')),
+        canReceiveFormPost(Uri.parse('http://localhost:22434'), 'windows'),
+        isTrue,
+      );
+    });
+
+    test('the web page still cannot: a POST body is unreadable from JS', () {
+      // redirect.html reads location.hash/search; the platform gives a page
+      // script no access to the request body that delivered it. The URI alone
+      // cannot separate this case from desktop loopback -- both are http(s) --
+      // which is why the predicate takes the platform too.
+      expect(
+        canReceiveFormPost(
+          Uri.parse('https://rp.oidc.test:22433/redirect.html'),
+          'Web',
+        ),
         isFalse,
       );
     });
@@ -231,45 +241,13 @@ void main() {
     });
   });
 
-  group('fragment responses need a transport that can carry a fragment', () {
-    test('hybrid and implicit return fragments', () {
-      expect(
-        isFragmentResponsePlan('oidcc-client-hybrid-certification-test-plan'),
-        isTrue,
-      );
-      expect(
-        isFragmentResponsePlan('oidcc-client-implicit-certification-test-plan'),
-        isTrue,
-      );
-    });
-
-    test('formpost variants do NOT, despite -hybrid-/-implicit- in the id', () {
-      // response_mode=form_post overrides the default, so these arrive as a
-      // POST body. A naive substring match classifies them as fragment plans
-      // and skips them for the wrong reason.
-      for (final p in [
-        'oidcc-client-formpost-hybrid-certification-test-plan',
-        'oidcc-client-formpost-implicit-certification-test-plan',
-      ]) {
-        expect(isFragmentResponsePlan(p), isFalse, reason: p);
-      }
-    });
-
-    test('the logout -rp-hybrid variants are not fragment plans either', () {
-      expect(
-        isFragmentResponsePlan('oidcc-client-rp-initiated-logout-rp-hybrid'),
-        isFalse,
-      );
-    });
-
-    test('loopback platforms cannot receive a fragment; others can', () {
-      expect(canReceiveFragmentResponse('linux'), isFalse);
-      expect(canReceiveFragmentResponse('windows'), isFalse);
-      for (final p in ['macos', 'ios', 'android', 'web']) {
-        expect(canReceiveFragmentResponse(p), isTrue, reason: p);
-      }
-    });
-  });
+  // The fragment gate (canReceiveFragmentResponse) is gone, deliberately.
+  // oidc_loopback_listener 1.1.0 recovers a fragment via its JS relay page and
+  // oidc_desktop 1.1.0 enables it exactly when the flow's response mode needs
+  // it, so every platform can now receive a fragment response and a
+  // universally-true gate is dead code. The response-mode classification the
+  // gate leaned on (formpost overrides the hybrid/implicit fragment default)
+  // lives on, tested, in oidc_desktop's responseArrivesInFragment.
 
   group(
     'third-party-initiated login needs an endpoint the app cannot host',

--- a/packages/oidc_loopback_listener/lib/src/oidc_loopback_listener.dart
+++ b/packages/oidc_loopback_listener/lib/src/oidc_loopback_listener.dart
@@ -135,7 +135,16 @@ class OidcLoopbackListener {
         // the way in, so the first request cannot carry it. Answer with the
         // relay page and keep listening; the script re-requests with the
         // fragment promoted to the query string and tagged with the marker.
+        //
+        // GET only. A fragment can only ride a GET navigation -- a form POST's
+        // response is in its BODY, already folded into `res` above, and the
+        // relay page's re-request carries location.search/hash but never a
+        // request body. Relaying a POST therefore destroys the very response
+        // it is trying to recover: observed live as every form_post
+        // hybrid/implicit module failing with "Couldn't resolve the response
+        // mode" because `state` arrived in the POST body and was dropped.
         if (captureFragment &&
+            request.method == 'GET' &&
             !res.queryParameters.containsKey(kOidcFragmentRelayMarker)) {
           request.response.write(oidcFragmentRelayHtmlPage);
           await request.response.close();

--- a/packages/oidc_loopback_listener/test/oidc_loopback_listener_test.dart
+++ b/packages/oidc_loopback_listener/test/oidc_loopback_listener_test.dart
@@ -268,6 +268,41 @@ void main() {
         isNot(contains(kOidcFragmentRelayMarker)),
       );
     });
+
+    test(
+      'a form POST completes immediately even with captureFragment on',
+      () async {
+        // Observed live (oidc PR #447): for form_post hybrid/implicit the
+        // client did not explicitly request response_mode=form_post, so the
+        // desktop wiring armed the relay -- and the relay branch DISCARDED the
+        // folded POST body and served the relay page, whose re-request carries
+        // only location.search/hash, never a request body. Every module died
+        // with "Couldn't resolve the response mode, make sure the key (state)
+        // exists in the Uri". A fragment can only ride a GET navigation, so a
+        // POST must never take the relay hop: its body IS the response.
+        final listener = OidcLoopbackListener(
+          captureFragment: true,
+          successfulPageResponse: 'good',
+        );
+        final serverCompleter = Completer<HttpServer>();
+        final receivedUriFuture = listener.listenForSingleResponse(
+          serverCompleter: serverCompleter,
+          timeout: const Duration(seconds: 5),
+        );
+        final server = await serverCompleter.future;
+
+        final resp = await http.post(
+          getTargetUriFromPort(port: server.port),
+          body: {'code': 'abc', 'id_token': 'eyJ.a.b', 'state': 'xyz'},
+        );
+        expect(resp.statusCode, HttpStatus.ok);
+        expect(resp.body, 'good');
+
+        final receivedUri = await receivedUriFuture;
+        expect(receivedUri!.queryParameters['state'], 'xyz');
+        expect(receivedUri.queryParameters['id_token'], 'eyJ.a.b');
+      },
+    );
   });
 
   group('timeout & socket cleanup', () {


### PR DESCRIPTION
## What

Flips the last two desktop conformance gates, putting **Hybrid RP, Implicit RP, and the three Form Post plans** in front of the live suite on linux and windows for the first time. Five profiles that were scored *"cannot be delivered on this platform"* become claimable, because the claim stopped being true when `oidc_loopback_listener` 1.1.0 and `oidc_desktop` 1.1.0 shipped (#445):

- the listener now reads an `application/x-www-form-urlencoded` POST body and folds it into the returned `Uri` — OAuth 2.0 Form Post Response Mode is deliverable to a loopback redirect
- the listener's relay page recovers a URL-fragment response (`location.hash` promoted to the query string), and `oidc_desktop` enables it exactly when the flow's response mode needs it

## The two gates went different ways

**`canReceiveFragmentResponse` is deleted, not flipped.** Every platform can receive a fragment now, and a universally-true gate is dead code. `isFragmentResponsePlan` goes with it — the skip block was its only production caller, and the formpost-overrides-fragment classification it encoded lives on, tested, in `oidc_desktop.responseArrivesInFragment`.

**`canReceiveFormPost` stays, and gains a `platform` parameter.** The web page and the desktop listener are both http(s), so the URI alone cannot tell "a listener that reads POST bodies" from "a static page whose script cannot see the request body that delivered it". The old single-argument signature was only answerable because the answer used to be false everywhere. Custom schemes and web remain excluded, and the skip message now states the real reason per case instead of citing the redirect scheme.

## What CI on this branch is for

Local tests prove the predicates; they cannot prove the live half — a real browser executing the relay page against `certification.openid.net`, and the suite's form POST landing in the listener. The linux and windows jobs here are that proof. A red on them is a finding about the relay or the listener, not a reason to re-gate: the gates were removed because the *capability claim* is released library behaviour, and if the live run contradicts it, the library (not the harness) is what needs fixing.

Expected cost: hybrid adds 48 modules and implicit 27 per desktop job, plus the three form-post plans. The flow-timeout budget test still holds locally; if a desktop job hits its wall-clock limit, that is a legible red with an obvious remedy.

## Verification

```
flutter analyze lib test integration_test  →  No issues found!
flutter test                               →  74 passed (was 77: 4 gate tests
                                              deleted, 1 capability test added)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6bj7Qhk5FXAkvy4HJbCER


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-aware conformance requests for web and native applications.
  * Added support for form-post redirects over HTTP(S) loopback transports on Linux and Windows.

* **Bug Fixes**
  * Improved handling of form-post responses by preserving submitted parameters and avoiding unnecessary fragment processing.
  * Updated conformance checks with clearer platform-specific results for unsupported web and custom-scheme redirects.

* **Tests**
  * Expanded coverage for platform selection, redirect support, and form-post response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->